### PR TITLE
Hot Fixes - CDP-2022, CDP-2023, CDP-2074, CDP-2075

### DIFF
--- a/components/FilterMenu/FilterMenuItem.js
+++ b/components/FilterMenu/FilterMenuItem.js
@@ -14,7 +14,7 @@ const FilterMenuItem = props => {
   const [selected, setSelected] = useState( [] );
 
   /**
-   * Format data into state that dopdowns will use
+   * Format data into state that dropdowns will use
    */
   const formatOptions = ( opts, filterName ) => {
     let filterOptions = opts.map( option => ( {
@@ -58,10 +58,12 @@ const FilterMenuItem = props => {
    * @param {array|string} value - updated filter value
    */
   const executeQuery = value => {
+    const filtered = props.name === 'postTypes' ? value.filter( val => val !== 'package') : value;
+
     // Add term from search reducer to ensure that it does not get removed from the query string
     const query = fetchQueryString( {
       ...props.filterStore,
-      [props.name]: value,
+      [props.name]: filtered,
       term: props.term,
       language: props.language
     } );
@@ -82,7 +84,7 @@ const FilterMenuItem = props => {
     // make copy of selected filter array, i.e. categories
     const arr = props.filterStore[props.name].slice( 0 );
 
-    // Some values have mutliple search terms within the input value
+    // Some values have multiple search terms within the input value
     // i.e. YALI appears as Young African Leaders Initiative|Young African Leaders Initiative Network
     // so we split the value into array and add/remove each to search array
     const values = value.split( '|' );
@@ -117,7 +119,7 @@ const FilterMenuItem = props => {
   );
 
   const renderCheckbox = option => {
-    // Some values have mutliple search terms within the input value
+    // Some values have multiple search terms within the input value
     // i.e. YALI appears as Young African Leaders Initiative|Young African Leaders Initiative Network
     // so we split the value into array and add/remove each to search array
     const values = option.value.split( '|' );
@@ -145,7 +147,7 @@ const FilterMenuItem = props => {
   };
 
   useEffect( () => {
-    // togglel listener won menu show/hide
+    // toggle listener won menu show/hide
     toggleEventListener( filterItemOpen );
 
     // Clean up the listener on unmount
@@ -158,11 +160,9 @@ const FilterMenuItem = props => {
     setSelected( props.selected );
   }, [props.selected] );
 
-
   const {
     formItem, options, filter
   } = props;
-
 
   return (
     <div

--- a/components/FilterMenu/FilterSelections.js
+++ b/components/FilterMenu/FilterSelections.js
@@ -22,7 +22,7 @@ class FilterSelections extends Component {
   }
 
   /**
-   * Removes slected filter item
+   * Removes selected filter item
    * @param {object} item
    */
   handleOnClick = item => {
@@ -33,7 +33,7 @@ class FilterSelections extends Component {
     const selectedItemsFromSpecificFilter = filter[item.name].slice( 0 );
     const filterItemList = global[item.name].list;
     const itemToRemove = filterItemList.find( l => l.key.indexOf( item.value ) !== -1 );
-    // Some values have mutliple search terms within the input value
+    // Some values have multiple search terms within the input value
     // i.e. YALI appears as Young African Leaders Initiative|Young African Leaders Initiative Network
     // so we split the value into array and to remove all
     const values = itemToRemove.key.split( '|' );
@@ -50,7 +50,7 @@ class FilterSelections extends Component {
   }
 
   /**
-   * Reset all filter to intial values
+   * Reset all filter to initial values
    */
   handleClearAllFilters = async () => {
     await this.props.clearFilters();
@@ -70,7 +70,10 @@ class FilterSelections extends Component {
    * @param {bool} isRadio - Does this filter allow multiple selections
    */
   getSelection = ( values, name, list, isRadio = false ) => {
-    let selections = values.map( value => {
+    // Filter out packages from the filter selections
+    const filtered = values.filter(val => val !== 'package');
+
+    let selections = filtered.map( value => {
       const label = list.find( item => item.key.indexOf( value ) !== -1 );
       return ( {
         value,
@@ -100,7 +103,7 @@ class FilterSelections extends Component {
     // loop thru filters to build selection list
     filterOrder.forEach( key => {
       const value = filter[key];
-
+      
       const isCheckbox = Array.isArray( value );
       const values = isCheckbox ? value : [value];
 

--- a/components/SearchInput/SearchInput.js
+++ b/components/SearchInput/SearchInput.js
@@ -72,7 +72,12 @@ class Search extends Component {
 
   handleSubmit = async () => {
     const { filter, search } = this.props;
-    const query = fetchQueryString( { ...filter, term: search.term, language: this.state.locale } );
+
+    const postTypesClone = filter?.postTypes ? [...filter.postTypes] : [];
+
+    const filteredPostTypes = postTypesClone.map(type => type === 'package' ? 'document' : type)
+
+    const query = fetchQueryString( { ...filter, term: search.term, language: this.state.locale, postTypes: filteredPostTypes } );
     this.props.router.push( {
       pathname: '/results',
       query

--- a/lib/redux/actions/postType.js
+++ b/lib/redux/actions/postType.js
@@ -7,31 +7,31 @@ import {
 } from '../constants';
 
 export const loadPostTypes = user => async dispatch => {
-  dispatch( { type: LOAD_POST_TYPES_PENDING } );
+  dispatch({ type: LOAD_POST_TYPES_PENDING });
 
   let response;
   try {
-    response = await postTypeAggRequest( user );
-  } catch ( err ) {
-    return dispatch( { type: LOAD_POST_TYPES_FAILED } );
+    response = await postTypeAggRequest(user);
+  } catch (err) {
+    return dispatch({ type: LOAD_POST_TYPES_FAILED });
   }
 
-  if ( response && response.aggregations ) {
+  if (response && response.aggregations) {
     const { buckets } = response.aggregations.postType;
-    const payload = buckets.filter( type => type.key !== 'courses' && type.key !== 'page' ).map( type => {
-      let displayName = capitalizeFirst( type.key );
-      if ( type.key === 'post' ) displayName = 'Article';
-      if ( type.key === 'package' ) displayName = 'Guidance Packages';
+    const payload = buckets.filter(type => type.key !== 'courses' && type.key !== 'page' && type.key !== 'package').map(type => {
+      let displayName = capitalizeFirst(type.key);
+      if (type.key === 'post') displayName = 'Article';
+      if (type.key === 'document') displayName = 'Press Releases and Guidance';
       return {
         key: type.key,
         display_name: displayName,
         count: type.doc_count
       };
-    } );
+    });
 
-    return dispatch( {
+    return dispatch({
       type: LOAD_POST_TYPES_SUCCESS,
       payload
-    } );
+    });
   }
 };


### PR DESCRIPTION
- Cherry-picks the commit implementing CDP-2022 & CDP-2023 (remove filter by package, add filter by document, respectively) from develop.
- Removes `package` from the list of selected filter items (CDP-2074).
- Remove the package content type from the query when another content type is selected. (CDP-2075)
- When running a search from the packages browse all page, it resets the post type filter from package to document (CDP-2075)

Note - It is still possible to see packages in search results if you search with no content filters at all. We can resolve this changing the query default from no specified content type to all content types but `package`.