### PR TITLE
CDP-2021 (HOTFIX)

### DIFF
--- a/components/Meta.js
+++ b/components/Meta.js
@@ -1,38 +1,25 @@
 import Head from 'next/head';
 import React from 'react';
 import PropTypes from 'prop-types';
-import getConfig from 'next/config';
-
-const {
-  publicRuntimeConfig: {
-    REACT_APP_GOOGLE_ANALYTICS_ID
-  }
-} = getConfig();
 
 const Meta = props => (
   <Head>
-    <script
-      async
-      src={ `https://www.googletagmanager.com/gtag/js?id=${REACT_APP_GOOGLE_ANALYTICS_ID}` }
-    />
-    { /* eslint-disable-next-line */ }
-    <script dangerouslySetInnerHTML={ {
+    <script dangerouslySetInnerHTML={{
       __html: `
-      window.dataLayer = window.dataLayer || [];
-      function gtag() { dataLayer.push( arguments ); }
-      gtag( 'js', new Date() );
-      gtag( 'config', '${REACT_APP_GOOGLE_ANALYTICS_ID}', {
-        page_path: window.location.pathname,
-      } );
-    `
-    } }
+      (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+      new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+      j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+      'https://www.googletagmanager.com/gtm.js?id='+i+dl+ '&gtm_auth=l-Fvm9iNgppOq80TmTKskg&gtm_preview=env-2&gtm_cookies_win=x';f.parentNode.insertBefore(j,f);
+      })(window,document,'script','dataLayer','GTM-NTQJVZD');
+        `
+    }}
     />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta charSet="utf-8" />
     <meta property="og:site_name" content="Content Commons" />
     <link rel="shortcut icon" href="/static/favicon.ico" />
     <link rel="stylesheet" type="text/css" href="/static/css/nprogress.css" />
-    <title>{ props.title }</title>
+    <title>{props.title}</title>
   </Head>
 );
 

--- a/components/Meta.js
+++ b/components/Meta.js
@@ -5,28 +5,28 @@ import getConfig from 'next/config';
 
 const {
   publicRuntimeConfig: {
-    REACT_APP_GOOGLE_ANALYTICS_ID
-  }
+    REACT_APP_GOOGLE_ANALYTICS_ID,
+  },
 } = getConfig();
 
-const Meta = props => (
+const Meta = ( { title } ) => (
   <Head>
-    <script dangerouslySetInnerHTML={{
+    <script dangerouslySetInnerHTML={ {
       __html: `
-      (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-      new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-      j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-      'https://www.googletagmanager.com/gtm.js?id='+i+dl+ '&gtm_auth=${REACT_APP_GOOGLE_ANALYTICS_ID}&gtm_cookies_win=x';f.parentNode.insertBefore(j,f);
-      })(window,document,'script','dataLayer','GTM-NTQJVZD');
-        `
-    }}
+        (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+        new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+        j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+        'https://www.googletagmanager.com/gtm.js?id='+i+dl+ '&gtm_auth=${REACT_APP_GOOGLE_ANALYTICS_ID}&gtm_cookies_win=x';f.parentNode.insertBefore(j,f);
+        })(window,document,'script','dataLayer','GTM-NTQJVZD');
+      `
+    } }
     />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta charSet="utf-8" />
     <meta property="og:site_name" content="Content Commons" />
     <link rel="shortcut icon" href="/static/favicon.ico" />
     <link rel="stylesheet" type="text/css" href="/static/css/nprogress.css" />
-    <title>{props.title}</title>
+    <title>{ title }</title>
   </Head>
 );
 

--- a/components/Meta.js
+++ b/components/Meta.js
@@ -1,6 +1,13 @@
 import Head from 'next/head';
 import React from 'react';
 import PropTypes from 'prop-types';
+import getConfig from 'next/config';
+
+const {
+  publicRuntimeConfig: {
+    REACT_APP_GOOGLE_ANALYTICS_ID
+  }
+} = getConfig();
 
 const Meta = props => (
   <Head>
@@ -9,7 +16,7 @@ const Meta = props => (
       (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
       new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
       j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-      'https://www.googletagmanager.com/gtm.js?id='+i+dl+ '&gtm_auth=l-Fvm9iNgppOq80TmTKskg&gtm_preview=env-2&gtm_cookies_win=x';f.parentNode.insertBefore(j,f);
+      'https://www.googletagmanager.com/gtm.js?id='+i+dl+ '&gtm_auth=${REACT_APP_GOOGLE_ANALYTICS_ID}&gtm_cookies_win=x';f.parentNode.insertBefore(j,f);
       })(window,document,'script','dataLayer','GTM-NTQJVZD');
         `
     }}

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -12,25 +12,36 @@ import makeStore from 'lib/redux/store';
 import 'styles/styles.scss';
 
 class Commons extends App {
-  static async getInitialProps( { Component, ctx } ) {
+  componentDidMount() {
+    const noscript = document.createElement("noscript"); // Create the noscript element
+
+    const ga = document.createTextNode(`<iframe src="https://www.googletagmanager.com/ns.html?id=GTM-NTQJVZD&gtm_auth=l-Fvm9iNgppOq80TmTKskg&gtm_preview=env-2&gtm_cookies_win=x"
+    height="0" width="0" style="display:none;visibility:hidden"></iframe>`); // Create the iframe snippet
+
+    noscript.appendChild(ga); // Append the ga iframe snippet to the noscript element
+
+    document.body.appendChild(noscript); // Add the noscript to the body
+  }
+
+  static async getInitialProps({ Component, ctx }) {
     let pageProps = {};
 
     // if user does not have appropriate page permissions redirect 
-    if ( !( await canAccessPage( ctx ) ) ) {
+    if (!(await canAccessPage(ctx))) {
       // only redirect if we are going to login
-      if ( ctx.pathname !== '/login' ) {  
+      if (ctx.pathname !== '/login') {
         // add redirect url as a query param
         // cannot use client side storage or libraries as this is executing on the server 
-        redirectTo( `/login?return=${ctx.asPath}`, ctx );
+        redirectTo(`/login?return=${ctx.asPath}`, ctx);
       }
     }
 
-    if ( Component.getInitialProps ) {
-      pageProps = await Component.getInitialProps( ctx );
+    if (Component.getInitialProps) {
+      pageProps = await Component.getInitialProps(ctx);
     }
 
     // exposes apollo query to component
-    if ( !isEmpty( ctx.query ) ) {
+    if (!isEmpty(ctx.query)) {
       pageProps.query = ctx.query;
     }
 
@@ -43,11 +54,11 @@ class Commons extends App {
     } = this.props;
 
     return (
-      <ApolloProvider client={ apollo }>
+      <ApolloProvider client={apollo}>
         <AuthProvider>
-          <Provider store={ store }>
+          <Provider store={store}>
             <Page>
-              <Component { ...pageProps } />
+              <Component {...pageProps} />
             </Page>
           </Provider>
         </AuthProvider>
@@ -56,4 +67,4 @@ class Commons extends App {
   }
 }
 
-export default withApollo( withRedux( makeStore )( Commons ) );
+export default withApollo(withRedux(makeStore)(Commons));

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -12,17 +12,6 @@ import makeStore from 'lib/redux/store';
 import 'styles/styles.scss';
 
 class Commons extends App {
-  componentDidMount() {
-    const noscript = document.createElement("noscript"); // Create the noscript element
-
-    const ga = document.createTextNode(`<iframe src="https://www.googletagmanager.com/ns.html?id=GTM-NTQJVZD&gtm_auth=l-Fvm9iNgppOq80TmTKskg&gtm_preview=env-2&gtm_cookies_win=x"
-    height="0" width="0" style="display:none;visibility:hidden"></iframe>`); // Create the iframe snippet
-
-    noscript.appendChild(ga); // Append the ga iframe snippet to the noscript element
-
-    document.body.appendChild(noscript); // Add the noscript to the body
-  }
-
   static async getInitialProps({ Component, ctx }) {
     let pageProps = {};
 

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -12,25 +12,25 @@ import makeStore from 'lib/redux/store';
 import 'styles/styles.scss';
 
 class Commons extends App {
-  static async getInitialProps({ Component, ctx }) {
+  static async getInitialProps( { Component, ctx } ) {
     let pageProps = {};
 
     // if user does not have appropriate page permissions redirect 
-    if (!(await canAccessPage(ctx))) {
+    if ( !( await canAccessPage( ctx ) ) ) {
       // only redirect if we are going to login
-      if (ctx.pathname !== '/login') {
+      if ( ctx.pathname !== '/login' ) {
         // add redirect url as a query param
         // cannot use client side storage or libraries as this is executing on the server 
-        redirectTo(`/login?return=${ctx.asPath}`, ctx);
+        redirectTo( `/login?return=${ctx.asPath}`, ctx );
       }
     }
 
-    if (Component.getInitialProps) {
-      pageProps = await Component.getInitialProps(ctx);
+    if ( Component.getInitialProps ) {
+      pageProps = await Component.getInitialProps( ctx );
     }
 
     // exposes apollo query to component
-    if (!isEmpty(ctx.query)) {
+    if ( !isEmpty( ctx.query ) ) {
       pageProps.query = ctx.query;
     }
 
@@ -39,7 +39,7 @@ class Commons extends App {
 
   render() {
     const {
-      Component, apollo, store, pageProps
+      Component, apollo, store, pageProps,
     } = this.props;
 
     return (
@@ -56,4 +56,4 @@ class Commons extends App {
   }
 }
 
-export default withApollo(withRedux(makeStore)(Commons));
+export default withApollo( withRedux( makeStore )( Commons ) );

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -1,0 +1,39 @@
+import Document, {
+  Html, Head, Main, NextScript
+} from 'next/document';
+import getConfig from 'next/config';
+
+const {
+  publicRuntimeConfig: {
+    REACT_APP_GOOGLE_ANALYTICS_ID
+  }
+} = getConfig();
+
+class MyDocument extends Document {
+  static async getInitialProps(ctx) {
+    const initialProps = await Document.getInitialProps(ctx);
+    return { ...initialProps };
+  }
+
+  render() {
+    return (
+      <Html>
+        <Head />
+        <body>
+          <Main />
+          <NextScript />
+          <noscript><iframe
+            src={`https://www.googletagmanager.com/ns.html?id=GTM-NTQJVZD&gtm_auth=${REACT_APP_GOOGLE_ANALYTICS_ID}&gtm_cookies_win=x`}
+            height="0"
+            width="0"
+            style={{ display: 'none', visibility: 'hidden' }}
+            title="Google Analytics"
+          />
+          </noscript>
+        </body>
+      </Html>
+    );
+  }
+}
+
+export default MyDocument;

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -1,17 +1,17 @@
 import Document, {
-  Html, Head, Main, NextScript
+  Html, Head, Main, NextScript,
 } from 'next/document';
 import getConfig from 'next/config';
 
 const {
   publicRuntimeConfig: {
-    REACT_APP_GOOGLE_ANALYTICS_ID
-  }
+    REACT_APP_GOOGLE_ANALYTICS_ID,
+  },
 } = getConfig();
 
 class MyDocument extends Document {
-  static async getInitialProps(ctx) {
-    const initialProps = await Document.getInitialProps(ctx);
+  static async getInitialProps( ctx ) {
+    const initialProps = await Document.getInitialProps( ctx );
     return { ...initialProps };
   }
 
@@ -20,16 +20,17 @@ class MyDocument extends Document {
       <Html>
         <Head />
         <body>
+          <noscript>
+            <iframe
+              src={ `https://www.googletagmanager.com/ns.html?id=GTM-NTQJVZD&gtm_auth=${REACT_APP_GOOGLE_ANALYTICS_ID}&gtm_cookies_win=x` }
+              height="0"
+              width="0"
+              style={ { display: 'none', visibility: 'hidden' } }
+              title="Google Analytics"
+            />
+          </noscript>
           <Main />
           <NextScript />
-          <noscript><iframe
-            src={`https://www.googletagmanager.com/ns.html?id=GTM-NTQJVZD&gtm_auth=${REACT_APP_GOOGLE_ANALYTICS_ID}&gtm_cookies_win=x`}
-            height="0"
-            width="0"
-            style={{ display: 'none', visibility: 'hidden' }}
-            title="Google Analytics"
-          />
-          </noscript>
         </body>
       </Html>
     );


### PR DESCRIPTION
- Adds production GTM snippet to the Head via the Meta file. This replaces the current implementation.

- Adds `<noscript>` snippet to the body via the main `_app.js` by using `componentDidMount()` and appending the snippet to the body. I know this is likely not the appropriate way to achieve that, but it's what I got to work so am looking forward to seeing notes.

* And just for clarification on the `<noscript>` snippet. This is just a fallback for the analytics incase the script is not running on the page for some reason.

Additionally, this implementation will be duplicated across Development and Staging. HOWEVER, it is a different snippet, so the code should not be rolled back. 