### PR TITLE
CDP-2130: Save & Exit/Preview/Publish buttons should become active once 1+ graphic files added to project from edit page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,7 +96,11 @@ _This sections lists changes committed since most recent release_
 - Remove the Social Media Share functionality for Graphics 
 - Use API URL to download video caption files 
 - Display the ShareAmerica logo in the graphic project preview and graphic project results card if the project's owner is ShareAmerica
-
+- Disable unpublish button on graphic project details page if there are no graphic files
+- Set disableBtns state based on the presence of graphic files
+- Adjust the no files message to instruct the user to upload at least one graphic file (for an existing project)
+- Return the graphic project type when updateGraphicProject is called to delete a graphic file
+ 
  
 
 **Fixed:**

--- a/components/admin/ButtonPublish/ButtonPublish.js
+++ b/components/admin/ButtonPublish/ButtonPublish.js
@@ -9,7 +9,7 @@ const ButtonPublish = props => {
     publishing,
     status,
     updated,
-    disabled
+    disabled,
   } = props;
 
   const setButtonState = btn => `action-btn btn--${btn} ${publishing ? 'loading' : ''}`;
@@ -24,7 +24,7 @@ const ButtonPublish = props => {
               && (
                 <Button className={ setButtonState( 'edit basic' ) } onClick={ handlePublish } disabled={ disabled }>Publish Changes</Button>
               ) }
-            <Button className="action-btn btn--publish" onClick={ handleUnPublish }>Unpublish</Button>
+            <Button className="action-btn btn--publish" onClick={ handleUnPublish } disabled={ disabled }>Unpublish</Button>
           </Fragment>
         ) }
     </Fragment>
@@ -32,7 +32,7 @@ const ButtonPublish = props => {
 };
 
 ButtonPublish.defaultProps = {
-  publishing: false
+  publishing: false,
 };
 
 ButtonPublish.propTypes = {
@@ -41,7 +41,7 @@ ButtonPublish.propTypes = {
   publishing: PropTypes.bool,
   status: PropTypes.string,
   updated: PropTypes.bool,
-  disabled: PropTypes.bool
+  disabled: PropTypes.bool,
 };
 
 export default ButtonPublish;

--- a/components/admin/ButtonPublish/ButtonPublish.test.js
+++ b/components/admin/ButtonPublish/ButtonPublish.test.js
@@ -7,7 +7,7 @@ const props = {
   publishing: false,
   status: 'DRAFT',
   updated: false,
-  disabled: false
+  disabled: false,
 };
 
 const getBtn = ( str, buttons ) => (
@@ -31,6 +31,7 @@ describe( '<ButtonPublish />, for DRAFT status', () => {
 
   it( 'renders the Publish button', () => {
     const publishBtn = getBtn( 'Publish', btns );
+
     expect( publishBtn.exists() ).toEqual( props.status === 'DRAFT' );
   } );
 
@@ -59,6 +60,7 @@ describe( '<ButtonPublish />, for DRAFT status', () => {
 
   it( 'does not render the Unpublish button', () => {
     const unpublishBtn = getBtn( 'Unpublish', btns );
+
     expect( unpublishBtn.exists() ).toEqual( false );
   } );
 } );
@@ -66,7 +68,7 @@ describe( '<ButtonPublish />, for DRAFT status', () => {
 describe( '<ButtonPublish />, for DRAFT status & disabled', () => {
   const newProps = {
     ...props,
-    disabled: true
+    disabled: true,
   };
   let Component;
   let wrapper;
@@ -84,6 +86,7 @@ describe( '<ButtonPublish />, for DRAFT status & disabled', () => {
 
   it( 'renders the disabled Publish button', () => {
     const publishBtn = getBtn( 'Publish', btns );
+
     expect( publishBtn.exists() ).toEqual( props.status === 'DRAFT' );
     expect( publishBtn.prop( 'disabled' ) ).toEqual( true );
   } );
@@ -106,6 +109,7 @@ describe( '<ButtonPublish />, for DRAFT status & disabled', () => {
 
   it( 'does not render the Unpublish button', () => {
     const unpublishBtn = getBtn( 'Unpublish', btns );
+
     expect( unpublishBtn.exists() ).toEqual( false );
   } );
 } );
@@ -113,7 +117,7 @@ describe( '<ButtonPublish />, for DRAFT status & disabled', () => {
 describe( '<ButtonPublish />, for PUBLISHED status', () => {
   const newProps = {
     ...props,
-    status: 'PUBLISHED'
+    status: 'PUBLISHED',
   };
   let Component;
   let wrapper;
@@ -131,6 +135,7 @@ describe( '<ButtonPublish />, for PUBLISHED status', () => {
 
   it( 'does not render the Publish button', () => {
     const publishBtn = getBtn( 'Publish', btns );
+
     expect( publishBtn.exists() ).toEqual( newProps.status === 'DRAFT' );
   } );
 
@@ -166,7 +171,7 @@ describe( '<ButtonPublish />, for PUBLISHED status & updated', () => {
   const newProps = {
     ...props,
     updated: true,
-    status: 'PUBLISHED'
+    status: 'PUBLISHED',
   };
   let Component;
   let wrapper;
@@ -184,6 +189,7 @@ describe( '<ButtonPublish />, for PUBLISHED status & updated', () => {
 
   it( 'does not render the Publish button', () => {
     const publishBtn = getBtn( 'Publish', btns );
+
     expect( publishBtn.exists() ).toEqual( newProps.status === 'DRAFT' );
   } );
 
@@ -212,6 +218,7 @@ describe( '<ButtonPublish />, for PUBLISHED status & updated', () => {
 
   it( 'renders the Unpublish button', () => {
     const unpublishBtn = getBtn( 'Unpublish', btns );
+
     expect( unpublishBtn.exists() ).toEqual( newProps.status !== 'DRAFT' );
   } );
 
@@ -235,7 +242,7 @@ describe( '<ButtonPublish />, for PUBLISHED status, updated, & disabled', () => 
     ...props,
     updated: true,
     status: 'PUBLISHED',
-    disabled: true
+    disabled: true,
   };
   let Component;
   let wrapper;
@@ -253,6 +260,7 @@ describe( '<ButtonPublish />, for PUBLISHED status, updated, & disabled', () => 
 
   it( 'does not render the Publish button', () => {
     const publishBtn = getBtn( 'Publish', btns );
+
     expect( publishBtn.exists() ).toEqual( newProps.status === 'DRAFT' );
   } );
 
@@ -282,6 +290,7 @@ describe( '<ButtonPublish />, for PUBLISHED status, updated, & disabled', () => 
 
   it( 'renders the Unpublish button', () => {
     const unpublishBtn = getBtn( 'Unpublish', btns );
+
     expect( unpublishBtn.exists() ).toEqual( newProps.status !== 'DRAFT' );
   } );
 
@@ -304,7 +313,7 @@ describe( '<ButtonPublish />, for PUBLISHING status, publishing, & not updated',
   const newProps = {
     ...props,
     publishing: true,
-    status: 'PUBLISHING'
+    status: 'PUBLISHING',
   };
   let Component;
   let wrapper;
@@ -322,6 +331,7 @@ describe( '<ButtonPublish />, for PUBLISHING status, publishing, & not updated',
 
   it( 'does not render the Publish button', () => {
     const publishBtn = getBtn( 'Publish', btns );
+
     expect( publishBtn.exists() ).toEqual( newProps.status === 'DRAFT' );
   } );
 
@@ -334,6 +344,7 @@ describe( '<ButtonPublish />, for PUBLISHING status, publishing, & not updated',
 
   it( 'renders the Unpublish button', () => {
     const unpublishBtn = getBtn( 'Unpublish', btns );
+
     expect( unpublishBtn.exists() ).toEqual( newProps.status !== 'DRAFT' );
   } );
 

--- a/components/admin/ProjectEdit/GraphicEdit/GraphicEdit.js
+++ b/components/admin/ProjectEdit/GraphicEdit/GraphicEdit.js
@@ -247,10 +247,9 @@ const GraphicEdit = ( { id } ) => {
 
     if ( data?.graphicProject ) {
       const { images } = data.graphicProject;
+      const hasImages = getCount( images ) > 0;
 
-      if ( !images.length ) {
-        setDisableBtns( true );
-      }
+      setDisableBtns( !hasImages );
     }
 
     return () => {
@@ -268,7 +267,6 @@ const GraphicEdit = ( { id } ) => {
       handleStatusChange( data.graphicProject );
     }
   }, [data] );
-
 
   const getStyleId = name => {
     const styles = stylesData?.graphicStyles;

--- a/components/admin/ProjectEdit/GraphicEdit/GraphicEdit.js
+++ b/components/admin/ProjectEdit/GraphicEdit/GraphicEdit.js
@@ -678,6 +678,7 @@ const GraphicEdit = ( { id } ) => {
               preview: !projectId || disableBtns || !isFormValid,
               publish: !projectId || disableBtns || !isFormValid, // having graphics required?
               publishChanges: !projectId || disableBtns || !isFormValid,
+              unpublish: !projectId || disableBtns || !isFormValid,
             } }
             handle={ {
               deleteConfirm: projectId ? handleDeleteConfirm : handleExit,

--- a/components/admin/ProjectEdit/GraphicEdit/GraphicFilesFormContainer/GraphicFilesForm/GraphicFilesForm.js
+++ b/components/admin/ProjectEdit/GraphicEdit/GraphicFilesFormContainer/GraphicFilesForm/GraphicFilesForm.js
@@ -86,7 +86,11 @@ const GraphicFilesForm = props => {
   if ( !getCount( files ) ) {
     return (
       <div className="graphic-project-graphic-files">
-        <p className="no-files">No files to upload</p>
+        <p className="no-files">
+          { projectId
+            ? 'Please upload at least one graphic file.'
+            : 'No files to upload' }
+        </p>
       </div>
     );
   }

--- a/components/admin/ProjectEdit/GraphicEdit/GraphicFilesFormContainer/GraphicFilesForm/GraphicFilesForm.js
+++ b/components/admin/ProjectEdit/GraphicEdit/GraphicFilesFormContainer/GraphicFilesForm/GraphicFilesForm.js
@@ -40,6 +40,7 @@ const GraphicFilesForm = props => {
     await updateGraphicProject( {
       variables: {
         data: {
+          type: 'SOCIAL_MEDIA',
           images: {
             'delete': {
               id,

--- a/components/admin/ProjectEdit/GraphicEdit/GraphicFilesFormContainer/GraphicFilesForm/GraphicFilesForm.test.js
+++ b/components/admin/ProjectEdit/GraphicEdit/GraphicFilesFormContainer/GraphicFilesForm/GraphicFilesForm.test.js
@@ -259,15 +259,60 @@ describe( '<GraphicFilesForm />, when no files are received', () => {
     graphicsForm = wrapper.find( 'GraphicFilesForm' );
   } );
 
-  it( 'renders a No Files message', () => {
+  it( 'renders a "Please upload..." message', () => {
     const semanticForm = graphicsForm.find( 'Form' );
     const noFilesWrapper = graphicsForm.find( '.no-files' );
-    const msg = 'No files to upload';
+    const uploadMsg = 'Please upload at least one graphic file.';
+    const noFilesMsg = 'No files to upload';
 
     expect( semanticForm.exists() ).toEqual( false );
     expect( noFilesWrapper.exists() ).toEqual( true );
     expect( noFilesWrapper.name() ).toEqual( 'p' );
-    expect( noFilesWrapper.contains( msg ) ).toEqual( true );
+    expect( noFilesWrapper.contains( uploadMsg ) ).toEqual( true );
+    expect( noFilesWrapper.contains( noFilesMsg ) ).toEqual( false );
+  } );
+} );
+
+describe( '<GraphicFilesForm />, when no files and no projectId', () => {
+  const consoleError = console.error;
+
+  beforeAll( () => suppressActWarning( consoleError ) );
+  afterAll( () => {
+    console.error = consoleError;
+  } );
+
+  let Component;
+  let wrapper;
+  let graphicsForm;
+
+  const newProps = {
+    ...props,
+    projectId: undefined,
+    files: [],
+  };
+
+  beforeEach( () => {
+    Component = (
+      <MockedProvider mocks={ mocks } addTypename>
+        <GraphicFilesForm { ...newProps } />
+      </MockedProvider>
+    );
+
+    wrapper = mount( Component );
+    graphicsForm = wrapper.find( 'GraphicFilesForm' );
+  } );
+
+  it( 'renders a "No files..." message', () => {
+    const semanticForm = graphicsForm.find( 'Form' );
+    const noFilesWrapper = graphicsForm.find( '.no-files' );
+    const uploadMsg = 'Please upload at least one graphic file.';
+    const noFilesMsg = 'No files to upload';
+
+    expect( semanticForm.exists() ).toEqual( false );
+    expect( noFilesWrapper.exists() ).toEqual( true );
+    expect( noFilesWrapper.name() ).toEqual( 'p' );
+    expect( noFilesWrapper.contains( uploadMsg ) ).toEqual( false );
+    expect( noFilesWrapper.contains( noFilesMsg ) ).toEqual( true );
   } );
 } );
 

--- a/components/admin/ProjectEdit/GraphicEdit/GraphicFilesFormContainer/GraphicFilesForm/mocks.js
+++ b/components/admin/ProjectEdit/GraphicEdit/GraphicFilesFormContainer/GraphicFilesForm/mocks.js
@@ -123,6 +123,7 @@ const mocks = [
       query: UPDATE_GRAPHIC_PROJECT_MUTATION,
       variables: {
         data: {
+          type: 'SOCIAL_MEDIA',
           images: {
             'delete': {
               id: props.files[0].id,

--- a/components/admin/ProjectEdit/GraphicEdit/__snapshots__/GraphicEdit.test.js.snap
+++ b/components/admin/ProjectEdit/GraphicEdit/__snapshots__/GraphicEdit.test.js.snap
@@ -10,6 +10,7 @@ exports[`<GraphicEdit />, when there is an existing DRAFT graphic project render
       "publish": false,
       "publishChanges": false,
       "save": false,
+      "unpublish": false,
     }
   }
   handle={
@@ -595,6 +596,7 @@ exports[`<GraphicEdit />, when there is an existing PUBLISHED graphic project re
       "publish": false,
       "publishChanges": false,
       "save": false,
+      "unpublish": false,
     }
   }
   handle={
@@ -1180,6 +1182,7 @@ exports[`<GraphicEdit />, when there is no props.id and local files have been se
       "publish": true,
       "publishChanges": true,
       "save": true,
+      "unpublish": true,
     }
   }
   handle={


### PR DESCRIPTION
* Includes CDP-1932
* Disables the unpublish button on the graphic project details page if there are no graphic files. Previously, the unpublish button was always enabled
* Sets the `disableBtns` state based on the presence of graphic files. Previously, `disableBtns` was set to `true` if there were no graphic files and never reset to `false`
* Adjusts the no files message to instruct the user to upload at least one graphic file, if it's an existing project.
* Returns the graphic project `type` when the `updateGraphicProject` mutation is called to delete a graphic file. This allows the `useIsDirty` hook to return `true` when a graphic file is deleted, which displays the Publish Changes button. This change addresses CDP-1932.