### PR TITLE
CDP-1968: Hook up the unpublish functionality in the dashboard for graphics

### DIFF
--- a/components/ScrollableTableWithMenu/TableActionsMenu/UnpublishProjects/UnpublishProjects.js
+++ b/components/ScrollableTableWithMenu/TableActionsMenu/UnpublishProjects/UnpublishProjects.js
@@ -58,9 +58,11 @@ const UnpublishProjects = ( {
    * each items as a 'UNPUBLISH_SUCCESS' or 'UNPUBLISH_FAILURE
    */
   const checkUnpublishStatus = () => {
-    const items = data?.packages ? data.packages : data.videoProjects;
+    const { projectType } = state;
 
-    if ( items ) {
+    if ( data && projectType ) {
+      const items = data[projectType] || [];
+
       // Determine how many items have completed (either success or failure)
       const updates = items.filter(
         item => item.status === 'UNPUBLISH_SUCCESS' || item.status === 'UNPUBLISH_FAILURE',


### PR DESCRIPTION
Pulls the content type off of the context object rather than depending on a hardcoded ternary. Having issues with getting the Apollo mock provider working in conjunction with mocked context, so in the interest of time am pushing without updated tests.