### PR TITLE
CDP-1177: Add social sharing headers to video pages

### DIFF
--- a/components/Meta.js
+++ b/components/Meta.js
@@ -6,6 +6,7 @@ const Meta = props => (
   <Head>
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta charSet="utf-8" />
+    <meta property="og:site_name" content="Content Commons" />
     <link rel="shortcut icon" href="/static/favicon.ico" />
     <link rel="stylesheet" type="text/css" href="/static/css/nprogress.css" />
     <title>{ props.title }</title>

--- a/lib/socialHeaders.js
+++ b/lib/socialHeaders.js
@@ -1,0 +1,91 @@
+/**
+ * Check if content exists for a given property
+ * If so, it is pushed to a properties array
+ *
+ * @param {object} array Target array into which values are added
+ * @param {string} property Property name
+ * @param {string} content Property content
+ */
+const checkAndPush = ( array, property, content ) => {
+  if ( content ) {
+    const newMeta = {
+      property,
+      content
+    };
+
+    array.push( newMeta );
+  }
+};
+
+/**
+ * Converts the content item object into a metavalues array using the checkAndPush method
+ *
+ * @param {object} item Object of metadata for a given content item
+ * @param {string} url The URL of the page to be rendered
+ * @returns {array} Array of { property: content } key pairs
+ */
+export const populateMetaArray = ( item, url ) => {
+  const {
+    description, thumbnail, selectedLanguageUnit, title, type
+  } = item;
+
+  const videoSrc = ( selectedLanguageUnit && selectedLanguageUnit.source && selectedLanguageUnit.source[0] )
+    ? selectedLanguageUnit.source[0]
+    : {};
+  const streamSrc = ( videoSrc.stream && videoSrc.stream.link ) ? videoSrc.stream.link : '';
+
+  // Initialize metavalue array with universal properties
+  const metaArr = [
+    {
+      property: 'og:type',
+      content: ( type && type === 'video' ) ? 'video.other' : 'article'
+    },
+    {
+      property: 'og:url',
+      content: url
+    },
+    {
+      property: 'twitter:card',
+      content: ( type && type === 'video' ) ? 'player' : 'summary'
+    }
+  ];
+
+  // Temporary array of optional meta values
+  const propsArray = [
+    {
+      property: 'og:description',
+      content: description
+    },
+    {
+      property: 'og:image',
+      content: thumbnail
+    },
+    {
+      property: 'og:title',
+      content: title
+    },
+    {
+      property: 'og:video:url',
+      content: streamSrc
+    },
+    {
+      property: 'twitter:player',
+      content: streamSrc
+    },
+    {
+      property: 'twitter:player:height',
+      content: ( type && type === 'video' ) ? '196px' : ''
+    },
+    {
+      property: 'twitter:player:width',
+      content: ( type && type === 'video' ) ? '350px' : ''
+    }
+  ];
+
+  // Checks for desired meta tags against items
+  propsArray.forEach( propPair => {
+    checkAndPush( metaArr, propPair.property, propPair.content );
+  } );
+
+  return metaArr;
+};

--- a/pages/video.js
+++ b/pages/video.js
@@ -1,22 +1,30 @@
-import React, { Component } from 'react';
+import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { getItemRequest, getDataFromHits } from 'lib/elastic/api';
 import Video from 'components/Video/Video';
 import { normalizeItem } from 'lib/elastic/parser';
+import { populateMetaArray } from 'lib/socialHeaders.js';
+import Head from 'next/head';
 
 class VideoPage extends Component {
-  static async getInitialProps ( { query } ) {
+  static async getInitialProps ( { req, query, asPath } ) {
+    const url = ( req && req.headers && req.headers.host && asPath )
+      ? `${req.headers.host}${asPath}`
+      : '';
     if ( query && query.site && query.id ) {
       const response = await getItemRequest( query.site, query.id );
       const item = getDataFromHits( response );
       if ( item && item[0] ) {
-        return { item: normalizeItem( item[0], query.language ) };
+        return {
+          item: normalizeItem( item[0], query.language ),
+          url
+        };
       }
     }
   }
 
   render() {
-    const { item } = this.props;
+    const { item, url } = this.props;
     const styles = {
       page: {
         marginTop: '90px'
@@ -26,6 +34,7 @@ class VideoPage extends Component {
         fontWeight: 700
       }
     };
+    const metaTags = populateMetaArray( item, url );
 
     if ( !item ) {
       return (
@@ -36,15 +45,23 @@ class VideoPage extends Component {
     }
 
     return (
-      <section className="max_width_1200" style={ styles.page }>
-        <Video item={ item } />
-      </section>
+      <Fragment>
+        <Head>
+          { metaTags && metaTags.map( tag => (
+            <meta key={ tag.property } property={ tag.property } content={ tag.content } />
+          ) ) }
+        </Head>
+        <section className="max_width_1200" style={ styles.page }>
+          <Video item={ item } />
+        </section>
+      </Fragment>
     );
   }
 }
 
 VideoPage.propTypes = {
-  item: PropTypes.object
+  item: PropTypes.object,
+  url: PropTypes.string
 };
 
 export default VideoPage;


### PR DESCRIPTION
Port of CDP-1130 from version 1:
- Dynamically populates the header of server-side-rendered video pages with og and twitter meta tags (used for social sharing)
- Adds `og:site_name` meta header of "Content Commons" to all pages
- Makes section flagged in v1 as a bit hard to read more explicit