### PR TITLE
Reinitialization

### DIFF
--- a/components/admin/PackageEdit/PackageDetailsFormContainer/PackageDetailsFormContainer.js
+++ b/components/admin/PackageEdit/PackageDetailsFormContainer/PackageDetailsFormContainer.js
@@ -3,7 +3,7 @@
  * PackageDetailsFormContainer
  *
  */
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { useMutation } from '@apollo/react-hooks';
 import { Formik } from 'formik';
@@ -16,6 +16,19 @@ import { initialSchema, baseSchema } from './validationSchema';
 
 const PackageDetailsFormContainer = props => {
   const { pkg, setIsFormValid } = props;
+
+  const [docNumber, setDocNumber] = useState( pkg?.documents ? pkg.documents.length : null );
+  const [reinitialize, setReinitialize] = useState( false );
+
+  useEffect( () => {
+    if ( pkg?.documents && pkg.documents.length !== docNumber ) {
+      setReinitialize( true );
+      setDocNumber( pkg.documents.length );
+    } else {
+      setReinitialize( false );
+    }
+  }, [pkg] );
+
   const [updatePackage] = useMutation( UPDATE_PACKAGE_MUTATION );
   const [showNotification, setShowNotification] = useState( false );
   const hideNotification = () => setShowNotification( false );
@@ -150,6 +163,7 @@ const PackageDetailsFormContainer = props => {
   return (
     <Formik
       initialValues={ getInitialValues() }
+      enableReinitialize={ reinitialize }
       validationSchema={ pkg.id ? baseSchema : initialSchema }
     >
       { renderContent }

--- a/components/admin/ProjectDetailsForm/ProjectDetailsForm.js
+++ b/components/admin/ProjectDetailsForm/ProjectDetailsForm.js
@@ -12,7 +12,6 @@ import {
   Input,
   TextArea
 } from 'semantic-ui-react';
-import Link from 'next/link';
 import VisibilityDropdown from 'components/admin/dropdowns/VisibilityDropdown/VisibilityDropdown';
 import CategoryDropdown from 'components/admin/dropdowns/CategoryDropdown/CategoryDropdown';
 import UserDropdown from 'components/admin/dropdowns/UserDropdown/UserDropdown';


### PR DESCRIPTION
**CDP-1746 -** Previous fix removing `enableReinitialization` prop prevented data from newly uploaded documents from appearing. This modification tests for newly added documents, and if present conditionally enables reinitialization.

**Additional Changes -** Removes unused imported module in `ProjectDetailsForm.js`.