### PR TITLE
CDP-2022 & CDP-2023

### DIFF
--- a/lib/redux/actions/postType.js
+++ b/lib/redux/actions/postType.js
@@ -7,31 +7,31 @@ import {
 } from '../constants';
 
 export const loadPostTypes = user => async dispatch => {
-  dispatch( { type: LOAD_POST_TYPES_PENDING } );
+  dispatch({ type: LOAD_POST_TYPES_PENDING });
 
   let response;
   try {
-    response = await postTypeAggRequest( user );
-  } catch ( err ) {
-    return dispatch( { type: LOAD_POST_TYPES_FAILED } );
+    response = await postTypeAggRequest(user);
+  } catch (err) {
+    return dispatch({ type: LOAD_POST_TYPES_FAILED });
   }
 
-  if ( response && response.aggregations ) {
+  if (response && response.aggregations) {
     const { buckets } = response.aggregations.postType;
-    const payload = buckets.filter( type => type.key !== 'courses' && type.key !== 'page' ).map( type => {
-      let displayName = capitalizeFirst( type.key );
-      if ( type.key === 'post' ) displayName = 'Article';
-      if ( type.key === 'package' ) displayName = 'Guidance Packages';
+    const payload = buckets.filter(type => type.key !== 'courses' && type.key !== 'page' && type.key !== 'package').map(type => {
+      let displayName = capitalizeFirst(type.key);
+      if (type.key === 'post') displayName = 'Article';
+      if (type.key === 'document') displayName = 'Press Releases and Guidance';
       return {
         key: type.key,
         display_name: displayName,
         count: type.doc_count
       };
-    } );
+    });
 
-    return dispatch( {
+    return dispatch({
       type: LOAD_POST_TYPES_SUCCESS,
       payload
-    } );
+    });
   }
 };


### PR DESCRIPTION
- Removes Guidance Packages as an option in Format filter options
- Renames Document type in filter list