### PR TITLE
HOT FIX - Constrain visibility options to public only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+# [3.1.3](2020-03-20)
+
+**Fixed:**
+
+- Hid internal-only visibility option for videos until that view is made available.
+
 # [3.1.3](2020-02-11)
 
 **Fixed:**

--- a/components/admin/dropdowns/VisibilityDropdown/VisibilityDropdown.js
+++ b/components/admin/dropdowns/VisibilityDropdown/VisibilityDropdown.js
@@ -22,22 +22,27 @@ const VisibilityDropdown = props => (
     { ( { data, loading, error } ) => {
       if ( error ) return `Error! ${error.message}`;
 
-      let options = [];
+      const options = [{
+        key: 'PUBLIC',
+        text: 'Public (displayed on Content Commons)',
+        value: 'PUBLIC'
+      }];
 
-      if ( data && data.__type && data.__type.enumValues ) {
-        options = data.__type.enumValues
-          .map( enumValue => {
-            const text = enumValue.name === 'PUBLIC'
-              ? 'Public (displayed on Content Commons)'
-              : 'Internal (Department of State only)';
+      // Commenting out for now since Internal only view is not yet enabled.
+      // if ( data && data.__type && data.__type.enumValues ) {
+      //   options = data.__type.enumValues
+      //     .map( enumValue => {
+      //       const text = enumValue.name === 'PUBLIC'
+      //         ? 'Public (displayed on Content Commons)'
+      //         : 'Internal (Department of State only)';
 
-            return {
-              key: enumValue.name,
-              text,
-              value: enumValue.name
-            };
-          } );
-      }
+      //       return {
+      //         key: enumValue.name,
+      //         text,
+      //         value: enumValue.name
+      //       };
+      //     } );
+      // }
 
       return (
         <Fragment>


### PR DESCRIPTION
Only allows users to mark video projects as for public use, since the internal only option is not yet ready.

Rather than iterating over the results from the visibility query, I hardcode in one option, namely:

```js
{
  key: 'PUBLIC',
  text: 'Public (displayed on Content Commons)',
  value: 'PUBLIC'
}
```

I've left the query in place and simply commented out the mapping over it's results to facilitate reintroducing this feature when we are ready. 