### PR TITLE
Fix for press docs displaying in search results for logged out users

### DIFF
--- a/lib/elastic/query.js
+++ b/lib/elastic/query.js
@@ -298,7 +298,7 @@ export const queryBuilder = ( store, user ) => {
   // i.e. checking the field visibility status
   // when requirements dictate hiding fields within a document
   // for example, showing video but not showing its editable file
-  if ( !user ) {
+  if ( !user || user?.id === 'public' ) {
     body.notQuery( 'match', 'type.keyword', 'document' );
     body.notQuery( 'match', 'type.keyword', 'package' );
   }


### PR DESCRIPTION
- account for public user.id in search query