### PR TITLE
CDP-1520: Update TableBody Tests for Status Subscription

### DIFF
--- a/components/ScrollableTableWithMenu/TableBody/TableBody.js
+++ b/components/ScrollableTableWithMenu/TableBody/TableBody.js
@@ -255,6 +255,18 @@ TableBody.propTypes = {
   subscribeToStatuses: PropTypes.func
 };
 
+const updateProjectStatus = ( prev, { subscriptionData: { data: { projectStatusChange } } } ) => {
+  if ( !projectStatusChange ) {
+    return prev;
+  }
+  const projectIndex = prev.videoProjects.findIndex( p => p.id === projectStatusChange.id );
+  if ( projectIndex === -1 ) {
+    return prev;
+  }
+  // Using immutability helper in order to ensure that React will rerender after the status change
+  return update( prev, { videoProjects: { [projectIndex]: { status: { $set: projectStatusChange.status } } } } );
+};
+
 const teamProjectsQuery = graphql( TEAM_VIDEO_PROJECTS_QUERY, {
   name: 'teamVideoProjects',
   props: ( { teamVideoProjects } ) => {
@@ -266,17 +278,7 @@ const teamProjectsQuery = graphql( TEAM_VIDEO_PROJECTS_QUERY, {
       subscribeToStatuses: () => subscribeToMore( {
         document: PROJECT_STATUS_CHANGE_SUBSCRIPTION,
         variables: { ids: videoProjectIds },
-        updateQuery: ( prev, { subscriptionData: { data: { projectStatusChange } } } ) => {
-          if ( !projectStatusChange ) {
-            return prev;
-          }
-          const projectIndex = prev.videoProjects.findIndex( p => p.id === projectStatusChange.id );
-          if ( projectIndex === -1 ) {
-            return prev;
-          }
-          // Using immutability helper in order to ensure that React will rerender after the status change
-          return update( prev, { videoProjects: { [projectIndex]: { status: { $set: projectStatusChange.status } } } } );
-        }
+        updateQuery: updateProjectStatus
       } )
     };
   },
@@ -288,4 +290,7 @@ const teamProjectsQuery = graphql( TEAM_VIDEO_PROJECTS_QUERY, {
 } );
 
 export default teamProjectsQuery( TableBody );
-export { TEAM_VIDEO_PROJECTS_QUERY };
+const TableBodyRaw = TableBody;
+export {
+  TEAM_VIDEO_PROJECTS_QUERY, updateProjectStatus, teamProjectsQuery, TableBodyRaw
+};

--- a/components/ScrollableTableWithMenu/TableBody/TableBody.test.js
+++ b/components/ScrollableTableWithMenu/TableBody/TableBody.test.js
@@ -238,23 +238,24 @@ describe( '<TableBody />', () => {
     it( 'updates the correct project', () => {
       const subscriptionData = { ...mocks[1].result };
       const result = updateProjectStatus( { videoProjects }, { subscriptionData } );
-      const expected = { videoProjects: [{ ...videoProjects[0], status: 'DRAFT' }, { ...videoProjects[1] }] };
-      expect( result ).toEqual( expected );
+      expect( videoProjects[0].status ).toEqual( 'PUBLISHED' );
+      expect( result.videoProjects[0].status ).toEqual( 'DRAFT' );
+      expect( videoProjects[0].id ).toEqual( result.videoProjects[0].id );
     } );
 
     it( 'does not update anything for null data', () => {
       const subscriptionData = { data: { projectStatusChange: null } };
-      const result = updateProjectStatus( { videoProjects }, { subscriptionData } );
-      const expected = { videoProjects };
-      expect( result ).toEqual( expected );
+      const prev = { videoProjects };
+      const result = updateProjectStatus( prev, { subscriptionData } );
+      expect( result ).toEqual( prev );
     } );
 
     it( 'does not update anything for a non existent project ID', () => {
       const subscriptionData = { ...mocks[1].result };
       subscriptionData.data.projectStatusChange.id = 'xxxx';
-      const result = updateProjectStatus( { videoProjects }, { subscriptionData } );
-      const expected = { videoProjects };
-      expect( result ).toEqual( expected );
+      const prev = { videoProjects };
+      const result = updateProjectStatus( prev, { subscriptionData } );
+      expect( result ).toEqual( prev );
     } );
   } );
 } );

--- a/components/ScrollableTableWithMenu/TableBody/mocks.js
+++ b/components/ScrollableTableWithMenu/TableBody/mocks.js
@@ -1,0 +1,120 @@
+import { TEAM_VIDEO_PROJECTS_QUERY } from 'components/ScrollableTableWithMenu/TableBody/TableBody';
+import { PROJECT_STATUS_CHANGE_SUBSCRIPTION } from 'lib/graphql/queries/common';
+
+export const videoProjects = [
+  {
+    id: 'd137',
+    createdAt: '2019-05-09T18:33:03.368Z',
+    updatedAt: '2019-05-09T18:33:03.368Z',
+    team: {
+      id: 't888',
+      name: 'IIP Video Production',
+      organization: 'Department of State'
+    },
+    author: {
+      id: 'a928',
+      firstName: 'Jane',
+      lastName: 'Doe'
+    },
+    projectTitle: 'Test Title 1',
+    status: 'PUBLISHED',
+    visibility: 'INTERNAL',
+    thumbnails: {
+      id: 't34',
+      url: 'https://thumbnailurl.com',
+      signedUrl: 'https://thumbnailurl.com',
+      alt: 'some alt text',
+    },
+    categories: [
+      {
+        id: '38s',
+        translations: [
+          {
+            id: '832',
+            name: 'about america',
+            language: {
+              id: 'en23',
+              locale: 'en-us'
+            }
+          }
+        ]
+      }
+    ]
+  },
+  {
+    id: 'z132',
+    createdAt: '2019-05-12T18:33:03.368Z',
+    updatedAt: '2019-05-12T18:33:03.368Z',
+    team: {
+      id: 't888',
+      name: 'IIP Video Production',
+      organization: 'Department of State'
+    },
+    author: {
+      id: 'a287',
+      firstName: 'Joe',
+      lastName: 'Schmoe'
+    },
+    projectTitle: 'Test Title 2',
+    status: 'PUBLISHED',
+    visibility: 'INTERNAL',
+    thumbnails: {
+      id: 't34',
+      url: 'https://thumbnailurl.com',
+      signedUrl: 'https://thumbnailurl.com',
+      alt: 'some alt text',
+    },
+    categories: [
+      {
+        id: '38s',
+        translations: [
+          {
+            id: '832',
+            name: 'about america',
+            language: {
+              id: 'en23',
+              locale: 'en-us'
+            }
+          }
+        ]
+      }
+    ]
+  }
+];
+
+export const videoProjectIds = videoProjects.map( p => p.id );
+
+export const propVariables = {
+  team: 'IIP Video Production',
+  searchTerm: '',
+  first: 4,
+  skip: 0
+};
+
+export const mocks = [
+  {
+    request: {
+      query: TEAM_VIDEO_PROJECTS_QUERY,
+      variables: { ...propVariables }
+    },
+    result: {
+      data: { videoProjects },
+      subscribeToStatuses: jest.fn()
+    }
+  },
+  {
+    request: {
+      query: PROJECT_STATUS_CHANGE_SUBSCRIPTION,
+      variables: { ids: videoProjectIds }
+    },
+    result: {
+      data: {
+        projectStatusChange: {
+          id: 'd137',
+          status: 'DRAFT',
+          error: null
+        }
+      }
+    }
+  }
+];


### PR DESCRIPTION
Restructured TableBody so that the graphql HOC and TableBody component
can be exported independently allowing HOC props to be tested
Added test to check that subscribeToStatuses is called
Added tests for the updateProjectStatus function which runs when
subscription data is received