### PR TITLE
Package Details Page Validation Issues

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -115,7 +115,16 @@
   },
   "settings": {
     "import/resolver": {
-      "babel-module": {}
+      "babel-module": {
+        "alias": {
+          "components": "./components",
+          "context": "./context",
+          "hocs": "./hocs",
+          "lib": "./lib",
+          "static": "./static",
+          "styles": "./styles"
+        }
+      }
     }
   }
 }

--- a/components/admin/PackageEdit/PackageDetailsFormContainer/PackageDetailsForm/PackageDetailsForm.js
+++ b/components/admin/PackageEdit/PackageDetailsFormContainer/PackageDetailsForm/PackageDetailsForm.js
@@ -13,6 +13,7 @@ import ButtonAddFiles from 'components/ButtonAddFiles/ButtonAddFiles';
 import TermsConditions from 'components/admin/TermsConditions/TermsConditions';
 import EditPackageFiles from 'components/admin/PackageEdit/EditPackageFilesModal/EditPackageFilesModal';
 import { useCrudActionsDocument } from 'lib/hooks/useCrudActionsDocument';
+
 import './PackageDetailsForm.scss';
 
 export const HandleOnChangeContext = createContext();
@@ -26,12 +27,9 @@ const PackageDetailsForm = props => {
     handleChange,
     hasInitialUploadCompleted,
     setFieldValue,
-    // isSubmitting,
-    // isValid,
     setFieldTouched,
-    // status,
     save,
-    pkg
+    pkg,
   } = props;
 
   const router = useRouter();
@@ -215,19 +213,14 @@ const PackageDetailsForm = props => {
 };
 
 PackageDetailsForm.propTypes = {
-  // id: PropTypes.string,
-  // assetPath: PropTypes.string,
   pkg: PropTypes.object,
   children: PropTypes.node,
-  // status: PropTypes.string,
   handleChange: PropTypes.func,
   hasInitialUploadCompleted: PropTypes.bool,
   values: PropTypes.object,
   errors: PropTypes.object,
   touched: PropTypes.object,
   setFieldValue: PropTypes.func,
-  // isSubmitting: PropTypes.bool,
-  // isValid: PropTypes.bool,
   setFieldTouched: PropTypes.func,
   save: PropTypes.func
 };

--- a/components/admin/PackageEdit/PackageDetailsFormContainer/PackageDetailsFormContainer.js
+++ b/components/admin/PackageEdit/PackageDetailsFormContainer/PackageDetailsFormContainer.js
@@ -147,7 +147,7 @@ const PackageDetailsFormContainer = props => {
   return (
     <Formik
       initialValues={ getInitialValues() }
-      validationSchema={ props.id ? baseSchema : initialSchema }
+      validationSchema={ pkg.id ? baseSchema : initialSchema }
     >
       { renderContent }
     </Formik>

--- a/components/admin/PackageEdit/PackageDetailsFormContainer/PackageDetailsFormContainer.js
+++ b/components/admin/PackageEdit/PackageDetailsFormContainer/PackageDetailsFormContainer.js
@@ -147,7 +147,6 @@ const PackageDetailsFormContainer = props => {
   return (
     <Formik
       initialValues={ getInitialValues() }
-      enableReinitialize // allow form to re initialize on document upload
       validationSchema={ props.id ? baseSchema : initialSchema }
     >
       { renderContent }

--- a/components/admin/PackageEdit/PackageDetailsFormContainer/PackageDetailsFormContainer.js
+++ b/components/admin/PackageEdit/PackageDetailsFormContainer/PackageDetailsFormContainer.js
@@ -15,7 +15,7 @@ import PackageDetailsForm from './PackageDetailsForm/PackageDetailsForm';
 import { initialSchema, baseSchema } from './validationSchema';
 
 const PackageDetailsFormContainer = props => {
-  const { pkg } = props;
+  const { pkg, setIsFormValid } = props;
   const [updatePackage] = useMutation( UPDATE_PACKAGE_MUTATION );
   const [showNotification, setShowNotification] = useState( false );
   const hideNotification = () => setShowNotification( false );
@@ -121,28 +121,31 @@ const PackageDetailsFormContainer = props => {
     return initialValues;
   };
 
-  const renderContent = formikProps => (
-    <div className="edit-package__form">
-      <Notification
-        el="p"
-        customStyles={ {
-          position: 'absolute',
-          top: '9em',
-          left: '50%',
-          transform: 'translateX(-50%)'
-        } }
-        show={ showNotification }
-        msg="Changes saved"
-      />
-      <PackageDetailsForm
-        { ...formikProps }
-        { ...props }
-        save={ save }
-      >
-        { props.children }
-      </PackageDetailsForm>
-    </div>
-  );
+  const renderContent = formikProps => {
+    setIsFormValid( formikProps.isValid );
+    return (
+      <div className="edit-package__form">
+        <Notification
+          el="p"
+          customStyles={ {
+            position: 'absolute',
+            top: '9em',
+            left: '50%',
+            transform: 'translateX(-50%)'
+          } }
+          show={ showNotification }
+          msg="Changes saved"
+        />
+        <PackageDetailsForm
+          { ...formikProps }
+          { ...props }
+          save={ save }
+        >
+          { props.children }
+        </PackageDetailsForm>
+      </div>
+    );
+  };
 
   return (
     <Formik
@@ -162,7 +165,8 @@ PackageDetailsFormContainer.propTypes = {
     title: PropTypes.string,
     type: PropTypes.string,
     documents: PropTypes.array
-  } )
+  } ),
+  setIsFormValid: PropTypes.func
 };
 
 export default PackageDetailsFormContainer;

--- a/components/admin/PackageEdit/PackageEdit.js
+++ b/components/admin/PackageEdit/PackageEdit.js
@@ -48,6 +48,7 @@ const PackageEdit = props => {
   const [publishOperation, setPublishOperation] = useState( '' );
   const [deleteConfirmOpen, setDeleteConfirmOpen] = useState( false );
   const [hasInitialUploadCompleted, setHasInitialUploadCompleted] = useState( false );
+  const [isFormValid, setIsFormValid] = useState( true );
 
   const [notification, setNotification] = useState( {
     notificationMessage: '',
@@ -181,7 +182,7 @@ const PackageEdit = props => {
             setDeleteConfirmOpen={ setDeleteConfirmOpen }
             disabled={ {
               delete: deletePackageEnabled(),
-              save: !packageId,
+              save: !packageId || !isFormValid,
               publish: !packageId
             } }
             handle={ {
@@ -222,6 +223,7 @@ const PackageEdit = props => {
         pkg={ pkg }
         updateNotification={ updateNotification }
         hasInitialUploadCompleted={ hasInitialUploadCompleted }
+        setIsFormValid={ setIsFormValid }
       >
         <PackageFiles pkg={ pkg } hasInitialUploadCompleted={ hasInitialUploadCompleted } />
       </PackageDetailsFormContainer>


### PR DESCRIPTION
**CDP-1746 -** Disables re-initalization in the Formik component in `PackageDetailsFormContainer.js` to prevent unnecessary re-renders. @edwinmah - This takes care of the ticket you were assigned earlier today.

**CDP-1639 & CDP-1747 -** Use `pkg.id` to determine whether the form is new or existing, and therefore apply the correct validation schema  in the Formik component in the `PackageDetailsFormContainer.js`. Previously was using the non-existent `props.id` and therefore always loading the validation schema for a new form.

**CDP-1734 -** Replace an old Formik form validation method in the FormikAutoSave component so that autosave only fires when the form is valid. Also disable the `Save & Exit` action button when the form does not pass validation. If this were not disabled, clicking this button would not save invalid field values, but it would take the user back to the projects list view implying the changes were accepted. I would also discard any valid updates to other fields after the form was rendered invalid. It seems more prudent to prevent the user from attempting to save if the form is at all invalid. @shawnmath - This should help address your ticket CDP-1661

**Additional Changes -**
- Clean out `PackageDetailsForm.js` by removing un-used commented out props and their props validations.
- Added the module aliases to the `.eslintrc` to avoid `cannot find module` import linting error for aliased imports (i.e. `import MyComp from 'components/MyComp'` rather than `import MyComp from '../../components/MyComp'`).