### PR TITLE
CDP-2114: Change footer feedback link to gpadigitalhelp@state.gov

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,11 +67,11 @@ _This sections lists changes committed since most recent release_
 - Adjust modal stylesheets for consistency
 - Update unit tests for ActionButtons, GraphicEdit, GraphicProject, and ModalContentMeta
 - Move the fetching of featured item results and post types from Redux to Context
+- The footer questions and feedback link to "gpadigitalhelp@state.gov" from "design@america.gov" 
 
 **Fixed:**
 
 - Fixed width in files popover menu
-  <<<<<<< HEAD
 - Hide the "saving changes" growl notification upon initial load of the project details form
 - The Formik initial save bug for GraphicProjectDetailsFormContainer and GraphicFilesFormContainer
 - Copyright dropdown validation for ProjectDetailsForm

--- a/components/Footer/Footer.js
+++ b/components/Footer/Footer.js
@@ -18,19 +18,20 @@ const Footer = () => {
     {
       name: 'privacy',
       to: '/privacy',
-      label: 'Privacy Policy'
+      label: 'Privacy Policy',
     },
     {
       name: 'releasenotes',
       to: '/releasenotes',
-      label: 'Release Notes'
+      label: 'Release Notes',
     },
     {
       name: 'documentation',
       to: '/documentation',
-      label: 'Documentation'
-    }
+      label: 'Documentation',
+    },
   ];
+
   return (
     <footer className="ui">
       <div className="footer-feedback">
@@ -75,8 +76,8 @@ const Footer = () => {
         </List>
         <Header as="div">
           <Header.Subheader className="subtext">
-            Can&apos;t find what you are looking for? To ask questions or provide feedback send us
-            an email at <a href="mailto:design@america.gov">design@america.gov</a>.
+            Can&rsquo;t find what you are looking for? To ask questions or provide feedback send us
+            an email at <a href="mailto:gpadigitalhelp@state.gov">gpadigitalhelp@state.gov</a>.
           </Header.Subheader>
           <Header.Subheader className="smalltext">
             This site is managed by the{ ' ' }
@@ -85,7 +86,7 @@ const Footer = () => {
             </a>{ ' ' }
             within the <a href="https://state.gov">U.S. Department of State</a>. External links to
             other Internet sites should not be construed as an endorsement of the views or privacy
-            policies contained therein. GPA © { new Date().getFullYear() }.
+            policies contained therein. GPA &copy; { new Date().getFullYear() }.
           </Header.Subheader>
         </Header>
         <img src={ flagImage } alt="United States Flag" className="footer_img footer_img--usflag" />

--- a/components/Footer/Footer.test.js
+++ b/components/Footer/Footer.test.js
@@ -4,14 +4,14 @@ import Footer from './Footer';
 
 jest.mock( 'next/config', () => () => ( {
   publicRuntimeConfig: {
-    PRESS_GUIDANCE_DB_URL: 'press-guidances'
-  }
+    PRESS_GUIDANCE_DB_URL: 'press-guidances',
+  },
 } ) );
 
 jest.mock( 'context/authContext', () => ( {
   useAuth: jest
     .fn( () => ( { user: null } ) )
-    .mockImplementationOnce( () => ( { user: true } ) )
+    .mockImplementationOnce( () => ( { user: true } ) ),
 } ) );
 
 describe( '<Footer />', () => {
@@ -27,7 +27,7 @@ describe( '<Footer />', () => {
 
     expect( list ).toHaveLength( 4 );
     expect( linkTextArr ).toEqual(
-      expect.arrayContaining( pressLinkText )
+      expect.arrayContaining( pressLinkText ),
     );
   } );
 
@@ -41,7 +41,7 @@ describe( '<Footer />', () => {
 
     expect( list ).toHaveLength( 3 );
     expect( linkTextArr ).toEqual(
-      expect.not.arrayContaining( pressLinkText )
+      expect.not.arrayContaining( pressLinkText ),
     );
   } );
 } );


### PR DESCRIPTION
Changes the footer questions and feedback link to "gpadigitalhelp@state.gov" from "design@america.gov"