### PR TITLE
HOT FIX - Add coronavirus priorities section to the homepage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+# [3.1.5](2020-03-25)
+
+**Added:**
+
+- Coronavirus (COVID-19) priorities section to homepage
+
 # [3.1.4](2020-03-20)
 
 **Fixed:**
@@ -21,7 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 **Added:**
 
-- Venezuela priorities section to Home
+- Venezuela priorities section to homepage
 
 **Fixed:**
 

--- a/pages/index.js
+++ b/pages/index.js
@@ -12,6 +12,17 @@ const featuredData = [
     component: 'priorities',
     order: 1,
     props: {
+      term: 'coronavirus covid',
+      label: 'Coronavirus (COVID-19)',
+      categories: [],
+      locale: 'en-us'
+    }
+  },
+  {
+    key: v4(),
+    component: 'priorities',
+    order: 2,
+    props: {
       term: 'iran',
       label: 'Iran',
       categories: [
@@ -25,7 +36,7 @@ const featuredData = [
   {
     key: v4(),
     component: 'priorities',
-    order: 2,
+    order: 3,
     props: {
       term: '5G',
       label: '5G',
@@ -36,7 +47,7 @@ const featuredData = [
   {
     key: v4(),
     component: 'priorities',
-    order: 3,
+    order: 4,
     props: {
       term: 'venezuela',
       label: 'Venezuela',
@@ -51,7 +62,7 @@ const featuredData = [
   {
     key: v4(),
     component: 'recents',
-    order: 4,
+    order: 5,
     props: {
       postType: 'video',
       locale: 'en-us'
@@ -60,7 +71,7 @@ const featuredData = [
   {
     key: v4(),
     component: 'recents',
-    order: 5,
+    order: 6,
     props: {
       postType: 'post',
       locale: 'en-us'


### PR DESCRIPTION
Adds a Department priorities box to the homepage using the search term `coronavirus covid`. Bumps all remaining boxes down one.