### PR TITLE
CDP-1614 - Redirect to dashboard if id is not present

### DIFF
--- a/pages/_error.js
+++ b/pages/_error.js
@@ -1,12 +1,28 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { withRouter } from 'next/router';
+import { redirectTo } from 'lib/browser';
 import NotFound404 from 'components/errors/NotFound404/NotFound404';
 
 class Error extends React.Component {
-  static getInitialProps( { res, err } ) {
+  static getInitialProps( { res, err, asPath } ) {
     // eslint-disable-next-line  no-nested-ternary
     const statusCode = res ? res.statusCode : err ? err.statusCode : null;
+
+    /**
+     * Addresses a longstanding Next bug (since v5, at least)
+     * where a trailing slash, (e.g., `/admin/package/`) results
+     * in 404. This is workaround until the bug is fixed.
+     * @see https://github.com/zeit/next.js/issues/5214#issuecomment-564724632
+     * @see https://github.com/zeit/next.js/pull/6421
+     */
+    if ( statusCode && statusCode === 404 ) {
+      if ( asPath.match( /\/$/ ) ) {
+        const withoutTrailingSlash = asPath.substr( 0, asPath.length - 1 );
+        redirectTo( withoutTrailingSlash, { res } );
+      }
+    }
+
     return { statusCode };
   }
 

--- a/pages/admin/package/index.js
+++ b/pages/admin/package/index.js
@@ -1,0 +1,33 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { redirectTo } from 'lib/browser';
+import { withRouter } from 'next/router';
+import isEmpty from 'lodash/isEmpty';
+
+const PackagePageIndex = props => {
+  // Handles client side route checking
+  const isValidPath = query => query && query.id;
+
+  if ( !isValidPath( props.query ) ) {
+    props.router.push( '/admin/dashboard' );
+  }
+
+  return <div />;
+};
+
+PackagePageIndex.getInitialProps = async ( { query, res } ) => {
+  // Send to dashboard if the query is not present
+  // Handles server side route checking
+  if ( isEmpty( query ) || !query.id ) {
+    redirectTo( '/admin/dashboard', { res } );
+  }
+
+  return {};
+};
+
+PackagePageIndex.propTypes = {
+  query: PropTypes.object,
+  router: PropTypes.object
+};
+
+export default withRouter( PackagePageIndex );

--- a/pages/admin/package/index.test.js
+++ b/pages/admin/package/index.test.js
@@ -1,0 +1,66 @@
+import { mount } from 'enzyme';
+import PackagePageIndex from './index';
+
+const props = {
+  query: { id: 'ck181818' },
+  router: { push: jest.fn() }
+};
+
+const Component = <PackagePageIndex { ...props } />;
+
+describe( '<PackagePageIndex />', () => {
+  it( 'renders without crashing', () => {
+    const wrapper = mount( Component );
+
+    expect( wrapper.exists() ).toEqual( true );
+  } );
+
+  it( 'redirects to the dashboard if there is no id', () => {
+    const wrapper = mount( Component );
+    wrapper.setProps( { query: {} } );
+
+    expect( props.router.push ).toHaveBeenCalledWith( '/admin/dashboard' );
+  } );
+
+  it( 'getInitialProps does not call res.writeHead and res.end if a query.id exists', async done => {
+    const wrapper = mount( Component );
+    const args = {
+      query: props.query,
+      res: {
+        writeHead: jest.fn(),
+        end: jest.fn()
+      }
+    };
+
+    const ret = await PackagePageIndex.getInitialProps( args );
+
+    expect( wrapper.prop( 'query' ).id ).toEqual( props.query.id );
+    expect( ret ).toEqual( {} );
+    expect( args.res.writeHead ).not.toHaveBeenCalled();
+    expect( args.res.end ).not.toHaveBeenCalled();
+    done();
+  } );
+
+  it( 'getInitialProps calls res.writeHead and res.end if a !query.id', async done => {
+    const wrapper = mount( Component );
+    wrapper.setProps( { query: {} } );
+
+    const args = {
+      query: wrapper.prop( 'query' ),
+      res: {
+        writeHead: jest.fn(),
+        end: jest.fn()
+      }
+    };
+
+    const ret = await PackagePageIndex.getInitialProps( args );
+
+    expect( wrapper.prop( 'query' ).id ).toEqual( undefined );
+    expect( ret ).toEqual( {} );
+    expect( args.res.writeHead ).toHaveBeenCalledWith( 302, {
+      Location: '/admin/dashboard'
+    } );
+    expect( args.res.end ).toHaveBeenCalled();
+    done();
+  } );
+} );


### PR DESCRIPTION
* Redirects to dashboard if !query.id
* Addresses Next.js trailing slash bug
* Adds test for `/package/index.js `
* Note: Redirect occurs on `/package/index.js` since the `[id].js` page is not loaded if there is no query.id. Without query.id, Next loads the `/package` route and `/package/` is redirected to `/package` instead of receiving a 404 (i.e., the Next trailing slash bug)