### PR TITLE
CDP-1785: Crop long excerpts displayed on DocumentCards

### DIFF
--- a/components/ContentHeightClamp/ContentHeightClamp.js
+++ b/components/ContentHeightClamp/ContentHeightClamp.js
@@ -7,6 +7,7 @@ const ContentHeightClamp = props => {
     children, className, el: Element, maxHeight, style
   } = props;
   const [height, setHeight] = useState( 0 );
+  const isLong = height > maxHeight;
 
   const ref = useCallback( node => {
     if ( node !== null ) {
@@ -17,8 +18,10 @@ const ContentHeightClamp = props => {
   return (
     <Element
       ref={ ref }
-      className={ `height-clamp ${className} ${height > maxHeight ? 'clamped' : 'unclamped'}` }
+      className={ `height-clamp ${className} ${isLong ? 'clamped' : 'unclamped'}` }
       style={ style }
+      // allow scrolling for kbd only users if isLong
+      { ...( isLong ? { tabIndex: 0 } : {} ) }
     >
       { children }
     </Element>

--- a/components/ContentHeightClamp/ContentHeightClamp.js
+++ b/components/ContentHeightClamp/ContentHeightClamp.js
@@ -1,0 +1,42 @@
+import React, { useCallback, useState } from 'react';
+import PropTypes from 'prop-types';
+import './ContentHeightClamp.scss';
+
+const ContentHeightClamp = props => {
+  const {
+    children, className, el: Element, maxHeight, style
+  } = props;
+  const [height, setHeight] = useState( 0 );
+
+  const ref = useCallback( node => {
+    if ( node !== null ) {
+      setHeight( node.getBoundingClientRect().height );
+    }
+  }, [] );
+
+  return (
+    <Element
+      ref={ ref }
+      className={ `height-clamp ${className} ${height > maxHeight ? 'clamped' : 'unclamped'}` }
+      style={ style }
+    >
+      { children }
+    </Element>
+  );
+};
+
+ContentHeightClamp.defaultProps = {
+  el: 'div',
+  maxHeight: 144,
+  style: {}
+};
+
+ContentHeightClamp.propTypes = {
+  children: PropTypes.node,
+  className: PropTypes.string,
+  el: PropTypes.string,
+  maxHeight: PropTypes.number,
+  style: PropTypes.object
+};
+
+export default ContentHeightClamp;

--- a/components/ContentHeightClamp/ContentHeightClamp.scss
+++ b/components/ContentHeightClamp/ContentHeightClamp.scss
@@ -1,3 +1,5 @@
+@import 'styles/colors.scss';
+
 .height-clamp {
   &.clamped {
     position: relative;
@@ -25,6 +27,11 @@
         rgba(255, 255, 255, 0) 0%,
         rgba(255, 255, 255, 1) 90%
       );
+    }
+
+    &:focus {
+      outline: 2px dotted $medium-grey; 
+      outline-offset: 2px;
     }
   }
 }

--- a/components/ContentHeightClamp/ContentHeightClamp.scss
+++ b/components/ContentHeightClamp/ContentHeightClamp.scss
@@ -1,0 +1,30 @@
+.height-clamp {
+  &.clamped {
+    position: relative;
+    max-height: 8rem;
+    overflow-y: auto;
+    -ms-overflow-style: none;
+    scrollbar-width: none; /* Firefox */
+    cursor: all-scroll;
+
+    /* Chrome, Safari */
+    &::-webkit-scrollbar {
+      display: none;
+      width: 0;
+      background: transparent;
+    }
+
+    &::after {
+      position: sticky; 
+      bottom: 0;
+      content: '';
+      display: block;
+      width: 100%;
+      height: 4rem;
+      background-image: linear-gradient(
+        rgba(255, 255, 255, 0) 0%,
+        rgba(255, 255, 255, 1) 90%
+      );
+    }
+  }
+}

--- a/components/ContentHeightClamp/ContentHeightClamp.test.js
+++ b/components/ContentHeightClamp/ContentHeightClamp.test.js
@@ -1,0 +1,57 @@
+import { mount } from 'enzyme';
+import ContentHeightClamp from './ContentHeightClamp';
+
+const props = {
+  children: <p>child node</p>,
+  className: 'excerpt'
+};
+
+describe( '<ContentHeightClamp />', () => {
+  let Component;
+  let wrapper;
+
+  beforeEach( () => {
+    Component = <ContentHeightClamp { ...props } />;
+    wrapper = mount( Component );
+  } );
+
+  it( 'renders without crashing', () => {
+    expect( wrapper.exists() ).toEqual( true );
+  } );
+
+  it( 'has the correct props', () => {
+    expect( wrapper.props() ).toEqual( {
+      ...props,
+      el: 'div',
+      maxHeight: 144,
+      style: {}
+    } );
+  } );
+
+  it( 'renders children', () => {
+    expect( wrapper.children().length ).toEqual( 1 );
+    expect( wrapper.contains( props.children ) ).toEqual( true );
+  } );
+
+  it( 'renders the correct className values if < props.maxHeight', () => {
+    const div = wrapper.find( 'div' );
+
+    // jsdom doesn't do rendering, so height will always be 0
+    expect( div.hasClass( 'height-clamp' ) ).toEqual( true );
+    expect( div.hasClass( props.className ) ).toEqual( true );
+    expect( div.hasClass( 'unclamped' ) ).toEqual( true );
+    expect( div.hasClass( 'clamped' ) ).toEqual( false );
+  } );
+
+  it.skip( 'renders the correct className values if > props.maxHeight - TBD', () => {
+    const div = wrapper.find( 'div' );
+    // jsdom doesn't do rendering, so height will always be 0
+    // div.getBoundingClientRect = jest.fn( () => ( { height: 200 } ) );
+    // console.log( div.getBoundingClientRect() );
+    // expect( document.documentElement.clientHeight ).toEqual( 200 );
+    expect( div.hasClass( 'height-clamp' ) ).toEqual( true );
+    expect( div.hasClass( props.className ) ).toEqual( true );
+    expect( div.hasClass( 'unclamped' ) ).toEqual( false );
+    expect( div.hasClass( 'clamped' ) ).toEqual( true );
+  } );
+} );

--- a/components/Document/DocumentCard/DocumentCard.js
+++ b/components/Document/DocumentCard/DocumentCard.js
@@ -47,8 +47,9 @@ const DocumentCard = props => {
   } );
 
   const setLangAttr = () => {
-    if ( language.languageCode ) return language.languageCode;
-    if ( language.language_code ) return language.language_code;
+    if ( language?.languageCode ) return language.languageCode;
+    // eslint-disable-next-line
+    if ( language?.language_code ) return language.language_code;
     return 'en';
   };
 

--- a/components/Document/DocumentCard/DocumentCard.js
+++ b/components/Document/DocumentCard/DocumentCard.js
@@ -1,4 +1,4 @@
-import React, { Fragment, useState } from 'react';
+import React, { Fragment, useCallback, useState } from 'react';
 import PropTypes from 'prop-types';
 import { Modal, Card } from 'semantic-ui-react';
 import ReactMarkdown from 'react-markdown';
@@ -22,6 +22,13 @@ import './DocumentCard.scss';
 const DocumentCard = props => {
   const { isAdminPreview, file: doc } = props;
   const [isOpen, setIsOpen] = useState( false );
+  const [excerptHeight, setExcerptHeight] = useState( 0 );
+
+  const excerptRef = useCallback( node => {
+    if ( node !== null ) {
+      setExcerptHeight( node.getBoundingClientRect().height );
+    }
+  }, [] );
 
   if ( !doc || !getCount( doc ) ) return null;
 
@@ -105,12 +112,13 @@ const DocumentCard = props => {
             ? (
               <Fragment>
                 <p>Excerpt:</p>
-                <ReactMarkdown
-                  className="excerpt"
-                  source={ excerpt }
-                  escapeHtml={ false }
-                  astPlugins={ [parseHtml] }
-                />
+                <div ref={ excerptRef } className={ `excerpt${excerptHeight > 160 && ' clamped'}` }>
+                  <ReactMarkdown
+                    source={ excerpt }
+                    escapeHtml={ false }
+                    astPlugins={ [parseHtml] }
+                  />
+                </div>
               </Fragment>
             )
             : <p>No excerpt available</p> }

--- a/components/Document/DocumentCard/DocumentCard.js
+++ b/components/Document/DocumentCard/DocumentCard.js
@@ -1,10 +1,11 @@
-import React, { Fragment, useCallback, useState } from 'react';
+import React, { Fragment, useState } from 'react';
 import PropTypes from 'prop-types';
 import { Modal, Card } from 'semantic-ui-react';
 import ReactMarkdown from 'react-markdown';
 import htmlParser from 'react-markdown/plugins/html-parser';
 import { getDateTimeTerms } from 'components/Package/utils';
 
+import ContentHeightClamp from 'components/ContentHeightClamp/ContentHeightClamp';
 import InternalUseDisplay from 'components/InternalUseDisplay/InternalUseDisplay';
 import MediaObject from 'components/MediaObject/MediaObject';
 import MetaTerms from 'components/admin/MetaTerms/MetaTerms';
@@ -22,13 +23,6 @@ import './DocumentCard.scss';
 const DocumentCard = props => {
   const { isAdminPreview, file: doc } = props;
   const [isOpen, setIsOpen] = useState( false );
-  const [excerptHeight, setExcerptHeight] = useState( 0 );
-
-  const excerptRef = useCallback( node => {
-    if ( node !== null ) {
-      setExcerptHeight( node.getBoundingClientRect().height );
-    }
-  }, [] );
 
   if ( !doc || !getCount( doc ) ) return null;
 
@@ -112,13 +106,13 @@ const DocumentCard = props => {
             ? (
               <Fragment>
                 <p>Excerpt:</p>
-                <div ref={ excerptRef } className={ `excerpt${excerptHeight > 160 && ' clamped'}` }>
+                <ContentHeightClamp className="excerpt">
                   <ReactMarkdown
                     source={ excerpt }
                     escapeHtml={ false }
                     astPlugins={ [parseHtml] }
                   />
-                </div>
+                </ContentHeightClamp>
               </Fragment>
             )
             : <p>No excerpt available</p> }

--- a/components/Document/DocumentCard/DocumentCard.scss
+++ b/components/Document/DocumentCard/DocumentCard.scss
@@ -87,8 +87,6 @@
         font-size: 0.777777778rem;
 
         > .excerpt {
-          overflow: hidden;
-
           em {
             font-style: normal;
           }
@@ -101,35 +99,6 @@
           ol {
             margin: 0 0 0 1.25em;
             padding-left: 0;
-          }
-
-          &.clamped {
-            position: relative;
-            max-height: 8rem;
-            overflow: auto;
-            -ms-overflow-style: none;
-            scrollbar-width: none; /* Firefox */
-            cursor: all-scroll;
-
-            /* Chrome, Safari */
-            &::-webkit-scrollbar {
-              display: none;
-              width: 0;
-              background: transparent;
-            }
-
-            &::after {
-              position: sticky; 
-              bottom: 0;
-              content: '';
-              display: block;
-              width: 100%;
-              height: 4rem;
-              background-image: linear-gradient(
-                rgba(255, 255, 255, 0) 0%,
-                rgba(255, 255, 255, 1) 90%
-              );
-            }
           }
         }
       }

--- a/components/Document/DocumentCard/DocumentCard.scss
+++ b/components/Document/DocumentCard/DocumentCard.scss
@@ -102,6 +102,35 @@
             margin: 0 0 0 1.25em;
             padding-left: 0;
           }
+
+          &.clamped {
+            position: relative;
+            max-height: 8rem;
+            overflow: auto;
+            -ms-overflow-style: none;
+            scrollbar-width: none; /* Firefox */
+            cursor: all-scroll;
+
+            /* Chrome, Safari */
+            &::-webkit-scrollbar {
+              display: none;
+              width: 0;
+              background: transparent;
+            }
+
+            &::after {
+              position: sticky; 
+              bottom: 0;
+              content: '';
+              display: block;
+              width: 100%;
+              height: 4rem;
+              background-image: linear-gradient(
+                rgba(255, 255, 255, 0) 0%,
+                rgba(255, 255, 255, 1) 90%
+              );
+            }
+          }
         }
       }
 

--- a/components/Document/DocumentCard/DocumentCard.test.js
+++ b/components/Document/DocumentCard/DocumentCard.test.js
@@ -1,0 +1,365 @@
+import { mount } from 'enzyme';
+import moment from 'moment';
+import { act } from 'react-dom/test-utils';
+import { normalizeDocumentItemByAPI } from 'components/Package/utils.js';
+import DocumentCard from './DocumentCard';
+
+jest.mock( 'next/config', () => () => ( { publicRuntimeConfig: { REACT_APP_PUBLIC_API: 'http://localhost:8080' } } ) );
+jest.mock(
+  'components/InternalUseDisplay/InternalUseDisplay',
+  () => function InternalUseDisplay() { return ''; }
+);
+jest.mock(
+  'components/MediaObject/MediaObject',
+  () => function MediaObject() { return ''; }
+);
+jest.mock(
+  'components/admin/MetaTerms/MetaTerms',
+  () => function MetaTerms() { return ''; }
+);
+jest.mock(
+  'components/modals/ModalPostTags/ModalPostTags',
+  () => function TagsList() { return ''; }
+);
+jest.mock(
+  'react-markdown',
+  () => function ReactMarkdown() { return ''; }
+);
+jest.mock(
+  '../Document',
+  () => function Document() { return ''; }
+);
+jest.mock(
+  'lib/browser', () => ( {
+    hasCssSupport: jest.fn( () => true )
+  } )
+);
+
+const props = {
+  file: {
+    id: 'ck38xhb9v1ypy072002wr8i5f',
+    createdAt: '2019-11-21T16:26:33.402Z',
+    updatedAt: '2020-01-03T13:51:29.909Z',
+    publishedAt: null,
+    title: 'sample one.doc 111',
+    filename: 'sample one.docx',
+    filetype: null,
+    filesize: null,
+    status: 'DRAFT',
+    visibility: 'INTERNAL',
+    url: '2019/12/sample one.docx',
+    signedUrl: 'https://amgov-publisher-dev.s3.amazonaws.com/2019/12/sample%20one.docx?AWSAccessKeyId=ggggg&Expires=1578603029&Signature=erererer',
+    excerpt: '<p>A statement provides the official U.S. policy/view or comment on a particular foreign policy issue usually in the name of the Spokesperson, Deputy Spokesperson, and sometimes from the Secretary of State.</p>',
+    content: {
+      id: 'ck391csz01yrw07205d7xr8iw',
+      rawText: 'U.S. DEPARTMENT OF STATE Office of the Spokesperson For Immediate Release Statement by ROBERT PALLADINO, DEPUTY SPOKESPERSON Month Date, 2018 100th Anniversary of the U.S.-Canada Boundary Waters Treaty &lt;Not in CAPS&gt; A statement provides the official U.S. policy/view or comment on a particular foreign policy issue usually in the name of the Spokesperson, Deputy Spokesperson, and sometimes from the Secretary of State.',
+      html: '<p>U.S. DEPARTMENT OF STATE</p><p>Office of the Spokesperson</p><p>For Immediate Release </p><p>Statement by ROBERT PALLADINO, DEPUTY SPOKESPERSON</p><p>Month Date, 2018</p><p>100th Anniversary of the U.S.-Canada Boundary Waters Treaty &lt;Not in CAPS&gt;</p><p>A statement provides the official U.S. policy/view or comment on a particular foreign policy issue usually in the name of the Spokesperson, Deputy Spokesperson, and sometimes from the Secretary of State.</p>',
+      __typename: 'DocumentConversionFormat'
+    },
+    use: {
+      id: 'ck2wbvj6010kz0720c358mbrt',
+      name: 'Department Press Briefing',
+      __typename: 'DocumentUse'
+    },
+    bureaus: [],
+    image: [],
+    language: {
+      id: 'ck2lzfx710hkq07206thus6pt',
+      locale: 'en-us',
+      languageCode: 'en',
+      displayName: 'English',
+      textDirection: 'LTR',
+      nativeName: 'English',
+      __typename: 'Language'
+    },
+    categories: [],
+    tags: [
+      {
+        id: 'ck2lzgu500rgb0720scmree6q',
+        translations: [
+          {
+            id: 'ck2lzg81f0l220720xozsqnww',
+            name: 'business and entrepreneurship',
+            language: {
+              id: 'ck2lzfx710hkq07206thus6pt',
+              locale: 'en-us',
+              languageCode: 'en',
+              displayName: 'English',
+              textDirection: 'LTR',
+              nativeName: 'English',
+              __typename: 'Language'
+            },
+            __typename: 'LanguageTranslation'
+          },
+          {
+            id: 'ck2lzg81z0l2907209nhmfzce',
+            name: 'negocios y emprendimiento',
+            language: {
+              id: 'ck2lzfx7o0hl707205uteku77',
+              locale: 'es-es',
+              languageCode: 'es',
+              displayName: 'Spanish',
+              textDirection: 'LTR',
+              nativeName: 'Español',
+              __typename: 'Language'
+            },
+            __typename: 'LanguageTranslation'
+          },
+          {
+            id: 'ck2lzg82k0l2g0720yojg47ku',
+            name: 'affaires et entrepreneuriat',
+            language: {
+              id: 'ck2lzfx710hkp07206oo0icbv',
+              locale: 'fr-fr',
+              languageCode: 'fr',
+              displayName: 'French',
+              textDirection: 'LTR',
+              nativeName: 'Français',
+              __typename: 'Language'
+            },
+            __typename: 'LanguageTranslation'
+          }
+        ],
+        __typename: 'Tag'
+      },
+      {
+        id: 'ck2lzgu5b0rho07207cqfeya0',
+        translations: [
+          {
+            id: 'ck2lzghuy0nne0720be7g4kki',
+            name: 'armed conflict',
+            language: {
+              id: 'ck2lzfx710hkq07206thus6pt',
+              locale: 'en-us',
+              languageCode: 'en',
+              displayName: 'English',
+              textDirection: 'LTR',
+              nativeName: 'English',
+              __typename: 'Language'
+            },
+            __typename: 'LanguageTranslation'
+          },
+          {
+            id: 'ck2lzghvp0nnl0720ddbyim3m',
+            name: 'conflicto armado',
+            language: {
+              id: 'ck2lzfx7o0hl707205uteku77',
+              locale: 'es-es',
+              languageCode: 'es',
+              displayName: 'Spanish',
+              textDirection: 'LTR',
+              nativeName: 'Español',
+              __typename: 'Language'
+            },
+            __typename: 'LanguageTranslation'
+          },
+          {
+            id: 'ck2lzghwb0nns07207xjmveqe',
+            name: 'un conflit armé',
+            language: {
+              id: 'ck2lzfx710hkp07206oo0icbv',
+              locale: 'fr-fr',
+              languageCode: 'fr',
+              displayName: 'French',
+              textDirection: 'LTR',
+              nativeName: 'Français',
+              __typename: 'Language'
+            },
+            __typename: 'LanguageTranslation'
+          }
+        ],
+        __typename: 'Tag'
+      }
+    ],
+    __typename: 'DocumentFile'
+  },
+  handleClick: jest.fn()
+};
+
+const normalizedDocFile = normalizeDocumentItemByAPI( { file: props.file, useGraphQl: true } );
+
+describe( '<DocumentCard />', () => {
+  let Component;
+  let wrapper;
+
+  beforeEach( () => {
+    Component = <DocumentCard file={ normalizedDocFile } handleClick={ props.handleClick } />;
+    wrapper = mount( Component );
+  } );
+
+  it( 'renders without crashing', () => {
+    expect( wrapper.exists() ).toEqual( true );
+  } );
+
+  it( 'renders the article.container', () => {
+    const article = wrapper.find( 'article.container' );
+
+    expect( article.exists() ).toEqual( true );
+    expect( article.prop( 'lang' ) )
+      .toEqual( props.file.language.languageCode );
+  } );
+
+  it( 'renders the .document-use MediaObject', () => {
+    const mediaObject = wrapper.find( 'MediaObject.document-use' );
+    const body = mount( <span>{ props.file.use.name }</span> );
+
+    expect( mediaObject.exists() ).toEqual( true );
+    expect( mount( mediaObject.prop( 'body' ) ) ).toEqual( body );
+    expect( mediaObject.prop( 'img' ) ).toEqual( {
+      src: 'image-stub',
+      alt: 'document icon',
+      style: { height: '30px', width: '30px' }
+    } );
+  } );
+
+  it( 'renders InternalUseDisplay', () => {
+    const internalUse = wrapper.find( 'InternalUseDisplay' );
+    expect( internalUse.exists() ).toEqual( true );
+  } );
+
+  it( 'renders the header and title', () => {
+    const header = wrapper.find( 'header' );
+    const heading = wrapper.find( 'h2' );
+    const title = heading.find( '.title' );
+
+    expect( header.name() ).toEqual( 'header' );
+    expect( header.prop( 'className' ) ).toEqual( 'header' );
+    expect( heading.name() ).toEqual( 'h2' );
+    expect( title.name() ).toEqual( 'button' );
+    expect( title.text() ).toEqual( props.file.title );
+    expect( title.prop( 'id' ) )
+      .toEqual( `documentCard_trigger_${props.file.id}` );
+  } );
+
+  it( 'renders the modal with correct props', () => {
+    const modal = wrapper.find( 'Modal' );
+
+    expect( modal.prop( 'open' ) ).toEqual( false );
+    expect( typeof modal.prop( 'onOpen' ) ).toEqual( 'function' );
+    expect( modal.prop( 'onOpen' ).name ).toEqual( 'handleOpen' );
+    expect( typeof modal.prop( 'onClose' ) ).toEqual( 'function' );
+    expect( modal.prop( 'onClose' ).name ).toEqual( 'handleClose' );
+    expect( modal.prop( 'closeIcon' ) ).toEqual( true );
+  } );
+
+  it( 'calling handleOpen/handleClose opens/closes the modal', () => {
+    const modal = () => wrapper.find( 'Modal' );
+
+    // initially closed
+    expect( modal().prop( 'open' ) ).toEqual( false );
+
+    // open modal
+    act( () => {
+      modal().prop( 'onOpen' )();
+    } );
+    wrapper.update();
+    expect( modal().prop( 'open' ) ).toEqual( true );
+
+    // close modal
+    act( () => {
+      modal().prop( 'onClose' )();
+    } );
+    wrapper.update();
+    expect( modal().prop( 'open' ) ).toEqual( false );
+  } );
+
+  it( 'renders the card content markup', () => {
+    const content = wrapper.find( 'CardContent > div.content' );
+    const contentHeightClamp = content.find( 'ContentHeightClamp' );
+    const markupElem = contentHeightClamp.find( 'ReactMarkdown' );
+
+    expect( content.exists() ).toEqual( true );
+    expect( content.prop( 'className' ) ).toEqual( 'content' );
+    expect( content.contains( 'Excerpt:' ) ).toEqual( true );
+    expect( contentHeightClamp.exists() ).toEqual( true );
+    expect( markupElem.exists() ).toEqual( true );
+    expect( markupElem.prop( 'source' ) ).toEqual( props.file.excerpt );
+    expect( markupElem.prop( 'escapeHtml' ) ).toEqual( false );
+  } );
+
+  it( 'renders "No excerpt available" if !excerpt', () => {
+    wrapper.setProps( {
+      file: {
+        ...props.file,
+        excerpt: ''
+      }
+    } );
+    const content = wrapper.find( 'CardContent > div.content' );
+    const markupElem = content.find( 'div.excerpt' );
+    const excerpt = <p>No excerpt available</p>;
+
+    expect( content.exists() ).toEqual( true );
+    expect( content.prop( 'className' ) ).toEqual( 'content' );
+    expect( content.contains( 'Excerpt:' ) ).toEqual( false );
+    expect( markupElem.exists() ).toEqual( false );
+    expect( content.contains( excerpt ) ).toEqual( true );
+  } );
+
+  it( 'renders footer', () => {
+    const footer = wrapper.find( 'CardMeta > .meta' );
+
+    expect( footer.exists() ).toEqual( true );
+    expect( footer.name() ).toEqual( 'footer' );
+  } );
+
+  it( 'renders footer > MetaTerms', () => {
+    const metaTerms = wrapper.find( 'CardMeta MetaTerms' );
+
+    const { id, createdAt, updatedAt } = props.file;
+    const isUpdated = updatedAt > createdAt;
+    const label = isUpdated ? 'Updated' : 'Created';
+    const dateTime = isUpdated ? updatedAt : createdAt;
+    const formattedDateTime = moment( dateTime ).format( 'LL' );
+    const timeElement = mount( <time dateTime={ dateTime }>{ formattedDateTime }</time> );
+    const { definition, displayName, name } = metaTerms.prop( 'terms' )[0];
+
+    expect( metaTerms.exists() ).toEqual( true );
+    expect( metaTerms.prop( 'className' ) ).toEqual( 'date-time' );
+    expect( metaTerms.prop( 'unitId' ) ).toEqual( id );
+    expect( displayName ).toEqual( label );
+    expect( name ).toEqual( label );
+    expect( mount( definition ) ).toEqual( timeElement );
+  } );
+
+  it( 'renders footer > TagsList', () => {
+    const tagsList = wrapper.find( 'CardMeta TagsList' );
+
+    expect( tagsList.exists() ).toEqual( true );
+    expect( tagsList.prop( 'tags' ) ).toEqual( [
+      {
+        id: 'ck2lzgu500rgb0720scmree6q',
+        name: 'business and entrepreneurship'
+      },
+      {
+        id: 'ck2lzgu5b0rho07207cqfeya0',
+        name: 'armed conflict'
+      }
+    ] );
+  } );
+
+  it( 'does not render footer > TagsList if !tags', () => {
+    wrapper.setProps( {
+      ...props,
+      file: {
+        ...props.file.tags,
+        tags: []
+      }
+    } );
+    const tagsList = wrapper.find( 'CardMeta TagsList' );
+
+    expect( tagsList.exists() ).toEqual( false );
+  } );
+
+  it( 'renders footer > MediaObject', () => {
+    const mediaObject = wrapper.find( 'CardMeta MediaObject' );
+    const body = mount( <span>U.S. Department of State</span> );
+
+    expect( mediaObject.exists() ).toEqual( true );
+    expect( mediaObject.prop( 'className' ) ).toEqual( 'seal' );
+    expect( mount( mediaObject.prop( 'body' ) ) ).toEqual( body );
+    expect( mediaObject.prop( 'img' ) ).toEqual( {
+      src: 'image-stub',
+      alt: 'U.S. Department of State seal'
+    } );
+  } );
+} );


### PR DESCRIPTION
* Excerpts longer than 144px in height are now cropped.
* Subtle fade appears at the bottom of cropped excerpts to indicate additional content can be viewed by scrolling
* Cropped excerpts are focusable and can be scrolled using keyboard by clicking `space` or `up` /`down` arrows
* Add tests for ContentHeightClamp and DocumentCard components