### PR TITLE
[HOT FIX] CDP 1833 - Add link to press guidance archive

### DIFF
--- a/components/Featured/Packages/Packages.js
+++ b/components/Featured/Packages/Packages.js
@@ -47,7 +47,7 @@ const Packages = props => {
             </Grid.Column>
           ) ) }
         </Grid>
-        <p className="latestPackages_guidance_link">For press guidance and releases from before 04/27/2020, please visit the <a href={ config.PRESS_GUIDANCE_DB_URL }>archived press guidance database</a>.</p>
+        <p className="latestPackages_guidance_link">For press guidance and releases from before 04/27/2020, please visit the <a href={ config.PRESS_GUIDANCE_DB_URL } rel="noopener noreferrer" target="_blank">archived press guidance database</a>.</p>
       </div>
     </section>
   );

--- a/components/Featured/Packages/Packages.js
+++ b/components/Featured/Packages/Packages.js
@@ -3,7 +3,10 @@ import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import Link from 'next/link';
 import { Grid, Message } from 'semantic-ui-react';
+
+import config from 'config';
 import PackageCard from 'components/Package/PackageCard/PackageCard';
+
 import './Packages.scss';
 
 const renderError = () => (
@@ -44,7 +47,7 @@ const Packages = props => {
             </Grid.Column>
           ) ) }
         </Grid>
-        <p className="latestPackages_guidance_link">For press guidance and releases from before 04/27/2020, please visit the <a href="https://pressguidance2.state.gov/">archived press guidance database</a>.</p>
+        <p className="latestPackages_guidance_link">For press guidance and releases from before 04/27/2020, please visit the <a href={ config.PRESS_GUIDANCE_DB_URL }>archived press guidance database</a>.</p>
       </div>
     </section>
   );

--- a/components/Featured/Packages/Packages.js
+++ b/components/Featured/Packages/Packages.js
@@ -44,6 +44,7 @@ const Packages = props => {
             </Grid.Column>
           ) ) }
         </Grid>
+        <p className="latestPackages_guidance_link">For press guidance and releases from before 04/27/2020, please visit the <a href="https://pressguidance2.state.gov/">archived press guidance database</a>.</p>
       </div>
     </section>
   );

--- a/components/Featured/Packages/Packages.scss
+++ b/components/Featured/Packages/Packages.scss
@@ -56,6 +56,11 @@
     }
   }
 
+  &_guidance_link {
+    font-size: 14px;
+    padding-top: 1.5em;
+  }
+
   &_header {
     display: flex;
     justify-content: space-between;

--- a/components/Footer/Footer.js
+++ b/components/Footer/Footer.js
@@ -62,7 +62,7 @@ const Footer = () => {
         <List horizontal divided className="footer-nav">
           { user && (
             <List.Item>
-              <a className="footer_link" href={ config.PRESS_GUIDANCE_DB_URL }>Archived Press Guidance</a>
+              <a className="footer_link" href={ config.PRESS_GUIDANCE_DB_URL }rel="noopener noreferrer" target="_blank">Archived Press Guidance</a>
             </List.Item>
           ) }
           { menuItems.map( item => (

--- a/components/Footer/Footer.js
+++ b/components/Footer/Footer.js
@@ -62,7 +62,7 @@ const Footer = () => {
         <List horizontal divided className="footer-nav">
           { user && (
             <List.Item>
-              <a className="footer_link" href={ config.PRESS_GUIDANCE_DB_URL }rel="noopener noreferrer" target="_blank">Archived Press Guidance</a>
+              <a className="footer_link" href={ config.PRESS_GUIDANCE_DB_URL } rel="noopener noreferrer" target="_blank">Archived Press Guidance</a>
             </List.Item>
           ) }
           { menuItems.map( item => (

--- a/components/Footer/Footer.js
+++ b/components/Footer/Footer.js
@@ -61,7 +61,7 @@ const Footer = () => {
         </Header>
         <List horizontal divided className="footer-nav">
           { user && (
-            <List.Item key="pressguidance">
+            <List.Item>
               <a className="footer_link" href={ config.PRESS_GUIDANCE_DB_URL }>Archived Press Guidance</a>
             </List.Item>
           ) }

--- a/components/Footer/Footer.js
+++ b/components/Footer/Footer.js
@@ -52,7 +52,7 @@ const Footer = () => {
         </p>
       </div>
       <Container text className="footer-content">
-        <Header as="h1">
+        <Header as="div">
           <Header.Subheader className="subtitle">
             Join the conversation on{ ' ' }
             <img src={ slackLogo } alt="Slack" className="footer_img footer_img--slack" />{ ' ' }
@@ -73,7 +73,7 @@ const Footer = () => {
             </List.Item>
           ) ) }
         </List>
-        <Header as="h1">
+        <Header as="div">
           <Header.Subheader className="subtext">
             Can&apos;t find what you are looking for? To ask questions or provide feedback send us
             an email at <a href="mailto:design@america.gov">design@america.gov</a>.

--- a/components/Footer/Footer.js
+++ b/components/Footer/Footer.js
@@ -1,7 +1,10 @@
 import React from 'react';
 import Link from 'next/link';
 import { Container, Header, List } from 'semantic-ui-react';
+
 import config from 'config';
+import { useAuth } from 'context/authContext';
+
 import slackLogo from 'static/images/logo_slack.png';
 import flagImage from 'static/images/flag.jpg';
 import DosSeal from 'static/images/dos_seal.svg';
@@ -9,17 +12,9 @@ import DosSeal from 'static/images/dos_seal.svg';
 import './Footer.scss';
 
 const Footer = () => {
+  const { user } = useAuth();
+
   const menuItems = [
-    {
-      name: 'home',
-      to: '/',
-      label: 'Content Commons'
-    },
-    // {
-    //   name: 'developer',
-    //   to: '#',
-    //   label: 'Developer Tools'
-    // },
     {
       name: 'privacy',
       to: '/privacy',
@@ -35,16 +30,6 @@ const Footer = () => {
       to: '/documentation',
       label: 'Documentation'
     }
-    // {
-    //   name: 'tos',
-    //   to: 'tos',
-    //   label: 'Terms of Service'
-    // },
-    // {
-    //   name: 'sitemap',
-    //   to: 'sitemap',
-    //   label: 'Sitemap'
-    // }
   ];
   return (
     <footer className="ui">
@@ -75,6 +60,11 @@ const Footer = () => {
           </Header.Subheader>
         </Header>
         <List horizontal divided className="footer-nav">
+          { user && (
+            <List.Item key="pressguidance">
+              <a className="footer_link" href={ config.PRESS_GUIDANCE_DB_URL }>Archived Press Guidance</a>
+            </List.Item>
+          ) }
           { menuItems.map( item => (
             <List.Item key={ item.name }>
               <Link href={ item.to }>

--- a/components/Footer/Footer.scss
+++ b/components/Footer/Footer.scss
@@ -94,7 +94,7 @@ footer {
     padding: 2em 0;
   }
 
-  h1.ui.header {
+  div.ui.header {
     color: #fff;
     font-weight: normal;
 

--- a/components/Footer/Footer.test.js
+++ b/components/Footer/Footer.test.js
@@ -1,0 +1,47 @@
+import { shallow } from 'enzyme';
+
+import Footer from './Footer';
+
+jest.mock( 'next/config', () => () => ( {
+  publicRuntimeConfig: {
+    PRESS_GUIDANCE_DB_URL: 'press-guidances'
+  }
+} ) );
+
+jest.mock( 'context/authContext', () => ( {
+  useAuth: jest
+    .fn( () => ( { user: null } ) )
+    .mockImplementationOnce( () => ( { user: true } ) )
+} ) );
+
+describe( '<Footer />', () => {
+  const pressLinkText = [expect.stringMatching( 'Archived Press Guidance' )];
+
+  it( 'renders proper list of links when user is logged in', () => {
+    const wrapper = shallow( <Footer /> );
+
+    const list = wrapper.find( 'ListItem' );
+
+    const links = wrapper.find( 'a.footer_link' ).getElements();
+    const linkTextArr = links.map( link => link.props.children );
+
+    expect( list ).toHaveLength( 4 );
+    expect( linkTextArr ).toEqual(
+      expect.arrayContaining( pressLinkText )
+    );
+  } );
+
+  it( 'renders proper list of links when user is logged out', () => {
+    const wrapper = shallow( <Footer /> );
+
+    const list = wrapper.find( 'ListItem' );
+
+    const links = wrapper.find( 'a.footer_link' ).getElements();
+    const linkTextArr = links.map( link => link.props.children );
+
+    expect( list ).toHaveLength( 3 );
+    expect( linkTextArr ).toEqual(
+      expect.not.arrayContaining( pressLinkText )
+    );
+  } );
+} );

--- a/config.js
+++ b/config.js
@@ -19,5 +19,6 @@ export default {
   EMAIL: 'design@america.gov',
   ERROR_MESSAGE: 'Oops! Something went wrong. If this issue persists, please email the IIP Office of Design',
   TIME_TO_STALE: 300000, // 5 minutes in milliseconds
-  FEEDBACK_FORM_URL: 'https://goo.gl/forms/9cJ3IBHH9QTld2Mj2'
+  FEEDBACK_FORM_URL: 'https://goo.gl/forms/9cJ3IBHH9QTld2Mj2',
+  PRESS_GUIDANCE_DB_URL: 'https://pressguidance2.state.gov/'
 };


### PR DESCRIPTION
1. Adds a link to the press guidance archive to the bottom of the featured packages box
1. Conditionally adds a similar link to the footer, only displaying the link if the user is logged in
1. Adds tests for footer component 🎉
1. Replaces h1 elements in the footer with divs in the interest of improved accessibility

I did not write tests for the `Packages` component because they would require on `redux-mock-store` as a dependency. This dependency has been added on the develop branch but hasn't made it to the master branch yet. For this reason, and because it is a pretty trivial change, I plan to write the accompanying `Packages` tests when I merge the hotfix back into develop.

