### PR TITLE
CDP-1467

### DIFF
--- a/components/ScrollableTableWithMenu/TableActionsMenu/ActionResults/ActionResultError.js
+++ b/components/ScrollableTableWithMenu/TableActionsMenu/ActionResults/ActionResultError.js
@@ -1,0 +1,28 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { List } from 'semantic-ui-react';
+import { getPluralStringOrNot } from 'lib/utils';
+import ActionResultsItem from './ActionResultsItem/ActionResultsItem';
+
+const ActionResultError = ( { action, errors, projectTitle } ) => {
+  const withErrors = errors.length >= 1 ? ` with ${getPluralStringOrNot( errors, 'error' )}:` : '';
+  const header = `Project '${projectTitle}' ${action} failed${withErrors}`;
+  return (
+    <ActionResultsItem isError>
+      <List.Header>{ header }</List.Header>
+      { errors.length > 0 && (
+        <List.Description>
+          <List items={ errors } style={ { paddingTop: '0.25em', paddingBottom: '0.75em' } } />
+        </List.Description>
+      ) }
+    </ActionResultsItem>
+  );
+};
+
+ActionResultError.propTypes = {
+  action: PropTypes.string,
+  errors: PropTypes.array,
+  projectTitle: PropTypes.string
+};
+
+export default ActionResultError;

--- a/components/ScrollableTableWithMenu/TableActionsMenu/ActionResults/ActionResults.js
+++ b/components/ScrollableTableWithMenu/TableActionsMenu/ActionResults/ActionResults.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { List } from 'semantic-ui-react';
-import ActionResultError from './ActionResultError';
+import ActionResultsError from './ActionResultsError/ActionResultsError';
 import ActionResultsItem from './ActionResultsItem/ActionResultsItem';
 
 const ActionResults = ( { failures } ) => {
@@ -9,10 +9,10 @@ const ActionResults = ( { failures } ) => {
   return (
     <List>
       { !isError && (
-        <ActionResultsItem isError={ false } />
+        <ActionResultsItem />
       ) }
       { isError && failures.map( failure => (
-        <ActionResultError { ...failure } key={ failure.id } />
+        <ActionResultsError { ...failure } key={ failure.project.id } />
       ) ) }
     </List>
   );

--- a/components/ScrollableTableWithMenu/TableActionsMenu/ActionResults/ActionResults.js
+++ b/components/ScrollableTableWithMenu/TableActionsMenu/ActionResults/ActionResults.js
@@ -1,0 +1,25 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { List } from 'semantic-ui-react';
+import ActionResultError from './ActionResultError';
+import ActionResultsItem from './ActionResultsItem/ActionResultsItem';
+
+const ActionResults = ( { failures } ) => {
+  const isError = failures && failures.length > 0;
+  return (
+    <List>
+      { !isError && (
+        <ActionResultsItem isError={ false } />
+      ) }
+      { isError && failures.map( failure => (
+        <ActionResultError { ...failure } key={ failure.id } />
+      ) ) }
+    </List>
+  );
+};
+
+ActionResults.propTypes = {
+  failures: PropTypes.arrayOf( PropTypes.object )
+};
+
+export default ActionResults;

--- a/components/ScrollableTableWithMenu/TableActionsMenu/ActionResults/ActionResults.test.js
+++ b/components/ScrollableTableWithMenu/TableActionsMenu/ActionResults/ActionResults.test.js
@@ -1,0 +1,41 @@
+import { mount, shallow } from 'enzyme';
+import ActionResults from './ActionResults';
+import ActionResultsItem from './ActionResultsItem/ActionResultsItem';
+import ActionResultsError from './ActionResultsError/ActionResultsError';
+
+import { failure } from './mocks';
+
+const props = { failures: [failure] };
+
+const Component = <ActionResults />;
+
+const ComponentError = <ActionResults { ...props } />;
+
+describe( '<ActionResults />', () => {
+  it( 'renders without crashing', () => {
+    const wrapper = shallow( Component );
+    expect( wrapper.exists() ).toEqual( true );
+  } );
+
+  it( 'renders a single ActionResultsItem when no errors provided', () => {
+    const wrapper = mount( Component );
+
+    const item = wrapper.find( ActionResultsItem );
+    expect( item.exists() ).toEqual( true );
+    expect( item.length ).toBe( 1 );
+
+    const error = wrapper.find( ActionResultsError );
+    expect( error.exists() ).toEqual( false );
+  } );
+
+  it( 'renders ActionResultsError when errors provided', () => {
+    const wrapper = mount( ComponentError );
+
+    const error = wrapper.find( ActionResultsError );
+    expect( error.exists() ).toEqual( true );
+    expect( error.length ).toEqual( 1 );
+
+    const item = wrapper.find( ActionResultsItem );
+    expect( item.exists() ).toEqual( true );
+  } );
+} );

--- a/components/ScrollableTableWithMenu/TableActionsMenu/ActionResults/ActionResults.test.js
+++ b/components/ScrollableTableWithMenu/TableActionsMenu/ActionResults/ActionResults.test.js
@@ -28,14 +28,13 @@ describe( '<ActionResults />', () => {
     expect( error.exists() ).toEqual( false );
   } );
 
-  it( 'renders ActionResultsError when errors provided', () => {
+  it( 'renders ActionResultsError with props when errors provided', () => {
     const wrapper = mount( ComponentError );
 
     const error = wrapper.find( ActionResultsError );
+    expect( error.props() ).toEqual( failure );
+
     expect( error.exists() ).toEqual( true );
     expect( error.length ).toEqual( 1 );
-
-    const item = wrapper.find( ActionResultsItem );
-    expect( item.exists() ).toEqual( true );
   } );
 } );

--- a/components/ScrollableTableWithMenu/TableActionsMenu/ActionResults/ActionResultsError/ActionResultsError.js
+++ b/components/ScrollableTableWithMenu/TableActionsMenu/ActionResults/ActionResultsError/ActionResultsError.js
@@ -1,10 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { List } from 'semantic-ui-react';
-import { getPluralStringOrNot } from 'lib/utils';
-import ActionResultsItem from './ActionResultsItem/ActionResultsItem';
+import { getApolloErrors, getPluralStringOrNot } from 'lib/utils';
+import ActionResultsItem from '../ActionResultsItem/ActionResultsItem';
 
-const ActionResultError = ( { action, errors, projectTitle } ) => {
+const ActionResultsError = ( { action, error, project: { projectTitle } } ) => {
+  const errors = getApolloErrors( error );
   const withErrors = errors.length >= 1 ? ` with ${getPluralStringOrNot( errors, 'error' )}:` : '';
   const header = `Project '${projectTitle}' ${action} failed${withErrors}`;
   return (
@@ -19,10 +20,10 @@ const ActionResultError = ( { action, errors, projectTitle } ) => {
   );
 };
 
-ActionResultError.propTypes = {
+ActionResultsError.propTypes = {
   action: PropTypes.string,
-  errors: PropTypes.array,
-  projectTitle: PropTypes.string
+  error: PropTypes.object,
+  project: PropTypes.object
 };
 
-export default ActionResultError;
+export default ActionResultsError;

--- a/components/ScrollableTableWithMenu/TableActionsMenu/ActionResults/ActionResultsError/ActionResultsError.test.js
+++ b/components/ScrollableTableWithMenu/TableActionsMenu/ActionResults/ActionResultsError/ActionResultsError.test.js
@@ -1,0 +1,33 @@
+import { mount } from 'enzyme';
+import { List } from 'semantic-ui-react';
+import { failure, errorStrings } from '../mocks';
+import ActionResultsError from './ActionResultsError';
+
+const props = { ...failure };
+
+const component = (
+  <List>
+    <ActionResultsError { ...props } />
+  </List>
+);
+
+describe( '<ActionResultsError />', () => {
+  it( 'renders without crashing', () => {
+    const wrapper = mount( component );
+    const item = wrapper.find( ActionResultsError );
+    expect( item.exists() ).toEqual( true );
+  } );
+
+  it( 'renders the project title', () => {
+    const wrapper = mount( component );
+    const item = wrapper.find( ActionResultsError );
+    expect( item.text() ).toEqual( expect.stringContaining( failure.project.projectTitle ) );
+  } );
+
+  it( 'renders a list with the expected error strings', () => {
+    const wrapper = mount( component );
+    const item = wrapper.find( ActionResultsError );
+    const list = item.find( List );
+    expect( list.props() ).toHaveProperty( 'items', errorStrings );
+  } );
+} );

--- a/components/ScrollableTableWithMenu/TableActionsMenu/ActionResults/ActionResultsError/ActionResultsError.test.js
+++ b/components/ScrollableTableWithMenu/TableActionsMenu/ActionResults/ActionResultsError/ActionResultsError.test.js
@@ -21,13 +21,14 @@ describe( '<ActionResultsError />', () => {
   it( 'renders the project title', () => {
     const wrapper = mount( component );
     const item = wrapper.find( ActionResultsError );
-    expect( item.text() ).toEqual( expect.stringContaining( failure.project.projectTitle ) );
+    const msg = `Project '${failure.project.projectTitle}' ${failure.action} failed with errors:`;
+    expect( item.find( '.header' ).text() ).toEqual( msg );
   } );
 
   it( 'renders a list with the expected error strings', () => {
     const wrapper = mount( component );
     const item = wrapper.find( ActionResultsError );
     const list = item.find( List );
-    expect( list.props() ).toHaveProperty( 'items', errorStrings );
+    expect( list.prop( 'items' ) ).toEqual( errorStrings );
   } );
 } );

--- a/components/ScrollableTableWithMenu/TableActionsMenu/ActionResults/ActionResultsItem/ActionResultsItem.js
+++ b/components/ScrollableTableWithMenu/TableActionsMenu/ActionResults/ActionResultsItem/ActionResultsItem.js
@@ -1,0 +1,28 @@
+import React from 'react';
+import * as PropTypes from 'prop-types';
+import { List } from 'semantic-ui-react';
+
+const ActionResultsItem = ( { isError, children } ) => (
+  <List.Item>
+    <List.Icon
+      color={ isError ? 'red' : 'green' }
+      name={ isError ? 'exclamation triangle' : 'check circle outline' }
+      size="big"
+    />
+    <List.Content style={ { fontSize: '1rem', verticalAlign: 'middle' } }>
+      { !isError && (
+        <List.Description>
+          You&rsquo;ve updated your projects successfully.
+        </List.Description>
+      ) }
+      { children }
+    </List.Content>
+  </List.Item>
+);
+
+ActionResultsItem.propTypes = {
+  isError: PropTypes.bool,
+  children: PropTypes.oneOfType( [PropTypes.array, PropTypes.element] )
+};
+
+export default ActionResultsItem;

--- a/components/ScrollableTableWithMenu/TableActionsMenu/ActionResults/ActionResultsItem/ActionResultsItem.js
+++ b/components/ScrollableTableWithMenu/TableActionsMenu/ActionResults/ActionResultsItem/ActionResultsItem.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import * as PropTypes from 'prop-types';
+import PropTypes from 'prop-types';
 import { List } from 'semantic-ui-react';
 
 const ActionResultsItem = ( { isError, children } ) => (
@@ -23,6 +23,10 @@ const ActionResultsItem = ( { isError, children } ) => (
 ActionResultsItem.propTypes = {
   isError: PropTypes.bool,
   children: PropTypes.oneOfType( [PropTypes.array, PropTypes.element] )
+};
+
+ActionResultsItem.defaultProps = {
+  isError: false
 };
 
 export default ActionResultsItem;

--- a/components/ScrollableTableWithMenu/TableActionsMenu/ActionResults/ActionResultsItem/ActionResultsItem.test.js
+++ b/components/ScrollableTableWithMenu/TableActionsMenu/ActionResults/ActionResultsItem/ActionResultsItem.test.js
@@ -1,0 +1,47 @@
+import { mount } from 'enzyme';
+import { List } from 'semantic-ui-react';
+import ActionResultsItem from './ActionResultsItem';
+
+const component = (
+  <List>
+    <ActionResultsItem />
+  </List>
+);
+
+const componentError = (
+  <List>
+    <ActionResultsItem isError>
+      <div id="child-item" />
+    </ActionResultsItem>
+  </List>
+);
+
+describe( '<ActionResultsItem />', () => {
+  it( 'renders without crashing', () => {
+    const wrapper = mount( component );
+    const item = wrapper.find( ActionResultsItem );
+    expect( item.exists() ).toEqual( true );
+  } );
+
+  it( 'renders red exclamation icon on error', () => {
+    const wrapper = mount( componentError );
+    const icon = wrapper.find( List.Icon );
+    expect( icon.exists() ).toEqual( true );
+    expect( icon.props() ).toHaveProperty( 'color', 'red' );
+    expect( icon.props() ).toHaveProperty( 'name', 'exclamation triangle' );
+  } );
+
+  it( 'renders green checkmark icon on no error', () => {
+    const wrapper = mount( component );
+    const icon = wrapper.find( List.Icon );
+    expect( icon.exists() ).toEqual( true );
+    expect( icon.props() ).toHaveProperty( 'color', 'green' );
+    expect( icon.props() ).toHaveProperty( 'name', 'check circle outline' );
+  } );
+
+  it( 'renders children', () => {
+    const wrapper = mount( componentError );
+    const child = wrapper.find( '#child-item' );
+    expect( child.exists() ).toEqual( true );
+  } );
+} );

--- a/components/ScrollableTableWithMenu/TableActionsMenu/ActionResults/mocks.js
+++ b/components/ScrollableTableWithMenu/TableActionsMenu/ActionResults/mocks.js
@@ -1,0 +1,24 @@
+export const errorStrings = [
+  'A GraphQLError1',
+  'A GraphQLError2',
+  'A NetworkError',
+  'An OtherError',
+];
+
+export const apolloError = {
+  graphQLErrors: [
+    { message: errorStrings[0] },
+    { message: errorStrings[1] },
+  ],
+  networkError: errorStrings[2],
+  otherError: errorStrings[3]
+};
+
+export const failure = {
+  project: {
+    id: 'abc123',
+    projectTitle: 'ABC',
+  },
+  action: 'delete',
+  error: apolloError
+};

--- a/components/ScrollableTableWithMenu/TableActionsMenu/DeleteProjects/DeleteProjects.js
+++ b/components/ScrollableTableWithMenu/TableActionsMenu/DeleteProjects/DeleteProjects.js
@@ -1,10 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Mutation } from 'react-apollo';
+import { graphql } from 'react-apollo';
 import gql from 'graphql-tag';
 import { Button, Modal } from 'semantic-ui-react';
-import ApolloError from 'components/errors/ApolloError';
-import { getCount, getPluralStringOrNot } from 'lib/utils';
+import { getApolloErrors, getCount, getPluralStringOrNot } from 'lib/utils';
+import { DELETE_VIDEO_PROJECT_MUTATION } from 'lib/graphql/queries/video';
 import ConfirmModalContent from 'components/admin/ConfirmModalContent/ConfirmModalContent';
 import DeleteProjectsList from './DeleteProjectsList/DeleteProjectsList';
 
@@ -21,9 +21,8 @@ const DeleteProjects = props => {
     deleteConfirmOpen,
     handleDeleteCancel,
     handleDeleteConfirm,
-    handleResetSelections,
     selections,
-    showConfirmationMsg
+    deleteVideoProject
   } = props;
 
   const getDrafts = () => {
@@ -40,77 +39,78 @@ const DeleteProjects = props => {
     return [];
   };
 
+
+  const drafts = getDrafts();
+  const draftsCount = getCount( drafts );
+
+  const nonDrafts = getNonDrafts();
+  const nonDraftsCount = getCount( nonDrafts );
+
+  const hasNonDraftsOnly = draftsCount === 0 && nonDraftsCount > 0;
+
+  const deleteProjects = () => {
+    const promises = drafts.map( project => deleteVideoProject( { variables: { id: project.id } } )
+      .catch( error => ( {
+        error,
+        errors: getApolloErrors( error ),
+        action: 'delete',
+        id: project.id,
+        projectTitle: project.projectTitle,
+      } ) ) );
+    return Promise.all( promises ).then( results => {
+      handleDeleteCancel();
+      return results;
+    } );
+  };
+
   return (
-    <Mutation
-      mutation={ DELETE_VIDEO_PROJECTS_MUTATION }
-      onCompleted={ () => {
-        handleResetSelections();
-        handleDeleteCancel();
-        showConfirmationMsg();
-      } }
-    >
-      { ( deleteProjects, { error } ) => {
-        if ( error ) return <ApolloError error={ error } />;
+    <Modal className="delete" open={ deleteConfirmOpen } size="small">
+      <ConfirmModalContent
+        className="delete_confirm delete_confirm--video"
+        headline={
+          hasNonDraftsOnly
+            ? 'Only DRAFT video projects can be deleted from the dashboard.'
+            : `Are you sure you want to delete the selected DRAFT video ${getPluralStringOrNot( drafts, 'project' )}?` // eslint-disable-line
+        }
+      >
+        { draftsCount > 0
+        && (
+          <DeleteProjectsList
+            headline={ `The following DRAFT video ${getPluralStringOrNot( drafts, 'project' )} will be removed permanently from the Content Cloud:` }
+            projects={ drafts }
+            isDrafts
+          />
+        ) }
 
-        const drafts = getDrafts();
-        const draftsCount = getCount( drafts );
-
-        const nonDrafts = getNonDrafts();
-        const nonDraftsCount = getCount( nonDrafts );
-
-        const hasNonDraftsOnly = draftsCount === 0 && nonDraftsCount > 0;
-
-        return (
-          <Modal className="delete" open={ deleteConfirmOpen } size="small">
-            <ConfirmModalContent
-              className="delete_confirm delete_confirm--video"
-              headline={
-                hasNonDraftsOnly
-                  ? 'Only DRAFT video projects can be deleted from the dashboard.'
-                  : `Are you sure you want to delete the selected DRAFT video ${getPluralStringOrNot( drafts, 'project' )}?` // eslint-disable-line
-              }
-            >
-              { draftsCount > 0
-                && (
-                  <DeleteProjectsList
-                    headline={ `The following DRAFT video ${getPluralStringOrNot( drafts, 'project' )} will be removed permanently from the Content Cloud:` }
-                    projects={ drafts }
-                    isDrafts
-                  />
-                ) }
-
-              { nonDraftsCount > 0
-                && (
-                  <DeleteProjectsList
-                    headline={ `${draftsCount > 0 && nonDraftsCount > 0 ? 'Only DRAFT video projects can be deleted from the dashboard. ' : ''}The following non-DRAFT video ${getPluralStringOrNot( nonDrafts, 'project' )} will NOT be removed:` }
-                    projects={ nonDrafts }
-                  />
-                ) }
-            </ConfirmModalContent>
-            <Modal.Actions>
-              <Button
-                content={
-                  hasNonDraftsOnly
-                    ? 'Take me back'
-                    : 'No, take me back'
-                }
-                onClick={ handleDeleteCancel }
-              />
-              <Button
-                content={
-                  hasNonDraftsOnly
-                    ? 'Not Applicable'
-                    : 'Yes, delete forever'
-                }
-                disabled={ hasNonDraftsOnly }
-                onClick={ () => handleDeleteConfirm( deleteProjects ) }
-                primary
-              />
-            </Modal.Actions>
-          </Modal>
-        );
-      } }
-    </Mutation>
+        { nonDraftsCount > 0
+        && (
+          <DeleteProjectsList
+            headline={ `${draftsCount > 0 && nonDraftsCount > 0 ? 'Only DRAFT video projects can be deleted from the dashboard. ' : ''}The following non-DRAFT video ${getPluralStringOrNot( nonDrafts, 'project' )} will NOT be removed:` }
+            projects={ nonDrafts }
+          />
+        ) }
+      </ConfirmModalContent>
+      <Modal.Actions>
+        <Button
+          content={
+            hasNonDraftsOnly
+              ? 'Take me back'
+              : 'No, take me back'
+          }
+          onClick={ handleDeleteCancel }
+        />
+        <Button
+          content={
+            hasNonDraftsOnly
+              ? 'Not Applicable'
+              : 'Yes, delete forever'
+          }
+          disabled={ hasNonDraftsOnly }
+          onClick={ () => handleDeleteConfirm( deleteProjects ) }
+          primary
+        />
+      </Modal.Actions>
+    </Modal>
   );
 };
 
@@ -118,11 +118,12 @@ DeleteProjects.propTypes = {
   deleteConfirmOpen: PropTypes.bool,
   handleDeleteCancel: PropTypes.func,
   handleDeleteConfirm: PropTypes.func,
-  handleResetSelections: PropTypes.func,
   selections: PropTypes.array,
-  showConfirmationMsg: PropTypes.func
+  deleteVideoProject: PropTypes.func
 };
 
-export default DeleteProjects;
+export default graphql( DELETE_VIDEO_PROJECT_MUTATION, {
+  name: 'deleteVideoProject'
+} )( DeleteProjects );
 
 export { DELETE_VIDEO_PROJECTS_MUTATION };

--- a/components/ScrollableTableWithMenu/TableActionsMenu/DeleteProjects/DeleteProjects.test.js
+++ b/components/ScrollableTableWithMenu/TableActionsMenu/DeleteProjects/DeleteProjects.test.js
@@ -122,7 +122,9 @@ describe( '<DeleteProjects />', () => {
 
     expect( props.handleActionResult ).toHaveBeenCalledTimes( drafts.length );
     const mockResults = draftMocks.map( mock => [mock.result] );
-    expect( props.handleActionResult.mock.calls ).toEqual( expect.arrayContaining( mockResults ) );
+    mockResults.forEach( result => {
+      expect( props.handleActionResult ).toHaveBeenCalledWith( result[0] );
+    } );
   } );
 
   it( 'clicking the confirm button calls handleDeleteConfirm and handleDeleteCancel when completed', async () => {

--- a/components/ScrollableTableWithMenu/TableActionsMenu/DeleteProjects/DeleteProjects.test.js
+++ b/components/ScrollableTableWithMenu/TableActionsMenu/DeleteProjects/DeleteProjects.test.js
@@ -1,16 +1,20 @@
 import { mount } from 'enzyme';
+import wait from 'waait';
 import toJSON from 'enzyme-to-json';
-import { Mutation } from 'react-apollo';
 import { MockedProvider } from 'react-apollo/test-utils';
 import { getPluralStringOrNot } from 'lib/utils';
-import DeleteProjects, { DELETE_VIDEO_PROJECTS_MUTATION } from './DeleteProjects';
-import { drafts, nonDrafts } from './mocks';
+import DeleteProjects from './DeleteProjects';
+import {
+  mocks, drafts, nonDrafts, draftMocks
+} from './mocks';
 
 const props = {
   deleteConfirmOpen: false,
+  handleActionResult: jest.fn(),
   handleDeleteCancel: jest.fn(),
   handleDeleteConfirm: jest.fn(),
   handleResetSelections: jest.fn(),
+  deleteVideoProject: jest.fn(),
   selections: [...drafts, ...nonDrafts],
   showConfirmationMsg: jest.fn()
 };
@@ -27,23 +31,6 @@ const nonDraftsProps = {
     selections: [...nonDrafts]
   }
 };
-
-const mocks = [
-  {
-    request: {
-      query: DELETE_VIDEO_PROJECTS_MUTATION,
-      variables: {
-        where: {
-          AND: [
-            { id_in: ['C1', 'C2', 'C3'] },
-            { status_in: ['DRAFT'] }
-          ]
-        }
-      }
-    },
-    result: { data: { deleteProjects: 3 } }
-  }
-];
 
 const Component = (
   <MockedProvider mocks={ mocks } addTypename={ false }>
@@ -123,24 +110,32 @@ describe( '<DeleteProjects />', () => {
     expect( props.handleDeleteCancel ).toHaveBeenCalled();
   } );
 
-  it( 'clicking the confirm button calls handleDeleteConfirm', () => {
+  it( 'clicking the confirm button calls handleActionResult with the apporpriate results', async () => {
     const wrapper = mount( OpenConfirmComponent );
-    const deleteMutation = wrapper.find( 'DeleteProjects' );
-    const confirm = deleteMutation.find( 'Modal.delete' );
+    const deleteProjects = wrapper.find( 'DeleteProjects' );
+    const confirm = deleteProjects.find( 'Modal.delete' );
     const confirmBtn = confirm.find( 'Button[content="Yes, delete forever"]' );
 
     confirmBtn.simulate( 'click' );
-    expect( props.handleDeleteConfirm ).toHaveBeenCalled();
+    await wait( 10 );
+    wrapper.update();
+
+    expect( props.handleActionResult ).toHaveBeenCalledTimes( drafts.length );
+    const mockResults = draftMocks.map( mock => [mock.result] );
+    expect( props.handleActionResult.mock.calls ).toEqual( expect.arrayContaining( mockResults ) );
   } );
 
-  it( 'mutation calls handleResetSelections, handleDeleteCancel, showConfirmationMsg on completion', () => {
-    const wrapper = mount( Component );
-    const deleteMutation = wrapper.find( 'DeleteProjects' );
-    const mutation = deleteMutation.find( Mutation );
+  it( 'clicking the confirm button calls handleDeleteConfirm and handleDeleteCancel when completed', async () => {
+    const wrapper = mount( OpenConfirmComponent );
+    const deleteProjects = wrapper.find( 'DeleteProjects' );
+    const confirm = deleteProjects.find( 'Modal.delete' );
+    const confirmBtn = confirm.find( 'Button[content="Yes, delete forever"]' );
 
-    mutation.prop( 'onCompleted' )();
-    expect( props.handleResetSelections ).toHaveBeenCalled();
+    confirmBtn.simulate( 'click' );
+    await wait( 10 );
+    wrapper.update();
+
+    expect( props.handleDeleteConfirm ).toHaveBeenCalled();
     expect( props.handleDeleteCancel ).toHaveBeenCalled();
-    expect( props.showConfirmationMsg ).toHaveBeenCalled();
   } );
 } );

--- a/components/ScrollableTableWithMenu/TableActionsMenu/DeleteProjects/__snapshots__/DeleteProjects.test.js.snap
+++ b/components/ScrollableTableWithMenu/TableActionsMenu/DeleteProjects/__snapshots__/DeleteProjects.test.js.snap
@@ -3,6 +3,8 @@
 exports[`<DeleteProjects /> renders without crashing 1`] = `
 <DeleteProjects
   deleteConfirmOpen={false}
+  deleteVideoProject={[Function]}
+  handleActionResult={[MockFunction]}
   handleDeleteCancel={[MockFunction]}
   handleDeleteConfirm={[MockFunction]}
   handleResetSelections={[MockFunction]}
@@ -341,121 +343,28 @@ exports[`<DeleteProjects /> renders without crashing 1`] = `
   }
   showConfirmationMsg={[MockFunction]}
 >
-  <Mutation
-    mutation={
-      Object {
-        "definitions": Array [
-          Object {
-            "directives": Array [],
-            "kind": "OperationDefinition",
-            "name": Object {
-              "kind": "Name",
-              "value": "DeleteManyVideoProjects",
-            },
-            "operation": "mutation",
-            "selectionSet": Object {
-              "kind": "SelectionSet",
-              "selections": Array [
-                Object {
-                  "alias": Object {
-                    "kind": "Name",
-                    "value": "deleteProjects",
-                  },
-                  "arguments": Array [
-                    Object {
-                      "kind": "Argument",
-                      "name": Object {
-                        "kind": "Name",
-                        "value": "where",
-                      },
-                      "value": Object {
-                        "kind": "Variable",
-                        "name": Object {
-                          "kind": "Name",
-                          "value": "where",
-                        },
-                      },
-                    },
-                  ],
-                  "directives": Array [],
-                  "kind": "Field",
-                  "name": Object {
-                    "kind": "Name",
-                    "value": "deleteManyVideoProjects",
-                  },
-                  "selectionSet": Object {
-                    "kind": "SelectionSet",
-                    "selections": Array [
-                      Object {
-                        "alias": undefined,
-                        "arguments": Array [],
-                        "directives": Array [],
-                        "kind": "Field",
-                        "name": Object {
-                          "kind": "Name",
-                          "value": "count",
-                        },
-                        "selectionSet": undefined,
-                      },
-                    ],
-                  },
-                },
-              ],
-            },
-            "variableDefinitions": Array [
-              Object {
-                "defaultValue": undefined,
-                "kind": "VariableDefinition",
-                "type": Object {
-                  "kind": "NamedType",
-                  "name": Object {
-                    "kind": "Name",
-                    "value": "VideoProjectWhereInput",
-                  },
-                },
-                "variable": Object {
-                  "kind": "Variable",
-                  "name": Object {
-                    "kind": "Name",
-                    "value": "where",
-                  },
-                },
-              },
-            ],
-          },
-        ],
-        "kind": "Document",
-        "loc": Object {
-          "end": 153,
-          "start": 0,
-        },
-      }
-    }
-    onCompleted={[Function]}
+  <Modal
+    centered={true}
+    className="delete"
+    closeOnDimmerClick={true}
+    closeOnDocumentClick={false}
+    dimmer={true}
+    eventPool="Modal"
+    open={false}
+    size="small"
   >
-    <Modal
-      centered={true}
-      className="delete"
-      closeOnDimmerClick={true}
+    <Portal
       closeOnDocumentClick={false}
-      dimmer={true}
+      closeOnEscape={true}
       eventPool="Modal"
+      mountNode={<body />}
+      onClose={[Function]}
+      onMount={[Function]}
+      onOpen={[Function]}
+      onUnmount={[Function]}
       open={false}
-      size="small"
-    >
-      <Portal
-        closeOnDocumentClick={false}
-        closeOnEscape={true}
-        eventPool="Modal"
-        mountNode={<body />}
-        onClose={[Function]}
-        onMount={[Function]}
-        onOpen={[Function]}
-        onUnmount={[Function]}
-        open={false}
-        openOnTriggerClick={true}
-      />
-    </Modal>
-  </Mutation>
+      openOnTriggerClick={true}
+    />
+  </Modal>
 </DeleteProjects>
 `;

--- a/components/ScrollableTableWithMenu/TableActionsMenu/DeleteProjects/mocks.js
+++ b/components/ScrollableTableWithMenu/TableActionsMenu/DeleteProjects/mocks.js
@@ -1,3 +1,5 @@
+import { DELETE_VIDEO_PROJECT_MUTATION } from 'lib/graphql/queries/video';
+
 export const drafts = [
   {
     id: 'cjx0j3ts9066y0708k1hg2g1b',
@@ -310,6 +312,21 @@ export const drafts = [
   }
 ];
 
+export const draftMocks = drafts.map( draft => ( {
+  request: {
+    query: DELETE_VIDEO_PROJECT_MUTATION,
+    variables: { id: draft.id }
+  },
+  result: {
+    data: {
+      deleteVideoProject: {
+        __typename: 'VideoProject',
+        id: draft.id
+      }
+    }
+  }
+} ) );
+
 export const nonDrafts = [
   {
     id: 'cjx0jixoa06c60708z2i7t2t3',
@@ -331,4 +348,21 @@ export const nonDrafts = [
     thumbnails: [],
     categories: [],
   }
+];
+
+export const nonDraftMocks = nonDrafts.map( nondraft => ( {
+  request: {
+    query: DELETE_VIDEO_PROJECT_MUTATION,
+    variables: { id: nondraft.id }
+  },
+  result: {
+    errors: [
+      { graphQLError: 'A GraphQLError1' }
+    ]
+  }
+} ) );
+
+export const mocks = [
+  ...draftMocks,
+  ...nonDraftMocks
 ];

--- a/components/ScrollableTableWithMenu/TableActionsMenu/TableActionsMenu.js
+++ b/components/ScrollableTableWithMenu/TableActionsMenu/TableActionsMenu.js
@@ -58,22 +58,26 @@ class TableActionsMenu extends React.Component {
     } );
   }
 
+  handleActionResult = result => {
+    if ( result.error ) {
+      this.setState( ( { actionFailures } ) => ( { actionFailures: [...actionFailures, result] } ) );
+    }
+  }
+
   handleDeleteCancel = () => {
     this.setState( { deleteConfirmOpen: false } );
   }
 
-  handleDeleteConfirm = async deleteFn => {
+  handleDeleteConfirm = () => {
     const {
-      variables, teamVideoProjects, teamVideoProjectsCount, handleResetSelections
+      variables, teamVideoProjects, teamVideoProjectsCount
     } = this.props;
-    const deleteResults = await deleteFn();
     teamVideoProjects.refetch( { ...variables } );
     teamVideoProjectsCount.refetch( {
       team: variables.team,
       searchTerm: variables.searchTerm
     } );
-    handleResetSelections();
-    this.showConfirmationMsg( deleteResults );
+    this.showConfirmationMsg();
   }
 
   handleDrafts = cache => {
@@ -186,9 +190,8 @@ class TableActionsMenu extends React.Component {
     return false;
   }
 
-  showConfirmationMsg = results => {
+  showConfirmationMsg = () => {
     this.setState( {
-      actionFailures: results.filter( result => result.error ),
       displayConfirmationMsg: true,
     } );
   }
@@ -210,7 +213,10 @@ class TableActionsMenu extends React.Component {
   }
 
   displayConfirmDelete = () => {
-    this.setState( { deleteConfirmOpen: true } );
+    this.setState( {
+      deleteConfirmOpen: true,
+      actionFailures: []
+    } );
   }
 
   renderMenu() {
@@ -280,6 +286,7 @@ class TableActionsMenu extends React.Component {
             deleteConfirmOpen={ this.state.deleteConfirmOpen }
             handleDeleteCancel={ this.handleDeleteCancel }
             handleDeleteConfirm={ this.handleDeleteConfirm }
+            handleActionResult={ this.handleActionResult }
             handleResetSelections={ this.props.handleResetSelections }
             selections={ selections }
             showConfirmationMsg={ this.showConfirmationMsg }
@@ -348,5 +355,5 @@ export default compose(
         searchTerm: props.variables.searchTerm
       }
     } )
-  } )
+  } ),
 )( TableActionsMenu );

--- a/components/ScrollableTableWithMenu/TableActionsMenu/TableActionsMenu.test.js
+++ b/components/ScrollableTableWithMenu/TableActionsMenu/TableActionsMenu.test.js
@@ -1,12 +1,10 @@
 import { mount } from 'enzyme';
 import wait from 'waait';
 import { MockedProvider } from 'react-apollo/test-utils';
-import { Checkbox } from 'semantic-ui-react';
-import ApolloError from 'components/errors/ApolloError';
 import TableActionsMenu from './TableActionsMenu';
 import { TEAM_VIDEO_PROJECTS_QUERY } from '../TableBody/TableBody';
-import { TEAM_VIDEO_PROJECTS_COUNT_QUERY } from '../TablePagination/TablePagination';
 import {
+  actionResult,
   allCheckedMocks,
   emptyMocks,
   errorMocks,
@@ -21,9 +19,22 @@ import {
  */
 jest.mock(
   'next-server/dynamic',
-  () => function VideoDetailsPopup() {
-    return <div>VideoDetailsPopup</div>;
-  }
+  () => function VideoDetailsPopup() { return ''; }
+);
+
+jest.mock(
+  './DeleteIconButton/DeleteIconButton',
+  () => function DeleteIconButton() { return ''; }
+);
+
+jest.mock(
+  './DeleteProjects/DeleteProjects',
+  () => function DeleteProjects() { return ''; }
+);
+
+jest.mock(
+  './UnpublishProjects/UnpublishProjects',
+  () => function UnpublishProjects() { return ''; }
 );
 
 const Component = (
@@ -39,7 +50,7 @@ const findProjectById = ( array, projectId ) => (
 describe( '<TableActionsMenu />', () => {
   it( 'renders initial loading state without crashing', () => {
     const wrapper = mount( Component );
-    const menu = wrapper.find( TableActionsMenu );
+    const menu = wrapper.find( 'TableActionsMenu' );
 
     expect( menu.exists() ).toEqual( true );
     expect( menu.contains( 'Loading....' ) ).toEqual( true );
@@ -56,15 +67,15 @@ describe( '<TableActionsMenu />', () => {
     await wait( 0 );
     wrapper.update();
 
-    const menu = wrapper.find( TableActionsMenu );
-    const errorComponent = menu.find( ApolloError );
+    const menu = wrapper.find( 'TableActionsMenu' );
+    const errorComponent = menu.find( 'ApolloError' );
 
     expect( errorComponent.exists() ).toEqual( true );
     expect( errorComponent.contains( 'There was an error.' ) )
       .toEqual( true );
   } );
 
-  it( 'renders null if videoProjects is falsy', async () => {
+  it( 'renders empty if videoProjects is falsy', async () => {
     const wrapper = mount(
       <MockedProvider mocks={ nullMocks } addTypename={ false }>
         <TableActionsMenu { ...props } />
@@ -73,15 +84,9 @@ describe( '<TableActionsMenu />', () => {
 
     await wait( 0 );
     wrapper.update();
-
     const menuWrapper = wrapper.find( '.actionsMenu_wrapper' );
 
-    /**
-     *  the Query (i.e., `childAt( 0 )` ) returns
-     *  `null` but will continue to render the
-     *  remainder of the menu (e.g., Modal, Popup, etc.)
-     */
-    expect( menuWrapper.childAt( 0 ).html() ).toEqual( null );
+    expect( menuWrapper.children().length ).toEqual( 0 );
   } );
 
   it( 'renders a Checkbox when TEAM_VIDEO_PROJECTS_QUERY is resolved', async () => {
@@ -89,8 +94,8 @@ describe( '<TableActionsMenu />', () => {
     await wait( 0 );
     wrapper.update();
 
-    const checkbox = wrapper.find( Checkbox );
-    const projectsCount = mocks[4].result.data.videoProjects.length;
+    const checkbox = wrapper.find( 'Checkbox' );
+    const projectsCount = mocks[2].result.data.videoProjects.length;
 
     expect( checkbox.exists() ).toEqual( true );
     expect( checkbox.prop( 'disabled' ) ).toEqual( projectsCount === 0 );
@@ -107,7 +112,7 @@ describe( '<TableActionsMenu />', () => {
     await wait( 0 );
     wrapper.update();
 
-    const checkbox = wrapper.find( Checkbox );
+    const checkbox = wrapper.find( 'Checkbox' );
     const projectsCount = emptyMocks[0].result.data.videoProjects.length;
 
     expect( checkbox.exists() ).toEqual( true );
@@ -124,7 +129,7 @@ describe( '<TableActionsMenu />', () => {
     await wait( 0 );
     wrapper.update();
 
-    const checkbox = wrapper.find( Checkbox );
+    const checkbox = wrapper.find( 'Checkbox' );
     const projectsCount = allCheckedMocks[0].result.data.videoProjects.length;
 
     expect( checkbox.prop( 'checked' ) ).toEqual( projectsCount === props.selectedItems.size );
@@ -136,8 +141,8 @@ describe( '<TableActionsMenu />', () => {
     await wait( 0 );
     wrapper.update();
 
-    const checkbox = wrapper.find( Checkbox );
-    const projectsCount = mocks[4].result.data.videoProjects.length;
+    const checkbox = wrapper.find( 'Checkbox' );
+    const projectsCount = mocks[2].result.data.videoProjects.length;
 
     expect( checkbox.prop( 'indeterminate' ) )
       .toEqual( projectsCount > props.selectedItems.size );
@@ -148,10 +153,9 @@ describe( '<TableActionsMenu />', () => {
     await wait( 0 );
     wrapper.update();
 
-    const checkbox = wrapper.find( Checkbox );
+    const checkbox = wrapper.find( 'Checkbox' );
 
     checkbox.simulate( 'change' );
-
     expect( props.toggleAllItemsSelection ).toHaveBeenCalled();
   } );
 
@@ -160,11 +164,10 @@ describe( '<TableActionsMenu />', () => {
     await wait( 0 );
     wrapper.update();
 
-    const menu = wrapper.find( TableActionsMenu );
+    const menu = wrapper.find( 'TableActionsMenu' );
     const inst = menu.instance();
 
     inst.componentDidMount();
-
     expect( inst._isMounted ).toEqual( true );
   } );
 
@@ -173,11 +176,10 @@ describe( '<TableActionsMenu />', () => {
     await wait( 0 );
     wrapper.update();
 
-    const menu = wrapper.find( TableActionsMenu );
+    const menu = wrapper.find( 'TableActionsMenu' );
     const inst = menu.instance();
 
     inst.componentWillUnmount();
-
     expect( inst._isMounted ).toEqual( false );
   } );
 
@@ -186,7 +188,7 @@ describe( '<TableActionsMenu />', () => {
     await wait( 0 );
     wrapper.update();
 
-    const menu = wrapper.find( TableActionsMenu );
+    const menu = wrapper.find( 'TableActionsMenu' );
     const inst = menu.instance();
     const fn = jest.fn();
     const timer = inst.confirmationMsgTimer;
@@ -202,18 +204,21 @@ describe( '<TableActionsMenu />', () => {
     await wait( 0 );
     wrapper.update();
 
-    const menu = wrapper.find( TableActionsMenu );
+    const menu = wrapper.find( 'TableActionsMenu' );
     const inst = menu.instance();
+    const results = [{ id: 'ud23' }, { id: 'ud74' }];
 
     // initial state
     expect( inst.state.displayConfirmationMsg ).toEqual( false );
 
-    inst.showConfirmationMsg();
+    inst.showConfirmationMsg( results );
     if ( inst._isMounted ) {
+      expect( inst.state.actionFailures ).toEqual( null );
       expect( inst.state.displayConfirmationMsg ).toEqual( true );
     }
 
     inst.hideConfirmationMsg();
+    expect( inst.state.actionFailures ).toEqual( null );
     expect( inst.state.displayConfirmationMsg ).toEqual( false );
     expect( inst.confirmationMsgTimer ).toEqual( null );
   } );
@@ -223,7 +228,7 @@ describe( '<TableActionsMenu />', () => {
     await wait( 0 );
     wrapper.update();
 
-    const menu = wrapper.find( TableActionsMenu );
+    const menu = wrapper.find( 'TableActionsMenu' );
     const inst = menu.instance();
 
     // initial state
@@ -241,14 +246,16 @@ describe( '<TableActionsMenu />', () => {
     await wait( 0 );
     wrapper.update();
 
-    const menu = () => wrapper.find( TableActionsMenu );
+    const menu = () => wrapper.find( 'TableActionsMenu' );
     const inst = () => menu().instance();
     const confirmModal = () => menu().find( 'Modal.confirmation' );
     const spy = jest.spyOn( inst(), 'hideConfirmationMsg' );
+    const results = [{ id: 'ud23' }, { id: 'ud74' }];
 
     // must open the modal before closing it
-    inst().showConfirmationMsg();
+    inst().showConfirmationMsg( results );
     wrapper.update();
+    expect( inst().state.actionFailures ).toEqual( null );
     expect( inst().state.displayConfirmationMsg ).toEqual( true );
     expect( confirmModal().prop( 'open' ) ).toEqual( true );
 
@@ -257,39 +264,41 @@ describe( '<TableActionsMenu />', () => {
     expect( spy ).toHaveBeenCalled();
   } );
 
-  it( 'handleDeleteConfirm calls deleteProjects mutate function', async () => {
+  it( 'handleActionResult adds result to actionFailures if it has an error', async () => {
     const wrapper = mount( Component );
     await wait( 0 );
     wrapper.update();
 
-    const menu = wrapper.find( TableActionsMenu );
+    const menu = () => wrapper.find( 'TableActionsMenu' );
+    const inst = () => menu().instance();
+    // must open the modal before adding action results
+    inst().displayConfirmDelete();
+    wrapper.update();
+    inst().handleActionResult( actionResult );
+    wrapper.update();
+    expect( inst().state.actionFailures ).toEqual( expect.arrayContaining( [actionResult] ) );
+  } );
+
+  it( 'handleDeleteConfirm refetches teamVideProjects, teamVideoProjectsCount, and calls showConfirmationMsg', async () => {
+    const wrapper = mount( Component );
+    await wait( 0 );
+    wrapper.update();
+
+    const menu = wrapper.find( 'TableActionsMenu' );
     const inst = menu.instance();
-    const deleteProjects = jest.fn();
-    const args = {
-      variables: {
-        where: {
-          AND: [
-            { id_in: [...props.selectedItems.keys()] },
-            { status_in: ['DRAFT'] }
-          ]
-        }
-      },
-      refetchQueries: [{
-        query: TEAM_VIDEO_PROJECTS_QUERY,
-        variables: { ...props.variables }
-      },
-      {
-        query: TEAM_VIDEO_PROJECTS_COUNT_QUERY,
-        variables: {
-          team: props.variables.team,
-          searchTerm: props.variables.searchTerm
-        }
-      }]
-    };
 
-    inst.handleDeleteConfirm( deleteProjects );
+    const teamVideoProjectsRefetch = jest.spyOn( menu.prop( 'teamVideoProjects' ), 'refetch' );
+    const teamVideoProjectsCountRefetch = jest.spyOn( menu.prop( 'teamVideoProjectsCount' ), 'refetch' );
+    const showConfirmationMsg = jest.spyOn( inst, 'showConfirmationMsg' );
 
-    expect( deleteProjects ).toHaveBeenCalledWith( args );
+    inst.handleDeleteConfirm();
+
+    expect( teamVideoProjectsRefetch ).toHaveBeenCalledWith( props.variables );
+    expect( teamVideoProjectsCountRefetch ).toHaveBeenCalledWith( {
+      team: props.variables.team,
+      searchTerm: props.variables.searchTerm
+    } );
+    expect( showConfirmationMsg ).toHaveBeenCalled();
   } );
 
   it( 'handleUnpublish calls unpublish mutate function', async () => {
@@ -297,7 +306,7 @@ describe( '<TableActionsMenu />', () => {
     await wait( 0 );
     wrapper.update();
 
-    const menu = wrapper.find( TableActionsMenu );
+    const menu = wrapper.find( 'TableActionsMenu' );
     const inst = menu.instance();
     const unpublish = jest.fn();
     const args = {
@@ -313,7 +322,6 @@ describe( '<TableActionsMenu />', () => {
     };
 
     inst.handleUnpublish( unpublish );
-
     expect( unpublish ).toHaveBeenCalledWith( args );
   } );
 
@@ -322,7 +330,7 @@ describe( '<TableActionsMenu />', () => {
     await wait( 0 );
     wrapper.update();
 
-    const menu = wrapper.find( TableActionsMenu );
+    const menu = wrapper.find( 'TableActionsMenu' );
     const inst = menu.instance();
     const items = [...props.selectedItems.keys()];
     const projects = [
@@ -331,7 +339,6 @@ describe( '<TableActionsMenu />', () => {
     ];
 
     inst.handleStatus( items, projects );
-
     projects.forEach( project => {
       expect( project.status ).toEqual( 'DRAFT' );
     } );
@@ -342,7 +349,7 @@ describe( '<TableActionsMenu />', () => {
     await wait( 0 );
     wrapper.update();
 
-    const menu = wrapper.find( TableActionsMenu );
+    const menu = wrapper.find( 'TableActionsMenu' );
     const inst = menu.instance();
     const transformed = inst.transformSelectedItemsMap();
 
@@ -356,7 +363,7 @@ describe( '<TableActionsMenu />', () => {
     await wait( 0 );
     wrapper.update();
 
-    const menu = wrapper.find( TableActionsMenu );
+    const menu = wrapper.find( 'TableActionsMenu' );
     const inst = menu.instance();
     const selectedProjectIds = inst.getSelectedProjectsIds();
 
@@ -368,9 +375,9 @@ describe( '<TableActionsMenu />', () => {
     await wait( 0 );
     wrapper.update();
 
-    const menu = wrapper.find( TableActionsMenu );
+    const menu = wrapper.find( 'TableActionsMenu' );
     const inst = menu.instance();
-    const { videoProjects } = mocks[4].result.data;
+    const { videoProjects } = mocks[2].result.data;
     const selectedProjectIds = [...props.selectedItems.keys()];
     const selectedProjects = inst.getSelectedProjects( videoProjects );
 
@@ -385,13 +392,13 @@ describe( '<TableActionsMenu />', () => {
     await wait( 0 );
     wrapper.update();
 
-    const menu = wrapper.find( TableActionsMenu );
+    const menu = wrapper.find( 'TableActionsMenu' );
     const separator = menu.find( '.separator' );
     const unpublishProjects = menu.find( 'UnpublishProjects' );
     const inst = menu.instance();
     const hasSelectedAllDrafts = inst.hasSelectedAllDrafts();
     const selectedProjects = ['ud78', 'ud98'];
-    const { videoProjects } = mocks[4].result.data;
+    const { videoProjects } = mocks[2].result.data;
 
     selectedProjects.forEach( project => {
       expect( findProjectById( videoProjects, project ).status )
@@ -418,13 +425,13 @@ describe( '<TableActionsMenu />', () => {
     await wait( 0 );
     wrapper.update();
 
-    const menu = wrapper.find( TableActionsMenu );
+    const menu = wrapper.find( 'TableActionsMenu' );
     const separator = menu.find( '.separator' );
     const unpublishProjects = menu.find( 'UnpublishProjects' );
     const inst = menu.instance();
     const hasSelectedAllDrafts = inst.hasSelectedAllDrafts();
-    const selectedProjects = inst.state.draftProjects;
-    const { videoProjects } = mocks[4].result.data;
+    const selectedProjects = ['ud23', 'ud74'];
+    const { videoProjects } = mocks[2].result.data;
 
     selectedProjects.forEach( project => {
       expect( findProjectById( videoProjects, project ).status )
@@ -451,12 +458,12 @@ describe( '<TableActionsMenu />', () => {
     await wait( 0 );
     wrapper.update();
 
-    const menu = wrapper.find( TableActionsMenu );
+    const menu = wrapper.find( 'TableActionsMenu' );
     const separator = menu.find( '.separator' );
     const unpublishProjects = menu.find( 'UnpublishProjects' );
     const inst = menu.instance();
     const hasSelectedAllDrafts = inst.hasSelectedAllDrafts();
-    const { videoProjects } = mocks[4].result.data;
+    const { videoProjects } = mocks[2].result.data;
 
     expect( findProjectById( videoProjects, 'ud78' ).status )
       .toEqual( 'PUBLISHED' );
@@ -472,12 +479,12 @@ describe( '<TableActionsMenu />', () => {
     await wait( 0 );
     wrapper.update();
 
-    const menu = wrapper.find( TableActionsMenu );
+    const menu = wrapper.find( 'TableActionsMenu' );
     const inst = menu.instance();
-    const { videoProjects } = mocks[4].result.data;
+    const { videoProjects } = mocks[2].result.data;
     const draftProjects = inst.getDraftProjects( videoProjects );
 
-    expect( draftProjects ).toEqual( inst.state.draftProjects );
+    expect( draftProjects ).toEqual( ['ud23', 'ud74'] );
     draftProjects.forEach( project => {
       expect( findProjectById( videoProjects, project ).status )
         .toEqual( 'DRAFT' );
@@ -489,7 +496,7 @@ describe( '<TableActionsMenu />', () => {
     await wait( 0 );
     wrapper.update();
 
-    const menu = wrapper.find( TableActionsMenu );
+    const menu = wrapper.find( 'TableActionsMenu' );
     const inst = menu.instance();
     const cache = { readQuery: jest.fn() };
     const query = TEAM_VIDEO_PROJECTS_QUERY;
@@ -498,28 +505,6 @@ describe( '<TableActionsMenu />', () => {
     expect( cache.readQuery ).toHaveBeenCalledWith( {
       query,
       variables: { ...props.variables }
-    } );
-  } );
-
-  it( 'handleDrafts sets draftProjects in state', async () => {
-    const wrapper = mount( Component );
-    await wait( 0 );
-    wrapper.update();
-
-    const menu = wrapper.find( TableActionsMenu );
-    const inst = menu.instance();
-    const { videoProjects } = mocks[4].result.data;
-
-    /**
-     * This test also provides evidence that `handleDrafts`
-     * is called on completion of the `Query`. See comment
-     * in the component about React Apollo bug and
-     * `onCompleted`.
-     */
-    expect( inst.state.draftProjects ).toEqual( ['ud23', 'ud74'] );
-    inst.state.draftProjects.forEach( project => {
-      expect( findProjectById( videoProjects, project ).status )
-        .toEqual( 'DRAFT' );
     } );
   } );
 } );

--- a/components/ScrollableTableWithMenu/TableActionsMenu/mocks.js
+++ b/components/ScrollableTableWithMenu/TableActionsMenu/mocks.js
@@ -1,7 +1,5 @@
 import { TEAM_VIDEO_PROJECTS_QUERY } from '../TableBody/TableBody';
 import { TEAM_VIDEO_PROJECTS_COUNT_QUERY } from '../TablePagination/TablePagination';
-import { DELETE_VIDEO_PROJECTS_MUTATION } from './DeleteProjects/DeleteProjects';
-import { UNPUBLISH_VIDEO_PROJECTS_MUTATION } from './UnpublishProjects/UnpublishProjects';
 
 export const props = {
   displayActionsMenu: true,
@@ -17,47 +15,6 @@ export const props = {
 };
 
 export const mocks = [
-  {
-    request: {
-      query: DELETE_VIDEO_PROJECTS_MUTATION,
-      variables: {
-        where: {
-          AND: [
-            { id_in: [...props.selectedItems.keys()] },
-            { status_in: ['DRAFT'] }
-          ]
-        }
-      }
-    },
-    result: {
-      data: {
-        deleteProjects: {
-          count: [...props.selectedItems.keys()].length
-        }
-      }
-    }
-  },
-  {
-    request: {
-      query: UNPUBLISH_VIDEO_PROJECTS_MUTATION,
-      variables: {
-        data: { status: 'DRAFT', visibility: 'INTERNAL' },
-        where: {
-          AND: [
-            { id_in: [...props.selectedItems.keys()] },
-            { status_not: 'DRAFT' }
-          ]
-        }
-      }
-    },
-    result: {
-      data: {
-        unpublish: {
-          count: [...props.selectedItems.keys()].length
-        }
-      }
-    }
-  },
   {
     request: {
       query: TEAM_VIDEO_PROJECTS_COUNT_QUERY,
@@ -296,12 +253,176 @@ export const mocks = [
         ]
       }
     }
+  },
+  {
+    request: {
+      query: TEAM_VIDEO_PROJECTS_QUERY,
+      variables: { ...props.variables }
+    },
+    result: {
+      data: {
+        videoProjects: [
+          {
+            id: 'ud78',
+            createdAt: '2019-05-09T18:33:03.368Z',
+            updatedAt: '2019-05-09T18:33:03.368Z',
+            team: {
+              id: 't888',
+              name: 'IIP Video Production',
+              organization: 'Department of State'
+            },
+            author: {
+              id: 'a928',
+              firstName: 'Jane',
+              lastName: 'Doe'
+            },
+            projectTitle: 'Test Title 1',
+            status: 'PUBLISHED',
+            visibility: 'INTERNAL',
+            thumbnails: {
+              id: 't34',
+              url: 'https://thumbnailurl.com',
+              alt: 'some alt text',
+            },
+            categories: [
+              {
+                id: '38s',
+                translations: [
+                  {
+                    id: '832',
+                    name: 'about america',
+                    language: {
+                      id: 'en23',
+                      locale: 'en-us'
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            id: 'ud98',
+            createdAt: '2019-05-12T18:33:03.368Z',
+            updatedAt: '2019-05-12T18:33:03.368Z',
+            team: {
+              id: 't888',
+              name: 'IIP Video Production',
+              organization: 'Department of State'
+            },
+            author: {
+              id: 'a287',
+              firstName: 'Joe',
+              lastName: 'Schmoe'
+            },
+            projectTitle: 'Test Title 2',
+            status: 'PUBLISHED',
+            visibility: 'INTERNAL',
+            thumbnails: {
+              id: 't34',
+              url: 'https://thumbnailurl.com',
+              alt: 'some alt text',
+            },
+            categories: [
+              {
+                id: '38s',
+                translations: [
+                  {
+                    id: '832',
+                    name: 'about america',
+                    language: {
+                      id: 'en23',
+                      locale: 'en-us'
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            id: 'ud64',
+            createdAt: '2019-05-12T18:33:03.368Z',
+            updatedAt: '2019-05-12T18:33:03.368Z',
+            team: {
+              id: 't888',
+              name: 'IIP Video Production',
+              organization: 'Department of State'
+            },
+            author: {
+              id: 'a287',
+              firstName: 'Joe',
+              lastName: 'Schmoe'
+            },
+            projectTitle: 'Test Title 2',
+            status: 'PUBLISHED',
+            visibility: 'INTERNAL',
+            thumbnails: {
+              id: 't34',
+              url: 'https://thumbnailurl.com',
+              alt: 'some alt text',
+            },
+            categories: [
+              {
+                id: '38s',
+                translations: [
+                  {
+                    id: '832',
+                    name: 'about america',
+                    language: {
+                      id: 'en23',
+                      locale: 'en-us'
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            id: 'ud74',
+            createdAt: '2019-05-12T18:33:03.368Z',
+            updatedAt: '2019-05-12T18:33:03.368Z',
+            team: {
+              id: 't888',
+              name: 'IIP Video Production',
+              organization: 'Department of State'
+            },
+            author: {
+              id: 'a287',
+              firstName: 'Joe',
+              lastName: 'Schmoe'
+            },
+            projectTitle: 'Test Title 2',
+            status: 'DRAFT',
+            visibility: 'INTERNAL',
+            thumbnails: {
+              id: 't34',
+              url: 'https://thumbnailurl.com',
+              alt: 'some alt text',
+            },
+            categories: [
+              {
+                id: '38s',
+                translations: [
+                  {
+                    id: '832',
+                    name: 'about america',
+                    language: {
+                      id: 'en23',
+                      locale: 'en-us'
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    }
   }
 ];
 
 export const errorMocks = [
   {
-    ...mocks[4],
+    ...mocks[2],
     result: {
       errors: [{ message: 'There was an error.' }]
     }
@@ -310,7 +431,7 @@ export const errorMocks = [
 
 export const nullMocks = [
   {
-    ...mocks[4],
+    ...mocks[2],
     result: {
       data: { videoProjects: null }
     }
@@ -319,7 +440,7 @@ export const nullMocks = [
 
 export const emptyMocks = [
   {
-    ...mocks[4],
+    ...mocks[2],
     result: {
       data: { videoProjects: [] }
     }
@@ -328,12 +449,21 @@ export const emptyMocks = [
 
 export const allCheckedMocks = [
   {
-    ...mocks[4],
+    ...mocks[2],
     result: {
       data: {
-        videoProjects: mocks[4].result.data.videoProjects
+        videoProjects: mocks[2].result.data.videoProjects
           .filter( project => project.id === 'ud78' || project.id === 'ud98' )
       }
     }
   }
 ];
+
+export const actionResult = {
+  error: 'Error message',
+  action: 'delete',
+  project: {
+    id: '123abc',
+    projectTitle: 'Title'
+  }
+};

--- a/components/errors/ApolloError.js
+++ b/components/errors/ApolloError.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { getApolloErrors } from 'lib/utils';
 
 
 const ApolloError = props => {
@@ -15,17 +16,7 @@ const ApolloError = props => {
 
     let errs = [];
     if ( error ) {
-      const { graphQLErrors, networkError, otherError } = error;
-      if ( graphQLErrors ) {
-        errs = graphQLErrors.map( error => error.message );
-      }
-      if ( networkError ) {
-        errs.push( networkError );
-      }
-
-      if ( otherError ) {
-        errs.push( otherError );
-      }
+      errs = getApolloErrors( error );
     }
 
     if ( errs[0] === 'This token is either invalid or expired!' ) {

--- a/lib/graphql/queries/video.js
+++ b/lib/graphql/queries/video.js
@@ -213,6 +213,14 @@ export const DELETE_VIDEO_PROJECT_MUTATION = gql`
   }
 `;
 
+export const DELETE_VIDEO_PROJECTS_MUTATION = gql`
+  mutation DeleteManyVideoProjects($where: VideoProjectWhereInput) {
+    deleteProjects: deleteManyVideoProjects(where: $where) {
+      count
+    }
+  }
+`;
+
 export const UPDATE_VIDEO_UNIT_MUTATION = gql`
   mutation UPDATE_VIDEO_UNIT_MUTATION(
     $data: VideoUnitUpdateInput!

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -377,3 +377,19 @@ export const getVideoDownloadLink = ( url, filename ) => {
   const fullUrl = maybeGetUrlToProdS3( url );
   return `${endpoint}/${btoa( unescape( encodeURIComponent( fullUrl ) ) )}/${filename}`;
 };
+
+export const getApolloErrors = error => {
+  let errs = [];
+  const { graphQLErrors, networkError, otherError } = error;
+  if ( graphQLErrors ) {
+    errs = graphQLErrors.map( error => error.message );
+  }
+  if ( networkError ) {
+    errs.push( networkError );
+  }
+
+  if ( otherError ) {
+    errs.push( otherError );
+  }
+  return errs;
+};


### PR DESCRIPTION
Modified DeleteProjects to use an HOC mutation instead of the Mutation component.
Added a delete function to DeleteProjects that deletes each project individually returning the results in a promise.
Modified TableActionsMenu to use HOC queries instead of Query component for more control. This also allows the calling of data.refetch
Added ActionResults components for handling success or error lists from a delete/unpublish action.
Extracted the error parsing function from ApolloError so that it can be used in the ActionResultError component.

Tests will need to be updated and have been left unmodified.