### PR TITLE
CDP-1392-1393

### DIFF
--- a/components/admin/Dashboard/MyProjects/MyProjectPrimaryCol/MyProjectPrimaryCol.js
+++ b/components/admin/Dashboard/MyProjects/MyProjectPrimaryCol/MyProjectPrimaryCol.js
@@ -164,8 +164,8 @@ const MyProjectPrimaryCol = props => {
           <div className="projects_data_actions_wrapper">
             { isPublishing
               ? actions.map( ( action, i ) => (
-                <Fragment>
-                  <span key={ `${action}-${id}` } className={ getActionCls() }>
+                <Fragment key={ `${action}-${id}` }>
+                  <span className={ getActionCls() }>
                     { action }
                   </span>
                   { ( i < actions.length - 1 )

--- a/components/admin/Dashboard/TeamProjects/TeamProjectPrimaryCol/TeamProjectPrimaryCol.js
+++ b/components/admin/Dashboard/TeamProjects/TeamProjectPrimaryCol/TeamProjectPrimaryCol.js
@@ -164,8 +164,8 @@ const TeamProjectPrimaryCol = props => {
           <div className="projects_data_actions_wrapper">
             { isPublishing
               ? actions.map( ( action, i ) => (
-                <Fragment>
-                  <span key={ `${action}-${id}` } className={ getActionCls() }>
+                <Fragment key={ `${action}-${id}` }>
+                  <span className={ getActionCls() }>
                     { action }
                   </span>
                   { ( i < actions.length - 1 )

--- a/components/admin/projects/ProjectEdit/PreviewProjectContent/PreviewProjectContent.js
+++ b/components/admin/projects/ProjectEdit/PreviewProjectContent/PreviewProjectContent.js
@@ -173,9 +173,10 @@ class PreviewProjectContent extends React.PureComponent {
   };
 
   getTags = ( tags, unit ) => (
-    tags.reduce( ( acc, curr ) => (
-      `${acc ? `${acc} · ` : ''}${this.getTag( curr, unit )}`
-    ), '' )
+    tags.reduce( ( acc, curr ) => ( [
+      ...acc,
+      { name: this.getTag( curr, unit ) }
+    ] ), [] )
   );
 
   toggleArrow = () => {
@@ -456,9 +457,7 @@ class PreviewProjectContent extends React.PureComponent {
 
         { ( tags && tags.length > 0 )
           && (
-            <section className="modal_section modal_section--postTags">
-              { this.getTags( tags, selectedUnit ) }
-            </section>
+            <ModalPostTags tags={ this.getTags( tags, selectedUnit ) } />
           ) }
       </ModalItem>
     );

--- a/components/admin/projects/ProjectEdit/PreviewProjectContent/PreviewProjectContent.js
+++ b/components/admin/projects/ProjectEdit/PreviewProjectContent/PreviewProjectContent.js
@@ -57,9 +57,7 @@ class PreviewProjectContent extends React.PureComponent {
       const { units } = this.props.data.project;
       if ( !units || ( units && units.length === 0 ) ) return;
 
-      const englishIndex = this.getEnglishIndex( units );
-      const { language } = units[englishIndex > -1 ? englishIndex : 0];
-
+      const language = this.getUnitLanguage( units );
       if ( !language || ( language && !Object.keys( language ).length ) ) {
         return;
       }
@@ -77,8 +75,10 @@ class PreviewProjectContent extends React.PureComponent {
       const { units } = this.props.data.project;
       if ( !units || ( units && units.length === 0 ) ) return;
 
-      const englishIndex = this.getEnglishIndex( units );
-      const { language } = units[englishIndex > -1 ? englishIndex : 0];
+      const language = this.getUnitLanguage( units );
+      if ( !language || ( language && !Object.keys( language ).length ) ) {
+        return;
+      }
 
       if ( !prevState.selectedLanguage ) {
         this.selectLanguage( language.displayName );
@@ -104,6 +104,28 @@ class PreviewProjectContent extends React.PureComponent {
   getEnglishIndex = units => (
     units.findIndex( unit => unit.language.displayName === 'English' )
   );
+
+  getFilesCount = ( units, i ) => {
+    if ( units[i] && units[i].files ) {
+      return units[i].files.length;
+    }
+    return 0;
+  };
+
+  getCurrUnitIndex = ( i, count = 0 ) => (
+    ( i > -1 && count > 0 ) ? i : 0
+  );
+
+  getUnitLanguage = units => {
+    /**
+     * Look for an English language unit first.
+     * Otherwise, get the first available unit.
+     */
+    const englishIndex = this.getEnglishIndex( units );
+    const englishFilesCount = this.getFilesCount( units, englishIndex );
+    const i = this.getCurrUnitIndex( englishIndex, englishFilesCount );
+    return units[i] ? units[i].language : {};
+  };
 
   getContentType = typename => {
     switch ( typename ) {

--- a/components/admin/projects/ProjectEdit/PreviewProjectContent/PreviewProjectContent.js
+++ b/components/admin/projects/ProjectEdit/PreviewProjectContent/PreviewProjectContent.js
@@ -216,7 +216,7 @@ class PreviewProjectContent extends React.PureComponent {
     if ( files && files.length === 0 ) {
       return (
         <p style={ { fontSize: '1rem' } }>
-          This project unit does not have any files to preview.
+          This { language.displayName } language unit does not have any files to preview.
         </p>
       );
     }

--- a/components/admin/projects/ProjectEdit/PreviewProjectContent/PreviewProjectContent.js
+++ b/components/admin/projects/ProjectEdit/PreviewProjectContent/PreviewProjectContent.js
@@ -134,6 +134,22 @@ class PreviewProjectContent extends React.PureComponent {
     return `<iframe src="${embedSrc}" width="640" height="360" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>`;
   }
 
+  getTag = ( tag, unit ) => {
+    const translation = tag.translations.find( t => (
+      t.language.locale === unit.language.locale
+    ) );
+
+    if ( translation && translation.name ) {
+      return translation.name;
+    }
+  };
+
+  getTags = ( tags, unit ) => (
+    tags.reduce( ( acc, curr ) => (
+      `${acc ? `${acc} · ` : ''}${this.getTag( curr, unit )}`
+    ), '' )
+  );
+
   toggleArrow = () => {
     this.setState( prevState => ( {
       dropDownIsOpen: !prevState.dropDownIsOpen
@@ -193,7 +209,7 @@ class PreviewProjectContent extends React.PureComponent {
     }
 
     const {
-      title, language, descPublic, files
+      title, language, descPublic, files, tags
     } = selectedUnit;
     const contentType = this.getContentType( __typename );
 
@@ -409,6 +425,14 @@ class PreviewProjectContent extends React.PureComponent {
         </div>
 
         <ModalPostMeta source={ team.name } datePublished={ createdAt } />
+
+        { ( tags && tags.length > 0 )
+          && (
+            <section className="modal_section modal_section--postTags">
+              { this.getTags( tags, selectedUnit ) }
+            </section>
+          )
+           }
       </ModalItem>
     );
   }

--- a/components/admin/projects/ProjectEdit/PreviewProjectContent/PreviewProjectContent.js
+++ b/components/admin/projects/ProjectEdit/PreviewProjectContent/PreviewProjectContent.js
@@ -256,14 +256,23 @@ class PreviewProjectContent extends React.PureComponent {
         />
 
         <div className="modal_options">
-          <Dropdown
-            className="modal_languages"
-            value={ selectedLanguage }
-            icon={ dropDownIsOpen ? 'chevron up' : 'chevron down' }
-            options={ this.getLanguages( units ) }
-            onClick={ this.toggleArrow }
-            onChange={ this.handleChange }
-          />
+          { units && units.length === 1
+            // use units since they're defined by language
+            ? (
+              <div className="modal_languages_single">
+                { selectedLanguage }
+              </div>
+            )
+            : (
+              <Dropdown
+                className="modal_languages"
+                value={ selectedLanguage }
+                icon={ dropDownIsOpen ? 'chevron up' : 'chevron down' }
+                options={ this.getLanguages( units ) }
+                onClick={ this.toggleArrow }
+                onChange={ this.handleChange }
+              />
+            ) }
 
           <div className="trigger-container">
             { ( contentType === 'video' && embedItem ) && (

--- a/components/admin/projects/ProjectEdit/PreviewProjectContent/PreviewProjectContent.js
+++ b/components/admin/projects/ProjectEdit/PreviewProjectContent/PreviewProjectContent.js
@@ -24,6 +24,7 @@ import ModalItem from 'components/modals/ModalItem/ModalItem';
 import ModalContentMeta from 'components/modals/ModalContentMeta/ModalContentMeta';
 import ModalDescription from 'components/modals/ModalDescription/ModalDescription';
 import ModalPostMeta from 'components/modals/ModalPostMeta/ModalPostMeta';
+import ModalPostTags from 'components/modals/ModalPostTags/ModalPostTags';
 
 import Notification from 'components/Notification/Notification';
 import Popup from 'components/popups/Popup';
@@ -87,18 +88,23 @@ class PreviewProjectContent extends React.PureComponent {
   }
 
   getLanguages = units => (
-    units.map( unit => ( {
-      key: unit.language.languageCode,
-      value: unit.language.displayName,
-      text: unit.language.displayName
-    } ) )
-  )
+    this.getUnitsWithFiles( units )
+      .map( unit => ( {
+        key: unit.language.languageCode,
+        value: unit.language.displayName,
+        text: unit.language.displayName
+      } ) )
+  );
 
   getProjectUnits = units => (
     units.reduce( ( acc, unit ) => ( {
       ...acc,
       [unit.language.displayName]: unit
     } ), {} )
+  );
+
+  getUnitsWithFiles = units => (
+    units.filter( u => u.files.length > 0 )
   );
 
   getEnglishIndex = units => (
@@ -294,7 +300,7 @@ class PreviewProjectContent extends React.PureComponent {
         />
 
         <div className="modal_options">
-          { units && units.length === 1
+          { ( units && this.getUnitsWithFiles( units ).length === 1 )
             // use units since they're defined by language
             ? (
               <div className="modal_languages_single">
@@ -453,8 +459,7 @@ class PreviewProjectContent extends React.PureComponent {
             <section className="modal_section modal_section--postTags">
               { this.getTags( tags, selectedUnit ) }
             </section>
-          )
-           }
+          ) }
       </ModalItem>
     );
   }

--- a/components/admin/projects/ProjectEdit/PreviewProjectContent/PreviewProjectContent.scss
+++ b/components/admin/projects/ProjectEdit/PreviewProjectContent/PreviewProjectContent.scss
@@ -17,4 +17,10 @@
       background-color: $light-blue;
     }
   }
+
+  .modal_section--postTags {
+    font-size: 12px;
+    font-style: italic;
+    color: $shuttle-grey;
+  }
 }

--- a/components/admin/projects/ProjectEdit/PreviewProjectContent/PreviewProjectContent.scss
+++ b/components/admin/projects/ProjectEdit/PreviewProjectContent/PreviewProjectContent.scss
@@ -18,9 +18,9 @@
     }
   }
 
-  .modal_section--postTags {
-    font-size: 12px;
-    font-style: italic;
-    color: $shuttle-grey;
-  }
+  // .modal_section--postTags {
+  //   font-size: 12px;
+  //   font-style: italic;
+  //   color: $shuttle-grey;
+  // }
 }

--- a/components/admin/projects/ProjectEdit/PreviewProjectContent/PreviewProjectContent.test.js
+++ b/components/admin/projects/ProjectEdit/PreviewProjectContent/PreviewProjectContent.test.js
@@ -247,6 +247,23 @@ describe( '<PreviewProjectContent />', () => {
     ] );
   } );
 
+  it( 'getUnitsWithFiles returns an array of units with files', async () => {
+    const wrapper = mount( Component );
+    await wait( 0 );
+    wrapper.update();
+
+    const preview = wrapper.find( 'PreviewProjectContent' );
+    const inst = preview.instance();
+    const units = [
+      { id: '1', files: [] },
+      { id: '2', files: [{ id: 'a', fileName: 'alpha' }] }
+    ];
+    const unitsWithFiles = inst.getUnitsWithFiles( units );
+
+    expect( Array.isArray( unitsWithFiles ) ).toEqual( true );
+    expect( unitsWithFiles[0] ).toEqual( units[1] );
+  } );
+
   it( 'calling getProjectUnits gets the projectUnits', async () => {
     const wrapper = mount( Component );
     await wait( 0 );

--- a/components/admin/projects/ProjectEdit/PreviewProjectContent/PreviewProjectContent.test.js
+++ b/components/admin/projects/ProjectEdit/PreviewProjectContent/PreviewProjectContent.test.js
@@ -105,6 +105,25 @@ const noFilesMocks = [
   }
 ];
 
+const noTagsMocks = [
+  {
+    ...mocks[0],
+    result: {
+      data: {
+        project: {
+          ...mocks[0].result.data.project,
+          units: [
+            {
+              ...mocks[0].result.data.project.units[0],
+              tags: []
+            }
+          ]
+        }
+      }
+    }
+  }
+];
+
 const noUnitsMocks = [
   {
     ...mocks[0],
@@ -517,5 +536,51 @@ describe( '<PreviewProjectContent />', () => {
     expect( units.length ).toEqual( 1 );
     expect( dropdown.exists() ).toEqual( false );
     expect( singleLanguage.exists() ).toEqual( true );
+  } );
+
+  it( 'getTag returns the correct translation tag name', async () => {
+    const wrapper = mount( Component );
+    await wait( 0 );
+    wrapper.update();
+
+    const preview = wrapper.find( 'PreviewProjectContent' );
+    const inst = preview.instance();
+    // using the English unit at index 1
+    const tag = mocks[0].result.data.project.units[1].tags[0];
+    const unit = mocks[0].result.data.project.units[1];
+    const tagName = inst.getTag( tag, unit );
+
+    expect( tagName ).toEqual( 'american culture' );
+  } );
+
+  it( 'getTags returns a string of translation tag name(s)', async () => {
+    const wrapper = mount( Component );
+    await wait( 0 );
+    wrapper.update();
+
+    const preview = wrapper.find( 'PreviewProjectContent' );
+    const inst = preview.instance();
+    // using the English unit at index 1
+    const { tags } = mocks[0].result.data.project.units[1];
+    const unit = mocks[0].result.data.project.units[1];
+    const tagNames = inst.getTags( tags, unit );
+
+    expect( typeof tagNames ).toEqual( 'string' );
+    expect( tagNames ).toEqual( 'american culture · english learning' );
+  } );
+
+  it( 'does not render a tags section if the selected unit has no tags', async () => {
+    const wrapper = mount(
+      <MockedProvider mocks={ noTagsMocks } addTypename>
+        <PreviewProjectContent { ...props } />
+      </MockedProvider>
+    );
+    await wait( 0 );
+    wrapper.update();
+
+    const preview = wrapper.find( 'PreviewProjectContent' );
+    const tagsSection = preview.find( '.modal_section--postTags' );
+
+    expect( tagsSection.exists() ).toEqual( false );
   } );
 } );

--- a/components/admin/projects/ProjectEdit/PreviewProjectContent/PreviewProjectContent.test.js
+++ b/components/admin/projects/ProjectEdit/PreviewProjectContent/PreviewProjectContent.test.js
@@ -478,9 +478,10 @@ describe( '<PreviewProjectContent />', () => {
     wrapper.update();
 
     const preview = wrapper.find( 'PreviewProjectContent' );
-    const noFilesMsg = 'This project unit does not have any files to preview.';
+    const { displayName } = noFilesMocks[0].result.data.project.units[0].language;
+    const noFilesMsg = `This ${displayName} language unit does not have any files to preview.`;
 
-    expect( preview.contains( noFilesMsg ) ).toEqual( true );
+    expect( preview.text() ).toEqual( noFilesMsg );
   } );
 
   it( 'renders a "no units message" if there are no units in the project', async () => {

--- a/components/admin/projects/ProjectEdit/PreviewProjectContent/PreviewProjectContent.test.js
+++ b/components/admin/projects/ProjectEdit/PreviewProjectContent/PreviewProjectContent.test.js
@@ -497,4 +497,24 @@ describe( '<PreviewProjectContent />', () => {
 
     expect( preview.contains( noUnitsMsg ) ).toEqual( true );
   } );
+
+  it( 'renders a single language but not a language dropdown if there is only one unit', async () => {
+    // use vimeoMocks since it has a single unit
+    const wrapper = mount(
+      <MockedProvider mocks={ vimeoMocks } addTypename>
+        <PreviewProjectContent { ...props } />
+      </MockedProvider>
+    );
+    await wait( 0 );
+    wrapper.update();
+
+    const preview = wrapper.find( 'PreviewProjectContent' );
+    const dropdown = preview.find( '.modal_languages' );
+    const singleLanguage = preview.find( '.modal_languages_single' );
+    const { units } = vimeoMocks[0].result.data.project;
+
+    expect( units.length ).toEqual( 1 );
+    expect( dropdown.exists() ).toEqual( false );
+    expect( singleLanguage.exists() ).toEqual( true );
+  } );
 } );

--- a/components/admin/projects/ProjectEdit/PreviewProjectContent/PreviewProjectContent.test.js
+++ b/components/admin/projects/ProjectEdit/PreviewProjectContent/PreviewProjectContent.test.js
@@ -618,7 +618,7 @@ describe( '<PreviewProjectContent />', () => {
     expect( tagName ).toEqual( 'american culture' );
   } );
 
-  it( 'getTags returns a string of translation tag name(s)', async () => {
+  it( 'getTags returns an array of translation tag name(s)', async () => {
     const wrapper = mount( Component );
     await wait( 0 );
     wrapper.update();
@@ -629,9 +629,13 @@ describe( '<PreviewProjectContent />', () => {
     const { tags } = mocks[0].result.data.project.units[1];
     const unit = mocks[0].result.data.project.units[1];
     const tagNames = inst.getTags( tags, unit );
+    const ret = [
+      { name: 'american culture' },
+      { name: 'english learning' }
+    ];
 
-    expect( typeof tagNames ).toEqual( 'string' );
-    expect( tagNames ).toEqual( 'american culture · english learning' );
+    expect( Array.isArray( tagNames ) ).toEqual( true );
+    expect( tagNames ).toEqual( ret );
   } );
 
   it( 'does not render a tags section if the selected unit has no tags', async () => {

--- a/components/admin/projects/ProjectEdit/PreviewProjectContent/PreviewProjectContent.test.js
+++ b/components/admin/projects/ProjectEdit/PreviewProjectContent/PreviewProjectContent.test.js
@@ -358,8 +358,56 @@ describe( '<PreviewProjectContent />', () => {
     const { units } = mocks[0].result.data.project;
     const englishIndex = inst.getEnglishIndex( units );
 
-    expect( spy ).toHaveBeenCalled();
+    expect( spy ).toHaveBeenCalledWith( units );
     expect( englishIndex ).toEqual( units.length - 1 );
+  } );
+
+  it( 'getFilesCount returns the correct number of unit files', async () => {
+    const wrapper = mount( Component );
+    await wait( 0 );
+    wrapper.update();
+
+    const preview = wrapper.find( 'PreviewProjectContent' );
+    const inst = preview.instance();
+    const spy = jest.spyOn( inst, 'getFilesCount' );
+    const { units } = mocks[0].result.data.project;
+    const currentUnitIndex = 0; // just use the first unit
+    const count = inst.getFilesCount( units, currentUnitIndex );
+
+    expect( spy ).toHaveBeenCalledWith( units, currentUnitIndex );
+    expect( count ).toEqual( units[currentUnitIndex].files.length );
+  } );
+
+  it( 'getCurrUnitIndex returns the correct index', async () => {
+    const wrapper = mount( Component );
+    await wait( 0 );
+    wrapper.update();
+
+    const preview = wrapper.find( 'PreviewProjectContent' );
+    const inst = preview.instance();
+
+    expect( inst.getCurrUnitIndex( 2, 2 ) ).toEqual( 2 );
+    expect( inst.getCurrUnitIndex( -1, 2 ) ).toEqual( 0 );
+    expect( inst.getCurrUnitIndex( 2, 0 ) ).toEqual( 0 );
+    expect( inst.getCurrUnitIndex( 2 ) ).toEqual( 0 );
+  } );
+
+  it( 'getUnitLanguage returns the unit language object', async () => {
+    const wrapper = mount( Component );
+    await wait( 0 );
+    wrapper.update();
+
+    const preview = wrapper.find( 'PreviewProjectContent' );
+    const inst = preview.instance();
+    const { units } = mocks[0].result.data.project;
+    const { units: noEnglishUnits } = vimeoMocks[0].result.data.project;
+    const nonEnglish = inst.getUnitLanguage( noEnglishUnits );
+    const english = inst.getUnitLanguage( units );
+
+    expect( typeof nonEnglish ).toEqual( 'object' );
+    expect( typeof english ).toEqual( 'object' );
+    expect( nonEnglish ).toEqual( noEnglishUnits[0].language );
+    expect( english ).toEqual( units[1].language );
   } );
 
   it( 'getContentType returns the correct content type', async () => {

--- a/components/admin/projects/ProjectEdit/PreviewProjectContent/__snapshots__/PreviewProjectContent.test.js.snap
+++ b/components/admin/projects/ProjectEdit/PreviewProjectContent/__snapshots__/PreviewProjectContent.test.js.snap
@@ -237,6 +237,40 @@ exports[`<PreviewProjectContent /> renders final state without crashing 1`] = `
                   },
                 ],
               },
+              Object {
+                "__typename": "Tag",
+                "id": "tag14",
+                "translations": Array [
+                  Object {
+                    "__typename": "LanguageTranslation",
+                    "id": "tr888",
+                    "language": Object {
+                      "__typename": "Language",
+                      "displayName": "English",
+                      "id": "en38",
+                      "languageCode": "en",
+                      "locale": "en-us",
+                      "nativeName": "English",
+                      "textDirection": "LTR",
+                    },
+                    "name": "english learning",
+                  },
+                  Object {
+                    "__typename": "LanguageTranslation",
+                    "id": "tr777",
+                    "language": Object {
+                      "__typename": "Language",
+                      "displayName": "French",
+                      "id": "fr82",
+                      "languageCode": "fr",
+                      "locale": "fr-fr",
+                      "nativeName": "French",
+                      "textDirection": "LTR",
+                    },
+                    "name": "Anglais langue étrangère",
+                  },
+                ],
+              },
             ],
             "thumbnails": Array [
               Object {
@@ -836,6 +870,40 @@ exports[`<PreviewProjectContent /> renders final state without crashing 1`] = `
                                   },
                                 ],
                               },
+                              Object {
+                                "__typename": "Tag",
+                                "id": "tag14",
+                                "translations": Array [
+                                  Object {
+                                    "__typename": "LanguageTranslation",
+                                    "id": "tr888",
+                                    "language": Object {
+                                      "__typename": "Language",
+                                      "displayName": "English",
+                                      "id": "en38",
+                                      "languageCode": "en",
+                                      "locale": "en-us",
+                                      "nativeName": "English",
+                                      "textDirection": "LTR",
+                                    },
+                                    "name": "english learning",
+                                  },
+                                  Object {
+                                    "__typename": "LanguageTranslation",
+                                    "id": "tr777",
+                                    "language": Object {
+                                      "__typename": "Language",
+                                      "displayName": "French",
+                                      "id": "fr82",
+                                      "languageCode": "fr",
+                                      "locale": "fr-fr",
+                                      "nativeName": "French",
+                                      "textDirection": "LTR",
+                                    },
+                                    "name": "Anglais langue étrangère",
+                                  },
+                                ],
+                              },
                             ],
                             "thumbnails": Array [
                               Object {
@@ -1013,6 +1081,40 @@ exports[`<PreviewProjectContent /> renders final state without crashing 1`] = `
                                           "textDirection": "RTL",
                                         },
                                         "name": "الثقافة الأميركية",
+                                      },
+                                    ],
+                                  },
+                                  Object {
+                                    "__typename": "Tag",
+                                    "id": "tag14",
+                                    "translations": Array [
+                                      Object {
+                                        "__typename": "LanguageTranslation",
+                                        "id": "tr888",
+                                        "language": Object {
+                                          "__typename": "Language",
+                                          "displayName": "English",
+                                          "id": "en38",
+                                          "languageCode": "en",
+                                          "locale": "en-us",
+                                          "nativeName": "English",
+                                          "textDirection": "LTR",
+                                        },
+                                        "name": "english learning",
+                                      },
+                                      Object {
+                                        "__typename": "LanguageTranslation",
+                                        "id": "tr777",
+                                        "language": Object {
+                                          "__typename": "Language",
+                                          "displayName": "French",
+                                          "id": "fr82",
+                                          "languageCode": "fr",
+                                          "locale": "fr-fr",
+                                          "nativeName": "French",
+                                          "textDirection": "LTR",
+                                        },
+                                        "name": "Anglais langue étrangère",
                                       },
                                     ],
                                   },
@@ -1256,6 +1358,11 @@ exports[`<PreviewProjectContent /> renders final state without crashing 1`] = `
           </span>
         </section>
       </ModalPostMeta>
+      <section
+        className="modal_section modal_section--postTags"
+      >
+        undefined · english learning
+      </section>
     </div>
   </ModalItem>
 </PreviewProjectContent>

--- a/components/admin/projects/ProjectEdit/PreviewProjectContent/__snapshots__/PreviewProjectContent.test.js.snap
+++ b/components/admin/projects/ProjectEdit/PreviewProjectContent/__snapshots__/PreviewProjectContent.test.js.snap
@@ -1358,11 +1358,39 @@ exports[`<PreviewProjectContent /> renders final state without crashing 1`] = `
           </span>
         </section>
       </ModalPostMeta>
-      <section
-        className="modal_section modal_section--postTags"
+      <ModalPostTags
+        tags={
+          Array [
+            Object {
+              "name": undefined,
+            },
+            Object {
+              "name": "english learning",
+            },
+          ]
+        }
       >
-        undefined · english learning
-      </section>
+        <section
+          className="modal_section modal_section--postTags"
+        >
+          <span
+            className="modal_postTag"
+            key="cat_0"
+          >
+             
+            undefined  · 
+             
+          </span>
+          <span
+            className="modal_postTag"
+            key="cat_1"
+          >
+             
+            english learning
+             
+          </span>
+        </section>
+      </ModalPostTags>
     </div>
   </ModalItem>
 </PreviewProjectContent>

--- a/components/admin/projects/ProjectEdit/PreviewProjectContent/mocks.js
+++ b/components/admin/projects/ProjectEdit/PreviewProjectContent/mocks.js
@@ -175,7 +175,64 @@ export const getMocks = ( query, variables ) => (
                       {
                         __typename: 'LanguageTranslation',
                         id: 'tr999',
-                        name: 'american culture'
+                        name: 'american culture',
+                        language: {
+                          __typename: 'Language',
+                          id: 'en38',
+                          displayName: 'English',
+                          languageCode: 'en',
+                          locale: 'en-us',
+                          nativeName: 'English',
+                          textDirection: 'LTR'
+                        }
+                      },
+                      {
+                        __typename: 'LanguageTranslation',
+                        id: 'tr019',
+                        name: 'Culture américaine',
+                        language: {
+                          __typename: 'Language',
+                          id: 'fr82',
+                          displayName: 'French',
+                          languageCode: 'fr',
+                          locale: 'fr-fr',
+                          nativeName: 'French',
+                          textDirection: 'LTR'
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    __typename: 'Tag',
+                    id: 'tag14',
+                    translations: [
+                      {
+                        __typename: 'LanguageTranslation',
+                        id: 'tr888',
+                        name: 'english learning',
+                        language: {
+                          __typename: 'Language',
+                          id: 'en38',
+                          displayName: 'English',
+                          languageCode: 'en',
+                          locale: 'en-us',
+                          nativeName: 'English',
+                          textDirection: 'LTR'
+                        }
+                      },
+                      {
+                        __typename: 'LanguageTranslation',
+                        id: 'tr777',
+                        name: 'Anglais langue étrangère',
+                        language: {
+                          __typename: 'Language',
+                          id: 'fr82',
+                          displayName: 'French',
+                          languageCode: 'fr',
+                          locale: 'fr-fr',
+                          nativeName: 'French',
+                          textDirection: 'LTR'
+                        }
                       }
                     ]
                   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1874,12 +1874,19 @@
       "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
     },
     "axios": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.18.0.tgz",
-      "integrity": "sha1-MtU+SFHv3AoRmTts0AB4nXDAUQI=",
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.0.tgz",
+      "integrity": "sha512-1uvKqKQta3KBxIz14F2v06AEHZ/dIoeKfbTRkK1E5oqjDnuEerLmYTgJB5AiQZHJcljpg1TuRzdjDR06qNk0DQ==",
       "requires": {
-        "follow-redirects": "^1.3.0",
-        "is-buffer": "^1.1.5"
+        "follow-redirects": "1.5.10",
+        "is-buffer": "^2.0.2"
+      },
+      "dependencies": {
+        "is-buffer": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.3.tgz",
+          "integrity": "sha512-U15Q7MXTuZlrbymiz95PJpZxu8IlipAp4dtS3wOdgPXx3mqBnslrWU14kxfHB+Py/+2PVKSr37dMAgM2A4uArw=="
+        }
       }
     },
     "axobject-query": {
@@ -5355,9 +5362,9 @@
       "integrity": "sha1-UhTXU3pNBqSjAcDMJi/rhBiAAuc="
     },
     "follow-redirects": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.6.1.tgz",
-      "integrity": "sha512-t2JCjbzxQpWvbhts3l6SH1DKzSrx8a+SsaVf4h6bG4kOXUuPYS/kg2Lr4gQSb7eemaHqJkOThF1BGyjlUkO1GQ==",
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
+      "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
       "requires": {
         "debug": "=3.1.0"
       }
@@ -9474,9 +9481,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+      "version": "4.17.14",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.14.tgz",
+      "integrity": "sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw=="
     },
     "lodash-es": {
       "version": "4.17.11",
@@ -11493,6 +11500,14 @@
             }
           }
         }
+      }
+    },
+    "react-apollo-hooks": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/react-apollo-hooks/-/react-apollo-hooks-0.4.5.tgz",
+      "integrity": "sha512-fq04h88hg4ONtlzxYInmv7Okqqstzk3UCp55jHWOlIO2lFKoZPhQrtCz7A+TrcRu8GGwtG1SsioRKN8kIQaAOQ==",
+      "requires": {
+        "lodash": "^4.17.11"
       }
     },
     "react-dom": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "graphql-tag": "^2.10.0",
     "html-react-parser": "^0.6.1",
     "isomorphic-unfetch": "^3.0.0",
-    "lodash": "^4.17.11",
+    "lodash": "^4.17.14",
     "lscache": "^1.3.0",
     "mime-types": "^2.1.24",
     "moment": "^2.23.0",


### PR DESCRIPTION
* If there's only one language unit, display the language instead of a dropdown
* Display the tags at the bottom of the preview project modal
* Display the next available unit in the modal if the English unit has no files
* Adjust the key for the dashboard primary columns to address error in console
* update and add new tests where needed