### PR TITLE
CDP-2110 - Fix for UNPUBLISH/PUBLISH SUCCESS Text Display when updating Graphic Projects

### DIFF
--- a/components/ScrollableTableWithMenu/ScrollableTableWithMenu.js
+++ b/components/ScrollableTableWithMenu/ScrollableTableWithMenu.js
@@ -36,16 +36,21 @@ const ScrollableTableWithMenu = ( { columnMenu, persistentTableHeaders, projectT
   const _breakpoint = 767;
 
   const { dispatch, state } = useContext( DashboardContext );
-  const projectType = state?.projectType ? state.projectType : '';
-  const column = state?.column ? state.column : 'createdAt';
-  const direction = state?.direction ? state.direction : 'descending';
+  // const projectType = state?.projectType ? state.projectType : '';
+  // const column = state?.column ? state.column : 'createdAt';
+  // const direction = state?.direction ? state.direction : 'descending';
+  const projectType = state?.projectType || '';
+  const column = state?.column || 'createdAt';
+  const direction = state?.direction || 'descending';
 
   // No-op query is never called, but added to avoid reference error in cases where context has not yet loaded
   const noopQuery = gql`query{ NOOP { noop } }`;
 
   // Get the content data
-  const contentQuery = state?.queries?.content ? state.queries.content : noopQuery;
-  const countQuery = state?.queries?.count ? state.queries.count : noopQuery;
+  // const contentQuery = state?.queries?.content ? state.queries.content : noopQuery;
+  // const countQuery = state?.queries?.count ? state.queries.count : noopQuery;
+  const contentQuery = state?.queries?.content || noopQuery;
+  const countQuery = state?.queries?.count || noopQuery;
 
   // Set GraphQL query variables
   const variables = { team: team.name, searchTerm };
@@ -77,7 +82,12 @@ const ScrollableTableWithMenu = ( { columnMenu, persistentTableHeaders, projectT
     const { data, error, loading, refetch } = countData;
 
     // Save project count in context
-    dispatch( { type: 'UPDATE_COUNT', payload: { count: { data, error, loading, refetch }, team, type: projectType } } );
+    dispatch( {
+      type: 'UPDATE_COUNT',
+      payload: {
+        count: { data, error, loading, refetch }, team, type: projectType,
+      },
+    } );
   }, [
     countData, dispatch, projectType, team,
   ] );
@@ -224,15 +234,15 @@ const ScrollableTableWithMenu = ( { columnMenu, persistentTableHeaders, projectT
     dispatch( { type: 'UPDATE_SELECTED_ALL', payload: { selected } } );
   };
 
-  const count = state?.count?.count ? state.count.count : null;
-  const countError = state?.count?.error ? state.count.error : null;
-  const countLoading = state?.count?.loading ? state.count.loading : false;
-  const countRefetch = state?.count?.refetch ? state.count.refetch : () => {};
+  const count = state?.count?.count || null;
+  const countError = state?.count?.error || null;
+  const countLoading = state?.count?.loading || false;
+  const countRefetch = state?.count?.refetch || ( () => {} );
 
-  const projectData = state?.content?.data ? state.content.data : null;
-  const projectError = state?.content?.error ? state.content.error : null;
-  const projectLoading = state?.content?.loading ? state.content.loading : false;
-  const projectRefetch = state?.content?.refetch ? state.content.refetch : () => {};
+  const projectData = state?.content?.data || null;
+  const projectError = state?.content?.error || null;
+  const projectLoading = state?.content?.loading || false;
+  const projectRefetch = state?.content?.refetch || ( () => {} );
 
   return (
     <Grid>

--- a/components/ScrollableTableWithMenu/ScrollableTableWithMenu.js
+++ b/components/ScrollableTableWithMenu/ScrollableTableWithMenu.js
@@ -36,9 +36,6 @@ const ScrollableTableWithMenu = ( { columnMenu, persistentTableHeaders, projectT
   const _breakpoint = 767;
 
   const { dispatch, state } = useContext( DashboardContext );
-  // const projectType = state?.projectType ? state.projectType : '';
-  // const column = state?.column ? state.column : 'createdAt';
-  // const direction = state?.direction ? state.direction : 'descending';
   const projectType = state?.projectType || '';
   const column = state?.column || 'createdAt';
   const direction = state?.direction || 'descending';
@@ -47,8 +44,6 @@ const ScrollableTableWithMenu = ( { columnMenu, persistentTableHeaders, projectT
   const noopQuery = gql`query{ NOOP { noop } }`;
 
   // Get the content data
-  // const contentQuery = state?.queries?.content ? state.queries.content : noopQuery;
-  // const countQuery = state?.queries?.count ? state.queries.count : noopQuery;
   const contentQuery = state?.queries?.content || noopQuery;
   const countQuery = state?.queries?.count || noopQuery;
 

--- a/components/ScrollableTableWithMenu/TableActionsMenu/TableActionsMenu.js
+++ b/components/ScrollableTableWithMenu/TableActionsMenu/TableActionsMenu.js
@@ -42,9 +42,9 @@ const TableActionsMenu = ( {
 } ) => {
   const { state } = useContext( DashboardContext );
 
-  const selectedItems = state?.selected?.selectedItems ? state.selected.selectedItems : new Map();
-  const displayActionsMenu = state?.selected?.displayActionsMenu ? state.selected.displayActionsMenu : false;
-  const team = state?.team ? state.team : { contentTypes: null };
+  const selectedItems = state?.selected?.selectedItems || new Map();
+  const displayActionsMenu = state?.selected?.displayActionsMenu || false;
+  const team = state?.team || { contentTypes: null };
 
   const [displayConfirmationMsg, setDisplayConfirmationMsg] = useState( false );
   const [deleteConfirmOpen, setDeleteConfirmOpen] = useState( false );

--- a/components/ScrollableTableWithMenu/TableActionsMenu/UnpublishProjects/UnpublishProjects.js
+++ b/components/ScrollableTableWithMenu/TableActionsMenu/UnpublishProjects/UnpublishProjects.js
@@ -91,11 +91,6 @@ const UnpublishProjects = ( {
     if ( data ) {
       checkUnpublishStatus();
     }
-
-    // Ensure polling does not continue on unmount
-    return () => {
-      stopPolling();
-    };
   }, [data] );
 
 
@@ -115,8 +110,7 @@ const UnpublishProjects = ( {
 
   const handleUnpublishProjects = async () => {
     // watch for status changes as projects are unpublished
-    startPolling( 1000 );
-
+    startPolling( 300 );
     await Promise.all( published.map( unpublishProject ) );
     handleResetSelections();
     showConfirmationMsg();

--- a/components/ScrollableTableWithMenu/TableRow/TableRow.js
+++ b/components/ScrollableTableWithMenu/TableRow/TableRow.js
@@ -19,6 +19,16 @@ const TableRow = ( { d, tableHeaders, projectTab } ) => {
 
   if ( !d ) return null;
 
+  const statusDisplay = () => {
+    let statusText = d.status;
+
+    if ( d.status === 'UNPUBLISH_SUCCESS' || d.status === 'PUBLISH_SUCCESS' ) {
+      statusText = 'UPDATING PROJECT...';
+    }
+
+    return statusText;
+  };
+
   return (
     <Table.Row
       className={ displayMobileData ? 'activeTableRow' : '' }
@@ -64,9 +74,7 @@ const TableRow = ( { d, tableHeaders, projectTab } ) => {
                   }
                 </span>
                 <br />
-                { header.label === 'CREATED'
-                  ? <span>{ d.status }</span>
-                  : null }
+                { header.label === 'CREATED' && <span>{ statusDisplay() }</span> }
               </Fragment>
             ) }
         </Table.Cell>


### PR DESCRIPTION
- remove premature stopPolling fn call in useEffect in UnpublishProject
- display updating text on gql publishing success instead of default text in TableRow for project status
- cleanup syntax