### PR TITLE
CDP-2125: Remove share buttons for graphics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,7 @@ _This sections lists changes committed since most recent release_
 - Use TeamDropdown instead of an input field in ProjectDetailsForm for graphic projects
 - Connect team.id in the graphic buildFormTree function to allow graphic users to change a graphic project's team
 - Adjust the graphic project team queries to handle GPA Editorial & Design or ShareAmerica, i.e., the two TeamDropdown options for graphic projects
+- Remove the Social Media Share functionality for Graphics
  
 
 **Fixed:**

--- a/components/Share/Share.js
+++ b/components/Share/Share.js
@@ -10,12 +10,21 @@ import ShareButton from './ShareButton';
 import './Share.scss';
 
 const Share = ( {
-  id, isPreview, language, link, site, title, type
+  id,
+  isPreview,
+  language,
+  link,
+  site,
+  title,
+  type,
 } ) => {
-  const internalOnly = type === 'document' || type === 'package';
+  const internalTypes = [
+    'document', 'graphic', 'package',
+  ];
+  const internalOnly = internalTypes.some( t => t === type );
   const video = type === 'video';
 
-  const queryStr = ( type === 'post' )
+  const queryStr = type === 'post'
     ? stringifyQueryString( { id, site } )
     : stringifyQueryString( { id, site, language } );
 
@@ -46,24 +55,27 @@ const Share = ( {
   const facebookURL = `https://www.facebook.com/sharer/sharer.php?u=${shareLink}`;
   const tweet = `https://twitter.com/intent/tweet?text=${title}&url=${shareLink}`;
 
+  const displaySocialBtns = shareLink && !internalOnly && !video;
+
   return (
     <div>
-      { shareLink && !internalOnly && !video && (
-        <List className="share_list">
-          <ShareButton
-            url={ facebookURL }
-            icon="facebook f"
-            label="Share on Facebook"
-            isPreview={ isPreview }
-          />
-          <ShareButton
-            url={ tweet }
-            icon="twitter"
-            label="Share on Twitter"
-            isPreview={ isPreview }
-          />
-        </List>
-      ) }
+      { displaySocialBtns
+        && (
+          <List className="share_list">
+            <ShareButton
+              url={ facebookURL }
+              icon="facebook f"
+              label="Share on Facebook"
+              isPreview={ isPreview }
+            />
+            <ShareButton
+              url={ tweet }
+              icon="twitter"
+              label="Share on Twitter"
+              isPreview={ isPreview }
+            />
+          </List>
+        ) }
       <ClipboardCopy
         label="Direct Link"
         copyItem={ directLink }
@@ -74,7 +86,7 @@ const Share = ( {
 };
 
 Share.defaultProps = {
-  isPreview: false
+  isPreview: false,
 };
 
 Share.propTypes = {
@@ -87,7 +99,7 @@ Share.propTypes = {
   language: PropTypes.string,
   link: PropTypes.string,
   title: PropTypes.string,
-  type: PropTypes.string
+  type: PropTypes.string,
 };
 
 export default Share;

--- a/components/Share/Share.test.js
+++ b/components/Share/Share.test.js
@@ -6,37 +6,39 @@ jest.mock( 'next/config', () => () => ( {
   publicRuntimeConfig: {},
 } ) );
 
-const props = {
-  id: 'c888',
-  isPreview: false,
-  site: '',
-  language: 'en-us',
-  link: 'https://player.vimeo.com/video/23729318',
-  title: 'the title',
-  type: 'video'
-};
-
-const Component = <Share { ...props } />;
 
 describe( '<Share />', () => {
-  it( 'renders without crashing', () => {
-    const wrapper = mount( Component );
+  const props = {
+    id: 'c888',
+    isPreview: false,
+    site: '',
+    language: 'en-us',
+    link: 'https://player.vimeo.com/video/23729318',
+    title: 'the title',
+    type: 'video',
+  };
 
+  let Component;
+  let wrapper;
+
+  beforeEach( () => {
+    Component = <Share { ...props } />;
+    wrapper = mount( Component );
+  } );
+
+  it( 'renders without crashing', () => {
     expect( wrapper.exists() ).toEqual( true );
     expect( toJSON( wrapper ) ).toMatchSnapshot();
   } );
 
   it( 'does not render the Facebook and Twitter share links if there is no link prop', () => {
-    const wrapper = mount( Component );
     wrapper.setProps( { link: '', type: 'post' } );
-
     const list = wrapper.find( 'List' );
 
     expect( list.exists() ).toEqual( false );
   } );
 
-  it( 'renders the Facebook and Twitter share links if type is post, but not if type is video, document, or package', () => {
-    const wrapper = mount( Component );
+  it( 'renders the Facebook and Twitter share links if type is post, but not if type is video, document, graphic, or package', () => {
     const list = wrapper.find( '.share_list' );
 
     // Test type video
@@ -53,6 +55,11 @@ describe( '<Share />', () => {
     expect( wrapper.prop( 'type' ) ).toEqual( 'document' );
     expect( list.exists() ).toEqual( false );
 
+    // Test type graphic
+    wrapper.setProps( { type: 'graphic' } );
+    expect( wrapper.prop( 'type' ) ).toEqual( 'graphic' );
+    expect( list.exists() ).toEqual( false );
+
     // Test type package
     wrapper.setProps( { type: 'package' } );
     expect( wrapper.prop( 'type' ) ).toEqual( 'package' );
@@ -61,10 +68,11 @@ describe( '<Share />', () => {
 
   it( 'passes the correct Facebook and Twitter share links if type is post and is from content.america.gov', () => {
     jest.resetModules();
-    const wrapper = mount( Component );
     wrapper.setProps( { link: 'content.america.gov', type: 'post' } );
 
-    const libBrowser = require( 'lib/browser' ); // eslint-disable-line
+    /* eslint-disable global-require */
+    const libBrowser = require( 'lib/browser' );
+
     libBrowser.stringifyQueryString = jest.fn( () => (
       `http://localhost/article?id=${props.id}&site=${props.site}`
     ) );
@@ -83,12 +91,13 @@ describe( '<Share />', () => {
 
   it( 'passes the correct link to ClipboardCopy if type is video & !isPreview', () => {
     jest.resetModules();
-    const wrapper = mount( Component );
     const clipboardCopy = wrapper.find( 'ClipboardCopy' );
+    const type = wrapper.prop( 'type' );
 
-    const libBrowser = require( 'lib/browser' ); // eslint-disable-line
+    const libBrowser = require( 'lib/browser' );
+
     libBrowser.stringifyQueryString = jest.fn( () => (
-      `http://localhost/video?id=${props.id}&site=${props.site}&language=${props.language}`
+      `http://localhost/${type}?id=${props.id}&site=${props.site}&language=${props.language}`
     ) );
     const shareLink = libBrowser.stringifyQueryString();
 
@@ -96,10 +105,9 @@ describe( '<Share />', () => {
   } );
 
   it( 'passes the placeholder text to ClipboardCopy if type is video & isPreview is true', () => {
-    const wrapper = mount( Component );
     wrapper.setProps( {
       isPreview: true,
-      link: 'The direct link to the project will appear here.'
+      link: 'The direct link to the project will appear here.',
     } );
     const clipboardCopy = wrapper.find( 'ClipboardCopy' );
 
@@ -108,11 +116,11 @@ describe( '<Share />', () => {
 
   it( 'passes the correct link to ClipboardCopy if type is post and is from content.america.gov', () => {
     jest.resetModules();
-    const wrapper = mount( Component );
     wrapper.setProps( { link: 'content.america.gov', type: 'post' } );
     const clipboardCopy = wrapper.find( 'ClipboardCopy' );
 
-    const libBrowser = require( 'lib/browser' ); // eslint-disable-line
+    const libBrowser = require( 'lib/browser' );
+
     libBrowser.stringifyQueryString = jest.fn( () => (
       `http://localhost/article?id=${props.id}&site=${props.site}`
     ) );
@@ -125,17 +133,18 @@ describe( '<Share />', () => {
 
   it( 'passes the correct link to ClipboardCopy if type is neither post nor video', () => {
     jest.resetModules();
-    const wrapper = mount( Component );
-    wrapper.setProps( { type: 'image' } );
+    wrapper.setProps( { type: 'graphic' } );
     const clipboardCopy = wrapper.find( 'ClipboardCopy' );
+    const type = wrapper.prop( 'type' );
 
-    const libBrowser = require( 'lib/browser' ); // eslint-disable-line
+    const libBrowser = require( 'lib/browser' );
+
     libBrowser.stringifyQueryString = jest.fn( () => (
-      `http://localhost/image?id=${props.id}&site=${props.site}&language=${props.language}`
+      `http://localhost/${type}?id=${props.id}&site=${props.site}&language=${props.language}`
     ) );
     const shareLink = libBrowser.stringifyQueryString();
 
-    expect( wrapper.prop( 'type' ) ).toEqual( 'image' );
+    expect( wrapper.prop( 'type' ) ).toEqual( type );
     expect( clipboardCopy.prop( 'copyItem' ) ).toEqual( shareLink );
   } );
 } );


### PR DESCRIPTION
* Removes social share buttons from the share dropdown in the graphic preview modal and commons page
* Updates tests for Share component