### PR TITLE
CDP 1814 - Dashboard Pagination

### DIFF
--- a/components/ScrollableTableWithMenu/TableActionsMenu/TableActionsMenu.js
+++ b/components/ScrollableTableWithMenu/TableActionsMenu/TableActionsMenu.js
@@ -22,10 +22,12 @@ const CONFIRMATION_MSG_DELAY = 3000;
 
 const getDraftProjects = projects => {
   if ( !projects ) return [];
+
   return projects.reduce( ( acc, curr ) => {
     if ( curr.status === 'DRAFT' ) {
       return [...acc, curr.id];
     }
+
     return [...acc];
   }, [] );
 };
@@ -69,8 +71,10 @@ const TableActionsMenu = props => {
   const [actionFailures, setActionFailures] = useState( [] );
 
   const [isMounted, setIsMounted] = useState( false );
+
   useEffect( () => {
     setIsMounted( true );
+
     return () => setIsMounted( false );
   }, [isMounted] );
 
@@ -113,6 +117,7 @@ const TableActionsMenu = props => {
 
   const handleActionCompleted = () => {
     const { variables } = props;
+
     dashboardProjectsRefetch( { ...variables } );
     dashboardProjectsCountRefetch( {
       team: variables.team,
@@ -123,31 +128,40 @@ const TableActionsMenu = props => {
 
   const transformSelectedItemsMap = () => {
     const { selectedItems } = props;
+
     if ( selectedItems.size === 0 ) return [];
     const arr = [];
+
     selectedItems.forEach( ( value, key ) => arr.push( { id: key, value } ) );
+
     return arr;
   };
 
   const getSelectedProjectsIds = () => {
     const projectsArr = transformSelectedItemsMap();
+
     if ( projectsArr && projectsArr.length ) {
       return projectsArr.reduce( ( acc, curr ) => {
         if ( curr.value ) {
           return [...acc, curr.id];
         }
+
         return [...acc];
       }, [] );
     }
+
     return [];
   };
 
   const getSelectedProjects = projects => {
     const projectIds = getSelectedProjectsIds();
+
     if ( projects && projects.length ) {
       const selections = projectIds.map( s => projects.find( p => s === p.id ) );
+
       return selections;
     }
+
     return [];
   };
 
@@ -158,6 +172,7 @@ const TableActionsMenu = props => {
     if ( selections.length > 0 ) {
       return selections.every( id => draftProjects.includes( id ) );
     }
+
     return false;
   };
 
@@ -168,6 +183,7 @@ const TableActionsMenu = props => {
 
   const getProjectsOnPage = projects => {
     const { first, skip } = props.variables;
+
     return projects && projects.slice( skip, skip + first );
   };
 

--- a/components/ScrollableTableWithMenu/TableBody/TableBody.js
+++ b/components/ScrollableTableWithMenu/TableBody/TableBody.js
@@ -18,10 +18,11 @@ import './TableBody.scss';
 const normalizeTypesData = type => {
   const thumbnail = () => {
     if ( !type.thumbnails ) return {};
-    return ( {
+
+    return {
       signedUrl: type.thumbnails && type.thumbnails.length ? type.thumbnails[0].signedUrl : '',
       alt: type.thumbnails && type.thumbnails.length ? type.thumbnails[0].alt : ''
-    } );
+    };
   };
 
   const normalizedTypeData = Object.create( {}, {
@@ -37,29 +38,43 @@ const normalizeTypesData = type => {
     thumbnail: { value: thumbnail() },
     categories: { value: getLangTaxonomies( type.categories ) }
   } );
+
   return normalizedTypeData;
 };
 
 const normalizeDashboardData = types => {
   const normalizedProjects = [];
+
   types.forEach( type => normalizedProjects.push( normalizeTypesData( type ) ) );
+
   return normalizedProjects;
 };
 
-const updateProjectStatus = dashboardProjectsType => ( prev, { subscriptionData: { data: { projectStatusChange } } } ) => {
+const updateProjectStatus = dashboardProjectsType => ( prev, {
+  subscriptionData: { data: { projectStatusChange } }
+} ) => {
   if ( !projectStatusChange ) {
     return prev;
   }
   const projectIndex = prev[dashboardProjectsType].findIndex( p => p.id === projectStatusChange.id );
+
   if ( projectIndex === -1 ) {
     return prev;
   }
+
   // Using immutability helper in order to ensure that React will rerender after the status change
-  return update( prev, { [dashboardProjectsType]: { [projectIndex]: { status: { $set: projectStatusChange.status } } } } );
+  return update( prev, {
+    [dashboardProjectsType]: {
+      [projectIndex]: {
+        status: { $set: projectStatusChange.status }
+      }
+    }
+  } );
 };
 
 const TableBody = props => {
   const {
+    direction,
     searchTerm,
     selectedItems,
     tableHeaders,
@@ -80,7 +95,7 @@ const TableBody = props => {
 
   // Run Query
   const {
-    loading, error, data,
+    loading, error, data
   } = useQuery( graphQuery, {
     variables: { ...variables },
     notifyOnNetworkStatusChange: true,
@@ -93,8 +108,10 @@ const TableBody = props => {
   // Set dashboard projects data & ID's for status subscription
   const setDashboardProjectsData = () => {
     let projectsData;
+
     if ( dashboardProjectsType === 'videoProjects' ) projectsData = data.videoProjects;
     if ( dashboardProjectsType === 'packages' ) projectsData = data.packages;
+
     return projectsData || null;
   };
   const dashboardProjects = setDashboardProjectsData();
@@ -105,18 +122,20 @@ const TableBody = props => {
 
   // Sort data by clicked column & direction
   // Default sort by createdAt & DESC
-  const direction = props.direction ? `${props.direction === 'ascending' ? 'asc' : 'desc'}` : 'desc';
+  const order = direction ? `${direction === 'ascending' ? 'asc' : 'desc'}` : 'desc';
 
   const tableData = orderBy(
     normalizeDashboardData( dashboardProjects ),
     tableDatum => {
       let { column } = props;
+
       if ( !column ) column = 'createdAt';
       // Format table data for case insensitive sorting
       const formattedTableDatum = tableDatum[column].toString().toLowerCase();
+
       return formattedTableDatum;
     },
-    [direction]
+    [order]
   );
 
   // skip & first query vars are used as start/end slice() params to paginate tableData on client
@@ -149,7 +168,7 @@ TableBody.propTypes = {
   variables: PropTypes.object,
   direction: PropTypes.string,
   projectTab: PropTypes.string,
-  team: PropTypes.object,
+  team: PropTypes.object
 };
 
 export default TableBody;

--- a/components/ScrollableTableWithMenu/TableHeader/TableHeader.js
+++ b/components/ScrollableTableWithMenu/TableHeader/TableHeader.js
@@ -17,6 +17,7 @@ const TableHeader = props => {
     handleSort,
     displayActionsMenu
   } = props;
+
   return (
     <Table.Header>
       <Table.Row>

--- a/lib/graphql/queries/package.js
+++ b/lib/graphql/queries/package.js
@@ -174,9 +174,14 @@ export const PACKAGE_FILES_QUERY = gql`
 
 export const TEAM_PACKAGES_QUERY = gql`
   query TeamPackagesQuery(
-    $team: String!, $searchTerm: String
+    $team: String!,
+    $searchTerm: String,
+    $first: Int,
+    $skip: Int,
   ){
     packages(
+      first: $first,
+      skip: $skip,
       where: {
         AND: [
           { team: { name: $team } },

--- a/lib/graphql/queries/package.js
+++ b/lib/graphql/queries/package.js
@@ -178,10 +178,12 @@ export const TEAM_PACKAGES_QUERY = gql`
     $searchTerm: String,
     $first: Int,
     $skip: Int,
+    $orderBy: PackageOrderByInput
   ){
     packages(
       first: $first,
       skip: $skip,
+      orderBy: $orderBy,
       where: {
         AND: [
           { team: { name: $team } },

--- a/lib/graphql/queries/video.js
+++ b/lib/graphql/queries/video.js
@@ -360,9 +360,16 @@ export const VIDEO_PROJECT_QUERY = gql`
 
 export const TEAM_VIDEO_PROJECTS_QUERY = gql`
   query VideoProjectsByTeam(
-    $team: String!, $searchTerm: String
+    $team: String!,
+    $searchTerm: String,
+    $first: Int,
+    $skip: Int,
+    $orderBy: VideoProjectOrderByInput
   ) {
     videoProjects(
+      first: $first,
+      skip: $skip,
+      orderBy: $orderBy,
       where: {
         AND: [
           { team: { name: $team } },

--- a/package-lock.json
+++ b/package-lock.json
@@ -3015,10 +3015,17 @@
       }
     },
     "@gpa-lab/eslint-config": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@gpa-lab/eslint-config/-/eslint-config-1.1.0.tgz",
-      "integrity": "sha512-KsTpYDgdWAK51R0JMg/VYC9QAMWvLDaD/rHMir8QOtynq0sz3/AlB9wKUlyHwsMbSQZ3a+GureAHyXVXrserbw==",
-      "dev": true
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@gpa-lab/eslint-config/-/eslint-config-1.1.2.tgz",
+      "integrity": "sha512-/IFo33Jd72VK+K+c96Wsbrxoe3640wrdbUQLO0r38LlNdWbpjhMG4H0y1Y+wpzowtONxNYB5E5NU/nj2rQoWgQ==",
+      "dev": true,
+      "requires": {
+        "eslint-plugin-jsx-a11y": "^6.2.3",
+        "eslint-plugin-prettier": "^3.1.2",
+        "eslint-plugin-react": "^7.17.0",
+        "eslint-plugin-react-hooks": "^2.3.0",
+        "prettier": "^1.19.1"
+      }
     },
     "@istanbuljs/load-nyc-config": {
       "version": "1.0.0",
@@ -7821,6 +7828,16 @@
         "jsx-ast-utils": "^2.2.1"
       }
     },
+    "eslint-plugin-prettier": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-3.1.3.tgz",
+      "integrity": "sha512-+HG5jmu/dN3ZV3T6eCD7a4BlAySdN7mLIbJYo0z1cFQuI+r2DiTJEFeF68ots93PsnrMxbzIZ2S/ieX+mkrBeQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "prettier-linter-helpers": "^1.0.0"
+      }
+    },
     "eslint-plugin-react": {
       "version": "7.19.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.19.0.tgz",
@@ -8463,6 +8480,13 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
       "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
+    },
+    "fast-diff": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.2.0.tgz",
+      "integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==",
+      "dev": true,
+      "optional": true
     },
     "fast-glob": {
       "version": "3.1.0",
@@ -17614,6 +17638,23 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
       "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw="
+    },
+    "prettier": {
+      "version": "1.19.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
+      "integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==",
+      "dev": true,
+      "optional": true
+    },
+    "prettier-linter-helpers": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
+      "integrity": "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "fast-diff": "^1.1.2"
+      }
     },
     "pretty-format": {
       "version": "25.3.0",

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "@babel/plugin-proposal-optional-chaining": "^7.7.5",
     "@babel/traverse": "^7.7.2",
     "@babel/types": "^7.7.2",
-    "@gpa-lab/eslint-config": "^1.1.0",
+    "@gpa-lab/eslint-config": "^1.1.2",
     "babel-eslint": "^10.0.3",
     "babel-jest": "^25.3.0",
     "babel-plugin-graphql-tag": "^2.5.0",


### PR DESCRIPTION
Passes the first, skip, and orderBy values to the queries `VideoProjectsByTeam` and `TeamPackagesQuery`. This allows for sorting and pagination to occur on the server rather than on the client after all results are returned.

However, special accommodations must be made to handle sorting of the author column because it is not possible to order by a nested property (i.e. the author returns a User type rather than a scalar name). As such, when sorting by author pagination props are not sent to the server, resulting in an overfetch which is then sorted on the client (line 127-152 of `TableBody.js`).

In order to take effect, these changes require analogous edits to the resolvers in the content-commons-server, which can be found a pull request with the same name in that repo.

Did not fix broken tests ☹️ .

Also bumps ESLint config version to latest to account for changes I made in a couple rules.