### PR TITLE
CDP-1790: Disable Publish button if no package files

### DIFF
--- a/components/admin/ButtonPublish/ButtonPublish.js
+++ b/components/admin/ButtonPublish/ButtonPublish.js
@@ -8,7 +8,8 @@ const ButtonPublish = props => {
     handleUnPublish,
     publishing,
     status,
-    updated
+    updated,
+    disabled
   } = props;
 
   const setButtonState = btn => `action-btn btn--${btn} ${publishing ? 'loading' : ''}`;
@@ -16,12 +17,12 @@ const ButtonPublish = props => {
   return (
     <Fragment>
       { status === 'DRAFT'
-        ? <Button className={ setButtonState( 'publish' ) } onClick={ handlePublish }>Publish</Button>
+        ? <Button className={ setButtonState( 'publish' ) } onClick={ handlePublish } disabled={ disabled }>Publish</Button>
         : (
           <Fragment>
             { ( ( status === 'PUBLISHED' || status === 'PUBLISHING' ) && updated )
               && (
-                <Button className={ setButtonState( 'edit basic' ) } onClick={ handlePublish }>Publish Changes</Button>
+                <Button className={ setButtonState( 'edit basic' ) } onClick={ handlePublish } disabled={ disabled }>Publish Changes</Button>
               ) }
             <Button className="action-btn btn--publish" onClick={ handleUnPublish }>Unpublish</Button>
           </Fragment>
@@ -40,6 +41,7 @@ ButtonPublish.propTypes = {
   publishing: PropTypes.bool,
   status: PropTypes.string,
   updated: PropTypes.bool,
+  disabled: PropTypes.bool
 };
 
 export default ButtonPublish;

--- a/components/admin/ButtonPublish/ButtonPublish.test.js
+++ b/components/admin/ButtonPublish/ButtonPublish.test.js
@@ -6,7 +6,8 @@ const props = {
   handleUnPublish: jest.fn(),
   publishing: false,
   status: 'DRAFT',
-  updated: false
+  updated: false,
+  disabled: false
 };
 
 const getBtn = ( str, buttons ) => (
@@ -14,24 +15,26 @@ const getBtn = ( str, buttons ) => (
 );
 
 describe( '<ButtonPublish />, for DRAFT status', () => {
-  const Component = <ButtonPublish { ...props } />;
+  let Component;
+  let wrapper;
+  let btns;
+
+  beforeEach( () => {
+    Component = <ButtonPublish { ...props } />;
+    wrapper = mount( Component );
+    btns = wrapper.find( 'Button' );
+  } );
 
   it( 'renders without crashing', () => {
-    const wrapper = mount( Component );
     expect( wrapper.exists() ).toEqual( true );
   } );
 
   it( 'renders the Publish button', () => {
-    const wrapper = mount( Component );
-    const btns = wrapper.find( 'Button' );
     const publishBtn = getBtn( 'Publish', btns );
-
     expect( publishBtn.exists() ).toEqual( props.status === 'DRAFT' );
   } );
 
   it( 'renders the correct className values for the Publish button', () => {
-    const wrapper = mount( Component );
-    const btns = wrapper.find( 'Button' );
     const publishBtn = getBtn( 'Publish', btns );
     const { className } = publishBtn.props();
 
@@ -41,8 +44,6 @@ describe( '<ButtonPublish />, for DRAFT status', () => {
   } );
 
   it( 'clicking Publish button calls handlePublish', () => {
-    const wrapper = mount( Component );
-    const btns = wrapper.find( 'Button' );
     const publishBtn = getBtn( 'Publish', btns );
 
     publishBtn.simulate( 'click' );
@@ -50,8 +51,6 @@ describe( '<ButtonPublish />, for DRAFT status', () => {
   } );
 
   it( 'does not render the Publish Changes button', () => {
-    const wrapper = mount( Component );
-    const btns = wrapper.find( 'Button' );
     const publishChangesBtn = getBtn( 'Publish Changes', btns );
 
     expect( publishChangesBtn.exists() )
@@ -59,10 +58,54 @@ describe( '<ButtonPublish />, for DRAFT status', () => {
   } );
 
   it( 'does not render the Unpublish button', () => {
-    const wrapper = mount( Component );
-    const btns = wrapper.find( 'Button' );
     const unpublishBtn = getBtn( 'Unpublish', btns );
+    expect( unpublishBtn.exists() ).toEqual( false );
+  } );
+} );
 
+describe( '<ButtonPublish />, for DRAFT status & disabled', () => {
+  const newProps = {
+    ...props,
+    disabled: true
+  };
+  let Component;
+  let wrapper;
+  let btns;
+
+  beforeEach( () => {
+    Component = <ButtonPublish { ...newProps } />;
+    wrapper = mount( Component );
+    btns = wrapper.find( 'Button' );
+  } );
+
+  it( 'renders without crashing', () => {
+    expect( wrapper.exists() ).toEqual( true );
+  } );
+
+  it( 'renders the disabled Publish button', () => {
+    const publishBtn = getBtn( 'Publish', btns );
+    expect( publishBtn.exists() ).toEqual( props.status === 'DRAFT' );
+    expect( publishBtn.prop( 'disabled' ) ).toEqual( true );
+  } );
+
+  it( 'renders the correct className values for the Publish button', () => {
+    const publishBtn = getBtn( 'Publish', btns );
+    const { className } = publishBtn.props();
+
+    expect( className.includes( 'action-btn btn--publish' ) )
+      .toEqual( props.status === 'DRAFT' );
+    expect( className.includes( 'loading' ) ).toEqual( props.publishing );
+  } );
+
+  it( 'does not render the Publish Changes button', () => {
+    const publishChangesBtn = getBtn( 'Publish Changes', btns );
+
+    expect( publishChangesBtn.exists() )
+      .toEqual( props.status === 'PUBLISHED' && props.updated );
+  } );
+
+  it( 'does not render the Unpublish button', () => {
+    const unpublishBtn = getBtn( 'Unpublish', btns );
     expect( unpublishBtn.exists() ).toEqual( false );
   } );
 } );
@@ -72,24 +115,26 @@ describe( '<ButtonPublish />, for PUBLISHED status', () => {
     ...props,
     status: 'PUBLISHED'
   };
-  const Component = <ButtonPublish { ...newProps } />;
+  let Component;
+  let wrapper;
+  let btns;
+
+  beforeEach( () => {
+    Component = <ButtonPublish { ...newProps } />;
+    wrapper = mount( Component );
+    btns = wrapper.find( 'Button' );
+  } );
 
   it( 'renders without crashing', () => {
-    const wrapper = mount( Component );
     expect( wrapper.exists() ).toEqual( true );
   } );
 
   it( 'does not render the Publish button', () => {
-    const wrapper = mount( Component );
-    const btns = wrapper.find( 'Button' );
     const publishBtn = getBtn( 'Publish', btns );
-
     expect( publishBtn.exists() ).toEqual( newProps.status === 'DRAFT' );
   } );
 
   it( 'does not render the Publish Changes button', () => {
-    const wrapper = mount( Component );
-    const btns = wrapper.find( 'Button' );
     const publishChangesBtn = getBtn( 'Publish Changes', btns );
 
     expect( publishChangesBtn.exists() )
@@ -97,16 +142,12 @@ describe( '<ButtonPublish />, for PUBLISHED status', () => {
   } );
 
   it( 'renders the Unpublish button', () => {
-    const wrapper = mount( Component );
-    const btns = wrapper.find( 'Button' );
     const unpublishBtn = getBtn( 'Unpublish', btns );
 
     expect( unpublishBtn.exists() ).toEqual( newProps.status !== 'DRAFT' );
   } );
 
   it( 'renders the correct className values for the Unpublish button', () => {
-    const wrapper = mount( Component );
-    const btns = wrapper.find( 'Button' );
     const unpublishBtn = getBtn( 'Unpublish', btns );
     const { className } = unpublishBtn.props();
 
@@ -114,8 +155,6 @@ describe( '<ButtonPublish />, for PUBLISHED status', () => {
   } );
 
   it( 'clicking Unpublish button calls handleUnPublish', () => {
-    const wrapper = mount( Component );
-    const btns = wrapper.find( 'Button' );
     const unpublishBtn = getBtn( 'Unpublish', btns );
 
     unpublishBtn.simulate( 'click' );
@@ -129,24 +168,26 @@ describe( '<ButtonPublish />, for PUBLISHED status & updated', () => {
     updated: true,
     status: 'PUBLISHED'
   };
-  const Component = <ButtonPublish { ...newProps } />;
+  let Component;
+  let wrapper;
+  let btns;
+
+  beforeEach( () => {
+    Component = <ButtonPublish { ...newProps } />;
+    wrapper = mount( Component );
+    btns = wrapper.find( 'Button' );
+  } );
 
   it( 'renders without crashing', () => {
-    const wrapper = mount( Component );
     expect( wrapper.exists() ).toEqual( true );
   } );
 
   it( 'does not render the Publish button', () => {
-    const wrapper = mount( Component );
-    const btns = wrapper.find( 'Button' );
     const publishBtn = getBtn( 'Publish', btns );
-
     expect( publishBtn.exists() ).toEqual( newProps.status === 'DRAFT' );
   } );
 
   it( 'renders the Publish Changes button', () => {
-    const wrapper = mount( Component );
-    const btns = wrapper.find( 'Button' );
     const publishChangesBtn = getBtn( 'Publish Changes', btns );
 
     expect( publishChangesBtn.exists() )
@@ -154,8 +195,6 @@ describe( '<ButtonPublish />, for PUBLISHED status & updated', () => {
   } );
 
   it( 'renders the correct className values for the Publish Changes button', () => {
-    const wrapper = mount( Component );
-    const btns = wrapper.find( 'Button' );
     const publishChangesBtn = getBtn( 'Publish Changes', btns );
     const { className } = publishChangesBtn.props();
 
@@ -165,8 +204,6 @@ describe( '<ButtonPublish />, for PUBLISHED status & updated', () => {
   } );
 
   it( 'clicking Publish Changes button calls handlePublish', () => {
-    const wrapper = mount( Component );
-    const btns = wrapper.find( 'Button' );
     const publishChangesBtn = getBtn( 'Publish Changes', btns );
 
     publishChangesBtn.simulate( 'click' );
@@ -174,16 +211,11 @@ describe( '<ButtonPublish />, for PUBLISHED status & updated', () => {
   } );
 
   it( 'renders the Unpublish button', () => {
-    const wrapper = mount( Component );
-    const btns = wrapper.find( 'Button' );
     const unpublishBtn = getBtn( 'Unpublish', btns );
-
     expect( unpublishBtn.exists() ).toEqual( newProps.status !== 'DRAFT' );
   } );
 
   it( 'renders the correct className values for the Unpublish button', () => {
-    const wrapper = mount( Component );
-    const btns = wrapper.find( 'Button' );
     const unpublishBtn = getBtn( 'Unpublish', btns );
     const { className } = unpublishBtn.props();
 
@@ -191,8 +223,6 @@ describe( '<ButtonPublish />, for PUBLISHED status & updated', () => {
   } );
 
   it( 'clicking Unpublish button calls handleUnPublish', () => {
-    const wrapper = mount( Component );
-    const btns = wrapper.find( 'Button' );
     const unpublishBtn = getBtn( 'Unpublish', btns );
 
     unpublishBtn.simulate( 'click' );
@@ -200,47 +230,62 @@ describe( '<ButtonPublish />, for PUBLISHED status & updated', () => {
   } );
 } );
 
-describe( '<ButtonPublish />, for PUBLISHING status, publishing, and not updated', () => {
+describe( '<ButtonPublish />, for PUBLISHED status, updated, & disabled', () => {
   const newProps = {
     ...props,
-    publishing: true,
-    status: 'PUBLISHING'
+    updated: true,
+    status: 'PUBLISHED',
+    disabled: true
   };
-  const Component = <ButtonPublish { ...newProps } />;
+  let Component;
+  let wrapper;
+  let btns;
+
+  beforeEach( () => {
+    Component = <ButtonPublish { ...newProps } />;
+    wrapper = mount( Component );
+    btns = wrapper.find( 'Button' );
+  } );
 
   it( 'renders without crashing', () => {
-    const wrapper = mount( Component );
     expect( wrapper.exists() ).toEqual( true );
   } );
 
   it( 'does not render the Publish button', () => {
-    const wrapper = mount( Component );
-    const btns = wrapper.find( 'Button' );
     const publishBtn = getBtn( 'Publish', btns );
-
     expect( publishBtn.exists() ).toEqual( newProps.status === 'DRAFT' );
   } );
 
-  it( 'does not render the Publish Changes button', () => {
-    const wrapper = mount( Component );
-    const btns = wrapper.find( 'Button' );
+  it( 'renders the disabled Publish Changes button', () => {
     const publishChangesBtn = getBtn( 'Publish Changes', btns );
 
     expect( publishChangesBtn.exists() )
       .toEqual( newProps.status === 'PUBLISHED' && newProps.updated );
+    expect( publishChangesBtn.prop( 'disabled' ) ).toEqual( true );
+  } );
+
+  it( 'renders the correct className values for the Publish Changes button', () => {
+    const publishChangesBtn = getBtn( 'Publish Changes', btns );
+    const { className } = publishChangesBtn.props();
+
+    expect( className.includes( 'action-btn btn--edit' ) )
+      .toEqual( newProps.status === 'PUBLISHED' && newProps.updated );
+    expect( className.includes( 'loading' ) ).toEqual( newProps.publishing );
+  } );
+
+  it( 'clicking Publish Changes button calls handlePublish', () => {
+    const publishChangesBtn = getBtn( 'Publish Changes', btns );
+
+    publishChangesBtn.simulate( 'click' );
+    expect( props.handlePublish ).toHaveBeenCalled();
   } );
 
   it( 'renders the Unpublish button', () => {
-    const wrapper = mount( Component );
-    const btns = wrapper.find( 'Button' );
     const unpublishBtn = getBtn( 'Unpublish', btns );
-
     expect( unpublishBtn.exists() ).toEqual( newProps.status !== 'DRAFT' );
   } );
 
   it( 'renders the correct className values for the Unpublish button', () => {
-    const wrapper = mount( Component );
-    const btns = wrapper.find( 'Button' );
     const unpublishBtn = getBtn( 'Unpublish', btns );
     const { className } = unpublishBtn.props();
 
@@ -248,8 +293,58 @@ describe( '<ButtonPublish />, for PUBLISHING status, publishing, and not updated
   } );
 
   it( 'clicking Unpublish button calls handleUnPublish', () => {
-    const wrapper = mount( Component );
-    const btns = wrapper.find( 'Button' );
+    const unpublishBtn = getBtn( 'Unpublish', btns );
+
+    unpublishBtn.simulate( 'click' );
+    expect( props.handleUnPublish ).toHaveBeenCalled();
+  } );
+} );
+
+describe( '<ButtonPublish />, for PUBLISHING status, publishing, & not updated', () => {
+  const newProps = {
+    ...props,
+    publishing: true,
+    status: 'PUBLISHING'
+  };
+  let Component;
+  let wrapper;
+  let btns;
+
+  beforeEach( () => {
+    Component = <ButtonPublish { ...newProps } />;
+    wrapper = mount( Component );
+    btns = wrapper.find( 'Button' );
+  } );
+
+  it( 'renders without crashing', () => {
+    expect( wrapper.exists() ).toEqual( true );
+  } );
+
+  it( 'does not render the Publish button', () => {
+    const publishBtn = getBtn( 'Publish', btns );
+    expect( publishBtn.exists() ).toEqual( newProps.status === 'DRAFT' );
+  } );
+
+  it( 'does not render the Publish Changes button', () => {
+    const publishChangesBtn = getBtn( 'Publish Changes', btns );
+
+    expect( publishChangesBtn.exists() )
+      .toEqual( newProps.status === 'PUBLISHED' && newProps.updated );
+  } );
+
+  it( 'renders the Unpublish button', () => {
+    const unpublishBtn = getBtn( 'Unpublish', btns );
+    expect( unpublishBtn.exists() ).toEqual( newProps.status !== 'DRAFT' );
+  } );
+
+  it( 'renders the correct className values for the Unpublish button', () => {
+    const unpublishBtn = getBtn( 'Unpublish', btns );
+    const { className } = unpublishBtn.props();
+
+    expect( className.includes( 'action-btn btn--publish' ) ).toEqual( true );
+  } );
+
+  it( 'clicking Unpublish button calls handleUnPublish', () => {
     const unpublishBtn = getBtn( 'Unpublish', btns );
 
     unpublishBtn.simulate( 'click' );
@@ -264,24 +359,27 @@ describe( '<ButtonPublish />, for PUBLISHING status, publishing, and updated', (
     status: 'PUBLISHING',
     updated: true,
   };
-  const Component = <ButtonPublish { ...newProps } />;
+  let Component;
+  let wrapper;
+  let btns;
+
+  beforeEach( () => {
+    Component = <ButtonPublish { ...newProps } />;
+    wrapper = mount( Component );
+    btns = wrapper.find( 'Button' );
+  } );
 
   it( 'renders without crashing', () => {
-    const wrapper = mount( Component );
     expect( wrapper.exists() ).toEqual( true );
   } );
 
   it( 'does not render the Publish button', () => {
-    const wrapper = mount( Component );
-    const btns = wrapper.find( 'Button' );
     const publishBtn = getBtn( 'Publish', btns );
 
     expect( publishBtn.exists() ).toEqual( newProps.status === 'DRAFT' );
   } );
 
   it( 'renders the Publish Changes button', () => {
-    const wrapper = mount( Component );
-    const btns = wrapper.find( 'Button' );
     const publishChangesBtn = getBtn( 'Publish Changes', btns );
 
     expect( publishChangesBtn.exists() )
@@ -289,8 +387,6 @@ describe( '<ButtonPublish />, for PUBLISHING status, publishing, and updated', (
   } );
 
   it( 'renders the correct className values for the Publish Changes button', () => {
-    const wrapper = mount( Component );
-    const btns = wrapper.find( 'Button' );
     const publishChangesBtn = getBtn( 'Publish Changes', btns );
     const { className } = publishChangesBtn.props();
 
@@ -300,8 +396,6 @@ describe( '<ButtonPublish />, for PUBLISHING status, publishing, and updated', (
   } );
 
   it( 'clicking Publish Changes button calls handlePublish', () => {
-    const wrapper = mount( Component );
-    const btns = wrapper.find( 'Button' );
     const publishChangesBtn = getBtn( 'Publish Changes', btns );
 
     publishChangesBtn.simulate( 'click' );
@@ -309,16 +403,12 @@ describe( '<ButtonPublish />, for PUBLISHING status, publishing, and updated', (
   } );
 
   it( 'renders the Unpublish button', () => {
-    const wrapper = mount( Component );
-    const btns = wrapper.find( 'Button' );
     const unpublishBtn = getBtn( 'Unpublish', btns );
 
     expect( unpublishBtn.exists() ).toEqual( newProps.status !== 'DRAFT' );
   } );
 
   it( 'renders the correct className values for the Unpublish button', () => {
-    const wrapper = mount( Component );
-    const btns = wrapper.find( 'Button' );
     const unpublishBtn = getBtn( 'Unpublish', btns );
     const { className } = unpublishBtn.props();
 
@@ -326,8 +416,6 @@ describe( '<ButtonPublish />, for PUBLISHING status, publishing, and updated', (
   } );
 
   it( 'clicking Unpublish button calls handleUnPublish', () => {
-    const wrapper = mount( Component );
-    const btns = wrapper.find( 'Button' );
     const unpublishBtn = getBtn( 'Unpublish', btns );
 
     unpublishBtn.simulate( 'click' );

--- a/components/admin/PackageEdit/PackageEdit.js
+++ b/components/admin/PackageEdit/PackageEdit.js
@@ -204,7 +204,7 @@ const PackageEdit = props => {
             disabled={ {
               delete: deletePackageEnabled(),
               save: !packageId || !isFormValid,
-              publishChanges: !pkg.documents.length,
+              publishChanges: !packageId || !pkg.documents.length,
               publish: !packageId || !pkg.documents.length
             } }
             handle={ {

--- a/components/admin/PackageEdit/PackageEdit.js
+++ b/components/admin/PackageEdit/PackageEdit.js
@@ -204,7 +204,8 @@ const PackageEdit = props => {
             disabled={ {
               delete: deletePackageEnabled(),
               save: !packageId || !isFormValid,
-              publish: !packageId
+              publishChanges: !pkg.documents.length,
+              publish: !packageId || !pkg.documents.length
             } }
             handle={ {
               deleteConfirm: handleDeleteConfirm,
@@ -286,6 +287,7 @@ const PackageEdit = props => {
             handleUnPublish={ handleUnPublish }
             status={ ( pkg && pkg.status ) || 'DRAFT' }
             updated={ isDirty }
+            disabled={ !packageId || !pkg.documents.length }
           />
         </section>
       ) }

--- a/components/admin/PackageEdit/PackageEdit.test.js
+++ b/components/admin/PackageEdit/PackageEdit.test.js
@@ -36,7 +36,7 @@ const suppressActWarning = consoleError => {
   } );
 };
 
-describe( '<PackageEdit />', () => {
+describe( '<PackageEdit />, if DRAFT status', () => {
   const router = {
     push: jest.fn(),
     query: {
@@ -72,8 +72,13 @@ describe( '<PackageEdit />', () => {
     console.error = consoleError;
   } );
 
+  let wrapper;
+
+  beforeEach( () => {
+    wrapper = mount( Component );
+  } );
+
   it( 'renders initial loading state without crashing', () => {
-    const wrapper = mount( Component );
     const pkgEdit = wrapper.find( 'PackageEdit' );
     const loader = wrapper.find( 'Loader' );
     const msg = 'Loading package details page...';
@@ -84,11 +89,11 @@ describe( '<PackageEdit />', () => {
   } );
 
   it( 'renders error message if a queryError is returned', async () => {
-    const wrapper = mount( ErrorComponent );
+    const errorWrapper = mount( ErrorComponent );
     await wait( 0 );
-    wrapper.update();
+    errorWrapper.update();
 
-    const apolloError = wrapper.find( 'ApolloError' );
+    const apolloError = errorWrapper.find( 'ApolloError' );
     const msg = 'There was an error.';
 
     expect( apolloError.exists() ).toEqual( true );
@@ -96,7 +101,6 @@ describe( '<PackageEdit />', () => {
   } );
 
   it( 'renders the final state without crashing', async () => {
-    const wrapper = mount( Component );
     await wait( 0 );
     wrapper.update();
     const pkgEdit = wrapper.find( 'PackageEdit' );
@@ -105,7 +109,6 @@ describe( '<PackageEdit />', () => {
   } );
 
   it( 'renders the ProjectHeader', async () => {
-    const wrapper = mount( Component );
     await wait( 0 );
     wrapper.update();
 
@@ -119,7 +122,6 @@ describe( '<PackageEdit />', () => {
   } );
 
   it( 'renders the ActionButtons', async () => {
-    const wrapper = mount( Component );
     await wait( 0 );
     wrapper.update();
 
@@ -144,7 +146,6 @@ describe( '<PackageEdit />', () => {
   } );
 
   it( 'clicking the Delete Package button opens the Confirm modal', async () => {
-    const wrapper = mount( Component );
     await wait( 0 );
     wrapper.update();
 
@@ -164,7 +165,6 @@ describe( '<PackageEdit />', () => {
   } );
 
   it( 'clicking the Cancel button in the Confirm modal closes the modal', async () => {
-    const wrapper = mount( Component );
     await wait( 0 );
     wrapper.update();
 
@@ -190,7 +190,6 @@ describe( '<PackageEdit />', () => {
   } );
 
   it( 'clicking the Confirm button in the Confirm modal calls deletePackage and redirects to the dashboard', async done => {
-    const wrapper = mount( Component );
     await wait( 0 );
     wrapper.update();
 
@@ -225,7 +224,6 @@ describe( '<PackageEdit />', () => {
   } );
 
   it( 'clicking the Save & Exit button redirects to the dashboard', async () => {
-    const wrapper = mount( Component );
     await wait( 0 );
     wrapper.update();
 
@@ -239,48 +237,31 @@ describe( '<PackageEdit />', () => {
     } );
   } );
 
-  it( 'clicking the Publish button ... TBD', async () => {
-    const wrapper = mount( Component );
+  it.skip( 'clicking the Publish button ... TBD', async () => {
     await wait( 0 );
     wrapper.update();
 
     const actionButtons = () => wrapper.find( 'ActionButtons' );
     const btns = actionButtons().find( 'button' );
     const publishBtn = getBtn( 'Publish', btns );
-    const logSpy = jest.spyOn( global.console, 'log' );
 
     publishBtn.simulate( 'click' );
-
-    /**
-     * For now, test for console.log. Update after
-     * publish workflow has been implemented.
-     */
-    expect( logSpy ).toHaveBeenCalledWith( 'Publish' );
     // TBD
   } );
 
   it.skip( 'clicking the Unpublish button ... TBD', async () => {
-    const wrapper = mount( Component );
     await wait( 0 );
     wrapper.update();
 
     const actionButtons = () => wrapper.find( 'ActionButtons' );
     const btns = actionButtons().find( 'button' );
     const unPublishBtn = getBtn( 'Unpublish', btns );
-    const logSpy = jest.spyOn( global.console, 'log' );
 
     unPublishBtn.simulate( 'click' );
-
-    /**
-     * For now, test for console.log. Update after
-     * unpublish workflow has been implemented.
-     */
-    expect( logSpy ).toHaveBeenCalledWith( 'Unpublish' );
     // TBD
   } );
 
   it( 'renders the PackageDetailsFormContainer', async () => {
-    const wrapper = mount( Component );
     await wait( 0 );
     wrapper.update();
     const pkgFormContainer = wrapper.find( 'PackageDetailsFormContainer' );
@@ -292,16 +273,15 @@ describe( '<PackageEdit />', () => {
       .toEqual( 'function' );
     expect( pkgFormContainer.prop( 'updateNotification' ).name )
       .toEqual( 'updateNotification' );
-    expect( typeof pkgFormContainer.prop( 'setIsDirty' ) )
+    expect( typeof pkgFormContainer.prop( 'setIsFormValid' ) )
       .toEqual( 'function' );
-    expect( pkgFormContainer.prop( 'setIsDirty' ).name )
+    expect( pkgFormContainer.prop( 'setIsFormValid' ).name )
       .toEqual( 'bound dispatchAction' );
     expect( pkgFormContainer.prop( 'hasInitialUploadCompleted' ) )
       .toEqual( router.query.action !== 'create' );
   } );
 
   it( 'renders ActionHeadline', async () => {
-    const wrapper = mount( Component );
     await wait( 0 );
     wrapper.update();
 
@@ -319,7 +299,6 @@ describe( '<PackageEdit />', () => {
   } );
 
   it( 'renders ButtonPublish', async () => {
-    const wrapper = mount( Component );
     await wait( 0 );
     wrapper.update();
 
@@ -331,6 +310,8 @@ describe( '<PackageEdit />', () => {
     expect( buttonPublish.prop( 'publishing' ) ).toEqual( undefined );
     expect( buttonPublish.prop( 'updated' ) )
       .toEqual( pkg.status === 'PUBLISHED' );
+    expect( buttonPublish.prop( 'disabled' ) )
+      .toEqual( !pkg.documents.length );
     expect( buttonPublish.prop( 'handlePublish' ).name )
       .toEqual( 'handlePublish' );
     expect( buttonPublish.prop( 'handleUnPublish' ).name )
@@ -338,17 +319,18 @@ describe( '<PackageEdit />', () => {
   } );
 
   it( 'renders ApolloError with an empty error prop', async () => {
-    const wrapper = mount( Component );
     await wait( 0 );
     wrapper.update();
-    const apolloError = wrapper.find( 'ApolloError' );
+    const apolloErrors = wrapper.find( 'ApolloError' );
 
-    expect( apolloError.exists() ).toEqual( true );
-    expect( apolloError.prop( 'error' ) ).toEqual( {} );
+    expect( apolloErrors.exists() ).toEqual( true );
+    expect( apolloErrors.length ).toEqual( 2 );
+    apolloErrors.forEach( error => {
+      expect( error.prop( 'error' ) ).toEqual( {} );
+    } );
   } );
 
   it( 'renders Notification with the correct initial props', async () => {
-    const wrapper = mount( Component );
     await wait( 0 );
     wrapper.update();
     const notification = wrapper.find( 'Notification' );
@@ -368,7 +350,164 @@ describe( '<PackageEdit />', () => {
   } );
 } );
 
-describe( '<PackageEdit />, if there are no documents,', () => {
+describe( '<PackageEdit />, if there are no documents & router.query.action !== create', () => {
+  const router = {
+    push: jest.fn(),
+    query: {
+      id: 'test-123'
+    }
+  };
+
+  const Component = (
+    <MockedProvider mocks={ noDocumentsMocks }>
+      <RouterContext.Provider value={ router }>
+        <PackageEdit { ...props } />
+      </RouterContext.Provider>
+    </MockedProvider>
+  );
+
+  const ErrorComponent = (
+    <MockedProvider mocks={ errorMocks }>
+      <RouterContext.Provider value={ router }>
+        <PackageEdit { ...props } />
+      </RouterContext.Provider>
+    </MockedProvider>
+  );
+
+  const consoleError = console.error;
+  beforeAll( () => suppressActWarning( consoleError ) );
+
+  afterAll( () => {
+    console.error = consoleError;
+  } );
+
+  let wrapper;
+
+  beforeEach( () => {
+    wrapper = mount( Component );
+  } );
+
+  it( 'renders initial loading state without crashing', () => {
+    const pkgEdit = wrapper.find( 'PackageEdit' );
+    const loader = wrapper.find( 'Loader' );
+    const msg = 'Loading package details page...';
+
+    expect( pkgEdit.exists() ).toEqual( true );
+    expect( loader.exists() ).toEqual( true );
+    expect( loader.contains( msg ) ).toEqual( true );
+  } );
+
+  it( 'renders error message if a queryError is returned', async () => {
+    const errorWrapper = mount( ErrorComponent );
+    await wait( 0 );
+    errorWrapper.update();
+
+    const apolloError = errorWrapper.find( 'ApolloError' );
+    const msg = 'There was an error.';
+
+    expect( apolloError.exists() ).toEqual( true );
+    expect( apolloError.contains( msg ) ).toEqual( true );
+  } );
+
+  it( 'renders the final state without crashing', async () => {
+    await wait( 0 );
+    wrapper.update();
+    const pkgEdit = wrapper.find( 'PackageEdit' );
+
+    expect( pkgEdit.exists() ).toEqual( true );
+  } );
+
+  it( 'renders the Action buttons', async () => {
+    await wait( 0 );
+    wrapper.update();
+
+    const actionButtons = wrapper.find( 'ActionButtons' );
+    const btns = ['Delete Package', 'Save & Exit', 'Publish'];
+
+    btns.forEach( b => {
+      const btn = getBtn( b, actionButtons );
+      expect( btn.exists() ).toEqual( true );
+      if ( b === 'Publish' ) {
+        expect( btn.prop( 'disabled' ) ).toEqual( true );
+      } else {
+        expect( btn.prop( 'disabled' ) ).toEqual( undefined );
+      }
+    } );
+  } );
+
+  it( 'renders the PackageDetailsFormContainer', async () => {
+    await wait( 0 );
+    wrapper.update();
+    const pkgFormContainer = wrapper.find( 'PackageDetailsFormContainer' );
+    const { pkg } = noDocumentsMocks[0].result.data;
+
+    expect( pkgFormContainer.exists() ).toEqual( true );
+    expect( pkgFormContainer.prop( 'pkg' ) ).toEqual( pkg );
+    expect( typeof pkgFormContainer.prop( 'updateNotification' ) )
+      .toEqual( 'function' );
+    expect( pkgFormContainer.prop( 'updateNotification' ).name )
+      .toEqual( 'updateNotification' );
+    expect( typeof pkgFormContainer.prop( 'setIsFormValid' ) )
+      .toEqual( 'function' );
+    expect( pkgFormContainer.prop( 'setIsFormValid' ).name )
+      .toEqual( 'bound dispatchAction' );
+    expect( pkgFormContainer.prop( 'hasInitialUploadCompleted' ) )
+      .toEqual( router.query.action !== 'create' );
+  } );
+
+  it( 'renders ButtonPublish', async () => {
+    await wait( 0 );
+    wrapper.update();
+
+    const buttonPublish = wrapper.find( 'ButtonPublish' );
+    const { pkg } = mocks[0].result.data;
+
+    expect( buttonPublish.exists() ).toEqual( true );
+    expect( buttonPublish.prop( 'status' ) ).toEqual( pkg.status );
+    expect( buttonPublish.prop( 'publishing' ) ).toEqual( undefined );
+    expect( buttonPublish.prop( 'updated' ) )
+      .toEqual( pkg.status === 'PUBLISHED' );
+    expect( buttonPublish.prop( 'disabled' ) )
+      .toEqual( !!pkg.documents.length );
+    expect( buttonPublish.prop( 'handlePublish' ).name )
+      .toEqual( 'handlePublish' );
+    expect( buttonPublish.prop( 'handleUnPublish' ).name )
+      .toEqual( 'handleUnPublish' );
+  } );
+
+  it( 'renders ApolloError with an empty error prop', async () => {
+    await wait( 0 );
+    wrapper.update();
+    const apolloErrors = wrapper.find( 'ApolloError' );
+
+    expect( apolloErrors.exists() ).toEqual( true );
+    expect( apolloErrors.length ).toEqual( 2 );
+    apolloErrors.forEach( error => {
+      expect( error.prop( 'error' ) ).toEqual( {} );
+    } );
+  } );
+
+  it( 'renders Notification with the correct initial props', async () => {
+    await wait( 0 );
+    wrapper.update();
+    const notification = wrapper.find( 'Notification' );
+
+    expect( notification.exists() ).toEqual( true );
+    expect( notification.props() ).toEqual( {
+      el: 'p',
+      customStyles: {
+        position: 'absolute',
+        top: '9em',
+        left: '50%',
+        transform: 'translateX(-50%)'
+      },
+      show: false,
+      msg: ''
+    } );
+  } );
+} );
+
+describe( '<PackageEdit />, if there are no documents', () => {
   const router = {
     push: jest.fn(),
     query: {
@@ -400,8 +539,13 @@ describe( '<PackageEdit />, if there are no documents,', () => {
     console.error = consoleError;
   } );
 
+  let wrapper;
+
+  beforeEach( () => {
+    wrapper = mount( Component );
+  } );
+
   it( 'renders initial loading state without crashing', () => {
-    const wrapper = mount( Component );
     const pkgEdit = wrapper.find( 'PackageEdit' );
     const loader = wrapper.find( 'Loader' );
     const msg = 'Loading package details page...';
@@ -412,11 +556,11 @@ describe( '<PackageEdit />, if there are no documents,', () => {
   } );
 
   it( 'renders error message if a queryError is returned', async () => {
-    const wrapper = mount( ErrorComponent );
+    const errorWrapper = mount( ErrorComponent );
     await wait( 0 );
-    wrapper.update();
+    errorWrapper.update();
 
-    const apolloError = wrapper.find( 'ApolloError' );
+    const apolloError = errorWrapper.find( 'ApolloError' );
     const msg = 'There was an error.';
 
     expect( apolloError.exists() ).toEqual( true );
@@ -424,7 +568,6 @@ describe( '<PackageEdit />, if there are no documents,', () => {
   } );
 
   it( 'renders the final state without crashing', async () => {
-    const wrapper = mount( Component );
     await wait( 0 );
     wrapper.update();
     const pkgEdit = wrapper.find( 'PackageEdit' );
@@ -433,7 +576,6 @@ describe( '<PackageEdit />, if there are no documents,', () => {
   } );
 
   it( 'renders the ProjectHeader', async () => {
-    const wrapper = mount( Component );
     await wait( 0 );
     wrapper.update();
 
@@ -446,17 +588,31 @@ describe( '<PackageEdit />, if there are no documents,', () => {
     expect( projectHeader.contains( title ) ).toEqual( true );
   } );
 
-  it( 'does not render PackageActions', async () => {
-    const wrapper = mount( Component );
+  it( 'renders the Delete Package button', async () => {
     await wait( 0 );
     wrapper.update();
-    const pkgActions = wrapper.find( 'PackageActions' );
 
-    expect( pkgActions.exists() ).toEqual( false );
+    const actionButtons = wrapper.find( 'ActionButtons' );
+    const deleteBtn = getBtn( 'Delete Package', actionButtons );
+
+    expect( deleteBtn.exists() ).toEqual( true );
+    expect( deleteBtn.prop( 'disabled' ) ).toEqual( undefined );
+  } );
+
+  it( 'does not render the Save, Publish Changes, Publish, & Unpublish buttons', async () => {
+    await wait( 0 );
+    wrapper.update();
+
+    const actionButtons = wrapper.find( 'ActionButtons' );
+    const unrenderedBtns = ['Save & Exit', 'Publish Changes', 'Publish', 'Unpublish'];
+
+    unrenderedBtns.forEach( b => {
+      const btn = getBtn( b, actionButtons );
+      expect( btn.exists() ).toEqual( false );
+    } );
   } );
 
   it( 'renders the PackageDetailsFormContainer', async () => {
-    const wrapper = mount( Component );
     await wait( 0 );
     wrapper.update();
     const pkgFormContainer = wrapper.find( 'PackageDetailsFormContainer' );
@@ -468,26 +624,27 @@ describe( '<PackageEdit />, if there are no documents,', () => {
       .toEqual( 'function' );
     expect( pkgFormContainer.prop( 'updateNotification' ).name )
       .toEqual( 'updateNotification' );
-    expect( typeof pkgFormContainer.prop( 'setIsDirty' ) )
+    expect( typeof pkgFormContainer.prop( 'setIsFormValid' ) )
       .toEqual( 'function' );
-    expect( pkgFormContainer.prop( 'setIsDirty' ).name )
+    expect( pkgFormContainer.prop( 'setIsFormValid' ).name )
       .toEqual( 'bound dispatchAction' );
     expect( pkgFormContainer.prop( 'hasInitialUploadCompleted' ) )
       .toEqual( router.query.action !== 'create' );
   } );
 
   it( 'renders ApolloError with an empty error prop', async () => {
-    const wrapper = mount( Component );
     await wait( 0 );
     wrapper.update();
-    const apolloError = wrapper.find( 'ApolloError' );
+    const apolloErrors = wrapper.find( 'ApolloError' );
 
-    expect( apolloError.exists() ).toEqual( true );
-    expect( apolloError.prop( 'error' ) ).toEqual( {} );
+    expect( apolloErrors.exists() ).toEqual( true );
+    expect( apolloErrors.length ).toEqual( 2 );
+    apolloErrors.forEach( error => {
+      expect( error.prop( 'error' ) ).toEqual( {} );
+    } );
   } );
 
   it( 'renders Notification with the correct initial props', async () => {
-    const wrapper = mount( Component );
     await wait( 0 );
     wrapper.update();
     const notification = wrapper.find( 'Notification' );

--- a/components/admin/PackageEdit/PackageFiles/PackageFiles.js
+++ b/components/admin/PackageEdit/PackageFiles/PackageFiles.js
@@ -67,7 +67,9 @@ const PackageFiles = props => {
       </div>
 
       { !units.length && (
-        <div style={ { marginTop: '1em' } }>This package does not have any uploaded files.</div>
+        <p style={ { marginTop: '1em', maxWidth: '55ch' } }>
+          This package does not have any uploaded files. Please upload at least one file to publish this package to Content Commons.
+        </p>
       ) }
 
       <div className="files">

--- a/components/admin/PackageEdit/PackageFiles/PackageFiles.test.js
+++ b/components/admin/PackageEdit/PackageFiles/PackageFiles.test.js
@@ -18,8 +18,6 @@ jest.mock( 'lib/hooks/useCrudActionsDocument', () => ( {
 
 jest.mock( 'next/config', () => ( { publicRuntimeConfig: { REACT_APP_AWS_S3_AUTHORING_BUCKET: 's3-bucket-url' } } ) );
 
-const Component = <PackageFiles { ...props } />;
-
 describe( '<PackageFiles />', () => {
   /**
    * @todo Suppress React 16.8 `act()` warnings globally.
@@ -40,15 +38,19 @@ describe( '<PackageFiles />', () => {
     console.error = consoleError;
   } );
 
-  it( 'renders without crashing', () => {
-    const wrapper = mount( Component );
+  let Component;
+  let wrapper;
 
+  beforeEach( () => {
+    Component = <PackageFiles { ...props } />;
+    wrapper = mount( Component );
+  } );
+
+  it( 'renders without crashing', () => {
     expect( wrapper.exists() ).toEqual( true );
   } );
 
   it( 'renders the correct PressPackageFile components with correct document prop', () => {
-    const wrapper = mount( Component );
-
     const pressPkgFiles = wrapper.find( 'Press-Package-File' );
     const { documents } = props.pkg;
 
@@ -59,7 +61,6 @@ describe( '<PackageFiles />', () => {
   } );
 
   it( 'renders the correct heading', () => {
-    const wrapper = mount( Component );
     const { documents } = props.pkg;
     const heading = `Uploaded File${documents.length > 1 ? 's' : ''} (${documents.length})`;
 
@@ -67,7 +68,6 @@ describe( '<PackageFiles />', () => {
   } );
 
   it( 'renders EditPackageFiles with correct props', () => {
-    const wrapper = mount( Component );
     const editPkgFiles = wrapper.find( 'EditPackageFiles' );
     const units = props.pkg.documents || [];
 
@@ -84,7 +84,6 @@ describe( '<PackageFiles />', () => {
   } );
 
   it( 'EditPackageFiles trigger/onClose opens/closes the modal', () => {
-    const wrapper = mount( Component );
     const editPkgFiles = () => wrapper.find( 'EditPackageFiles' );
     const trigger = mount( editPkgFiles().prop( 'trigger' ) );
 
@@ -103,16 +102,20 @@ describe( '<PackageFiles />', () => {
   } );
 
   it( 'renders null if !hasInitialUploadCompleted', () => {
-    const wrapper = mount( Component );
     wrapper.setProps( { hasInitialUploadCompleted: false } );
-
     expect( wrapper.html() ).toEqual( null );
   } );
 
   it( 'renders null if pkg === {}', () => {
-    const wrapper = mount( Component );
     wrapper.setProps( { pkg: {} } );
-
     expect( wrapper.html() ).toEqual( null );
+  } );
+
+  it( 'renders the no files message and heading if there are no package documents', () => {
+    const msg = 'This package does not have any uploaded files. Please upload at least one file to publish this package to Content Commons.';
+    wrapper.setProps( { pkg: { documents: [] } } );
+
+    expect( wrapper.contains( 'Uploaded File (0)' ) ).toEqual( true );
+    expect( wrapper.contains( msg ) ).toEqual( true );
   } );
 } );


### PR DESCRIPTION
* Publish and Publish Changes buttons are disabled if a package has no files
* Added a message that at least one file must be uploaded before publishing to Content Commons
* Updated tests for PackageEdit, PackageFiles, and ButtonPublish