### PR TITLE
CDP-2110 - Dashboard status change not updating correctly

### DIFF
--- a/components/ScrollableTableWithMenu/ScrollableTableWithMenu.js
+++ b/components/ScrollableTableWithMenu/ScrollableTableWithMenu.js
@@ -46,8 +46,6 @@ const ScrollableTableWithMenu = ( { columnMenu, persistentTableHeaders, projectT
   // Get the content data
   const contentQuery = state?.queries?.content || noopQuery;
   const countQuery = state?.queries?.count || noopQuery;
-  // const contentQuery = state?.queries?.content;
-  // const countQuery = state?.queries?.count;
 
   // Set GraphQL query variables
   const variables = { team: team.name, searchTerm };

--- a/components/ScrollableTableWithMenu/ScrollableTableWithMenu.js
+++ b/components/ScrollableTableWithMenu/ScrollableTableWithMenu.js
@@ -46,6 +46,8 @@ const ScrollableTableWithMenu = ( { columnMenu, persistentTableHeaders, projectT
   // Get the content data
   const contentQuery = state?.queries?.content || noopQuery;
   const countQuery = state?.queries?.count || noopQuery;
+  // const contentQuery = state?.queries?.content;
+  // const countQuery = state?.queries?.count;
 
   // Set GraphQL query variables
   const variables = { team: team.name, searchTerm };

--- a/components/ScrollableTableWithMenu/TableActionsMenu/TableActionsMenu.js
+++ b/components/ScrollableTableWithMenu/TableActionsMenu/TableActionsMenu.js
@@ -227,19 +227,17 @@ const TableActionsMenu = ( {
             <img src={ archiveIcon } alt="Archive Selection(s)" title="Archive Selection(s)" />
           </Button>
 
-          { !hasSelectedAllDrafts() && (
-            <Fragment>
-              <span className="separator">|</span>
-              <UnpublishProjects
-                team={ team }
-                handleResetSelections={ handleResetSelections }
-                handleActionResult={ handleActionResult }
-                showConfirmationMsg={ showConfirmationMsg }
-                selections={ selections }
-                variables={ variables }
-              />
-            </Fragment>
-          ) }
+          {/* Keep UnpublishProjects mounted so polling is not stopped prematurely */}
+          { !hasSelectedAllDrafts() && <span className="separator">|</span> }
+          <UnpublishProjects
+            team={ team }
+            handleResetSelections={ handleResetSelections }
+            handleActionResult={ handleActionResult }
+            showConfirmationMsg={ showConfirmationMsg }
+            selections={ selections }
+            variables={ variables }
+            hasSelectedAllDrafts={ hasSelectedAllDrafts() }
+          />
         </div>
       </Fragment>
     );

--- a/context/dashboardContext.js
+++ b/context/dashboardContext.js
@@ -8,6 +8,7 @@ import {
   GRAPHIC_PROJECT_IMAGE_FILES_QUERY,
   UNPUBLISH_GRAPHIC_PROJECT_MUTATION,
   UPDATE_GRAPHIC_STATUS_MUTATION,
+  GRAPHIC_PROJECTS_META_QUERY,
 } from 'lib/graphql/queries/graphic';
 import {
   DELETE_PACKAGE_MUTATION,
@@ -135,6 +136,7 @@ export const setQueries = team => {
       queries.content = TEAM_GRAPHIC_PROJECTS_QUERY;
       queries.count = TEAM_GRAPHIC_PROJECTS_COUNT_QUERY;
       queries.files = GRAPHIC_PROJECT_IMAGE_FILES_QUERY;
+      queries.metaContent = GRAPHIC_PROJECTS_META_QUERY;
       queries.remove = DELETE_GRAPHIC_PROJECT_MUTATION;
       queries.status = UPDATE_GRAPHIC_STATUS_MUTATION;
       queries.unpublish = UNPUBLISH_GRAPHIC_PROJECT_MUTATION;

--- a/lib/graphql/queries/graphic.js
+++ b/lib/graphql/queries/graphic.js
@@ -162,6 +162,18 @@ export const UPDATE_GRAPHIC_PROJECT_STATUS_MUTATION = gql`
   }
 `;
 
+export const UPDATE_GRAPHIC_STATUS_MUTATION = gql`
+  mutation UPDATE_GRAPHIC_STATUS_MUTATION(
+   $data: GraphicProjectUpdateInput!
+    $where: GraphicProjectWhereUniqueInput!
+  ) {
+    updateGraphicProject(data: $data, where: $where) {
+      id
+      status
+    }
+  }
+`;
+
 /*----------------------------------------
  Queries
  -----------------------------------------*/
@@ -176,6 +188,16 @@ export const GRAPHIC_PROJECTS_QUERY = gql`
   }
   ${GRAPHIC_PROJECT_FRAGMENT}
   ${SUPPORT_FILE_DETAILS_FRAGMENT}
+`;
+
+export const GRAPHIC_PROJECTS_META_QUERY = gql`
+  query GraphicProjectsMeta {
+    graphicProjects {
+      id
+      publishedAt
+      status
+    }
+  }
 `;
 
 export const GRAPHIC_PROJECT_QUERY = gql`
@@ -293,18 +315,6 @@ export const TEAM_GRAPHIC_PROJECTS_COUNT_QUERY = gql`
       }
     ) {
       id
-    }
-  }
-`;
-
-export const UPDATE_GRAPHIC_STATUS_MUTATION = gql`
-  mutation UPDATE_GRAPHIC_STATUS_MUTATION(
-   $data: GraphicProjectUpdateInput!
-    $where: GraphicProjectWhereUniqueInput!
-  ) {
-    updateGraphicProject(data: $data, where: $where) {
-      id
-      status
     }
   }
 `;


### PR DESCRIPTION
- need to keep UnpublishProjects mounted (as opposed to only mounting if a published project is selected) so polling is not stopped before the status of projects is updated
- using a new query in UnpublishProjects to only fetch the id, status & publishedAt fields for graphic content instead of querying all graphic content (imgs) which were creating a network strain when polling (all the imgs were continuously being downloaded)
- removed calling stopPolling as that was preventing status updates from completing