### PR TITLE
CDP-2134: Add Internal Use Only flag to graphic projects on Commons when they are marked as Internal on Publisher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,8 @@ _This sections lists changes committed since most recent release_
 - Set disableBtns state based on the presence of graphic files
 - Adjust the no files message to instruct the user to upload at least one graphic file (for an existing project)
 - Return the graphic project type when updateGraphicProject is called to delete a graphic file
+- Display "Internal Use Only" message in graphic project previews and card if project visibility is INTERNAL
+- Update tests for GraphicProject and GraphicCard
  
  
 

--- a/components/GraphicProject/GraphicCard/GraphicCard.js
+++ b/components/GraphicProject/GraphicCard/GraphicCard.js
@@ -4,10 +4,14 @@ import moment from 'moment';
 import useSignedUrl from 'lib/hooks/useSignedUrl';
 import { getCount } from 'lib/utils';
 import { Modal } from 'semantic-ui-react';
+
+import InternalUseDisplay from 'components/InternalUseDisplay/InternalUseDisplay';
 import MediaObject from 'components/MediaObject/MediaObject';
 import TagsList from 'components/modals/ModalPostTags/ModalPostTags';
+
 import DosSeal from 'static/images/dos_seal.svg';
 import logoShareAmerica from 'static/images/logo_shareamerica.svg';
+
 import { getGraphicImgsBySocial } from '../utils';
 import GraphicProject from '../GraphicProject';
 import './GraphicCard.scss';
@@ -26,6 +30,7 @@ const GraphicCard = ( { item } ) => {
     images,
     categories,
     icon,
+    visibility,
   } = item;
 
   // Filter for Twitter imgs if available || return all imgs
@@ -50,6 +55,10 @@ const GraphicCard = ( { item } ) => {
         <img src={ signedUrl } alt={ thumbnailImg.alt } data-img="graphic_thumbnail" />
         <img src={ icon } className="graphic_icon" alt="graphic card icon" />
       </div>
+
+      { visibility === 'INTERNAL'
+          && <InternalUseDisplay style={ { margin: '0.5em auto 0 1em' } } /> }
+
       <Modal
         open={ isOpen }
         onOpen={ handleOpen }

--- a/components/GraphicProject/GraphicCard/GraphicCard.test.js
+++ b/components/GraphicProject/GraphicCard/GraphicCard.test.js
@@ -14,11 +14,11 @@ const mockedSignedUrl = 'https://mockImg.jpg';
 
 jest.mock( 'lib/hooks/useSignedUrl', () => jest.fn( () => ( { signedUrl: mockedSignedUrl } ) ) );
 
+jest.mock(
+  'components/InternalUseDisplay/InternalUseDisplay',
+  () => function InternalUseDisplay() { return ''; },
+);
 jest.mock( '../GraphicProject', () => function GraphicProject() { return ''; } );
-
-const props = {
-  item: normalizeItem( graphicElasticMock[0], 'en-us' ),
-};
 
 // Set default thumbnail img
 // const filteredGraphicImgs = getGraphicImgsBySocial( props.item.images, 'Twitter' );
@@ -33,10 +33,17 @@ const props = {
 // };
 // const thumbnailImg = setDefaultImg();
 
-const Component = <GraphicCard { ...props } />;
+describe( '<GraphicCard />', () => {
+  const props = {
+    item: normalizeItem( graphicElasticMock[0], 'en-us' ),
+  };
+  let Component;
+  let wrapper;
 
-describe( 'GraphicCard', () => {
-  const wrapper = mount( Component );
+  beforeEach( () => {
+    Component = <GraphicCard { ...props } />;
+    wrapper = mount( Component );
+  } );
 
   it( 'renders without crashing', () => {
     expect( wrapper.exists() ).toEqual( true );
@@ -126,5 +133,36 @@ describe( 'GraphicCard', () => {
 
     expect( mediaObj.find( '.media > span' ).text() ).toEqual( propsOwner );
     expect( mediaObj.find( '.media > img' ).prop( 'src' ) ).toEqual( 'image-stub' );
+  } );
+
+  it( 'does not render the InternalUseDisplay', () => {
+    const internalDisplay = wrapper.find( 'InternalUseDisplay' );
+
+    expect( internalDisplay.exists() ).toEqual( false );
+  } );
+} );
+
+describe( '<GraphicCard />, with INTERNAL visibility', () => {
+  const props = {
+    item: {
+      ...normalizeItem( graphicElasticMock[0], 'en-us' ),
+      visibility: 'INTERNAL',
+    },
+  };
+  let Component;
+  let wrapper;
+
+  beforeEach( () => {
+    Component = <GraphicCard { ...props } />;
+    wrapper = mount( Component );
+  } );
+
+  it( 'renders the InternalUseDisplay', () => {
+    const internalDisplay = wrapper.find( 'InternalUseDisplay' );
+
+    expect( internalDisplay.exists() ).toEqual( true );
+    expect( internalDisplay.props() ).toEqual( {
+      style: { margin: '0.5em auto 0 1em' },
+    } );
   } );
 } );

--- a/components/GraphicProject/GraphicProject.js
+++ b/components/GraphicProject/GraphicProject.js
@@ -14,11 +14,12 @@ import {
 import downloadIcon from 'static/icons/icon_download.svg';
 import shareIcon from 'static/icons/icon_share.svg';
 
+import DownloadItem from 'components/download/DownloadItem/DownloadItem';
+import InternalUseDisplay from 'components/InternalUseDisplay/InternalUseDisplay';
 import Notification from 'components/Notification/Notification';
 import Popover from 'components/popups/Popover/Popover';
-import TabLayout from 'components/TabLayout/TabLayout';
-import DownloadItem from 'components/download/DownloadItem/DownloadItem';
 import Share from 'components/Share/Share';
+import TabLayout from 'components/TabLayout/TabLayout';
 import GraphicFiles from './Download/GraphicFiles';
 import GenericFiles from './Download/GenericFiles';
 import Help from './Download/Help';
@@ -52,6 +53,7 @@ const GraphicProject = ( {
     projectType,
     published,
     modified,
+    visibility,
     owner,
     title: projectTitle,
     desc,
@@ -236,6 +238,10 @@ const GraphicProject = ( {
             handleLanguageChange={ handleLanguageChange }
           />
         </div>
+
+        { visibility === 'INTERNAL'
+          && <InternalUseDisplay style={ { marginLeft: 'auto' } } /> }
+
         <div className="trigger-container">
           <Popover
             id={ `${id}_graphic-share` }

--- a/components/GraphicProject/GraphicProject.test.js
+++ b/components/GraphicProject/GraphicProject.test.js
@@ -57,6 +57,10 @@ jest.mock(
 );
 
 jest.mock(
+  'components/InternalUseDisplay/InternalUseDisplay',
+  () => function InternalUseDisplay() { return ''; },
+);
+jest.mock(
   'components/Notification/Notification',
   () => function Notification() { return ''; },
 );
@@ -291,6 +295,12 @@ describe( '<GraphicProject />, for GraphQL data', () => {
       tags: getTransformedLangTaxArray( props.item.categories ),
     } );
   } );
+
+  it( 'does not render the InternalUseDisplay if visibility is PUBLIC', () => {
+    const internalDisplay = wrapper.find( 'InternalUseDisplay' );
+
+    expect( internalDisplay.exists() ).toEqual( false );
+  } );
 } );
 
 describe( '<GraphicProject />, for GraphQL data with no project alt', () => {
@@ -388,6 +398,35 @@ describe( '<GraphicProject />, for GraphQL data with null support files', () => 
 
   it( 'renders without crashing', () => {
     expect( wrapper.exists() ).toEqual( true );
+  } );
+} );
+
+describe( '<GraphicProject />, for GraphQL data with INTERNAL visibility', () => {
+  const props = {
+    displayAsModal: true,
+    isAdminPreview: true,
+    item: {
+      ...graphicGraphqlMock,
+      visibility: 'INTERNAL',
+    },
+    useGraphQl: true,
+  };
+
+  let Component;
+  let wrapper;
+
+  beforeEach( () => {
+    Component = <GraphicProject { ...props } />;
+    wrapper = mount( Component );
+  } );
+
+  it( 'renders the InternalUseDisplay', () => {
+    const internalDisplay = wrapper.find( 'InternalUseDisplay' );
+
+    expect( internalDisplay.exists() ).toEqual( true );
+    expect( internalDisplay.props() ).toEqual( {
+      style: { marginLeft: 'auto' },
+    } );
   } );
 } );
 
@@ -559,6 +598,12 @@ describe( '<GraphicProject />, for ElasticSearch data', () => {
       tags: props.item.categories,
     } );
   } );
+
+  it( 'does not render the InternalUseDisplay if visibility is PUBLIC', () => {
+    const internalDisplay = wrapper.find( 'InternalUseDisplay' );
+
+    expect( internalDisplay.exists() ).toEqual( false );
+  } );
 } );
 
 describe( '<GraphicProject />, for ElasticSearch data with no image alts', () => {
@@ -649,6 +694,36 @@ describe( '<GraphicProject />, for ElasticSearch data with null support files', 
 
   it( 'renders without crashing', () => {
     expect( wrapper.exists() ).toEqual( true );
+  } );
+} );
+
+describe( '<GraphicProject />, for ElasticSearch data with INTERNAL visibility', () => {
+  const props = {
+    item: {
+      ...graphicElasticMock[0]._source,
+      visibility: 'INTERNAL',
+    },
+  };
+
+  const normalizedData = normalizeGraphicProjectByAPI( {
+    file: props.item,
+  } );
+
+  let Component;
+  let wrapper;
+
+  beforeEach( () => {
+    Component = <GraphicProject { ...props } />;
+    wrapper = mount( Component );
+  } );
+
+  it( 'renders the InternalUseDisplay', () => {
+    const internalDisplay = wrapper.find( 'InternalUseDisplay' );
+
+    expect( internalDisplay.exists() ).toEqual( true );
+    expect( internalDisplay.props() ).toEqual( {
+      style: { marginLeft: 'auto' },
+    } );
   } );
 } );
 

--- a/components/GraphicProject/utils.js
+++ b/components/GraphicProject/utils.js
@@ -26,6 +26,7 @@ export const normalizeGraphicProjectByAPI = ( { file, useGraphQl = false } ) => 
     images: file.images || [],
     supportFiles: file.supportFiles || [],
     categories: file.categories || '',
+    visibility: file.visibility || 'PUBLIC',
   };
 
   // Elastic API

--- a/lib/elastic/parser.js
+++ b/lib/elastic/parser.js
@@ -379,6 +379,7 @@ export const normalizeItem = ( item, language ) => {
     link: source.link || '',
     published: source.published,
     modified: source.modified,
+    visibility: source.visibility,
   };
 
   const typeSpecificObj = getTypeSpecObj( source, language );


### PR DESCRIPTION
* Displays "Internal Use Only" message in graphic project previews and result cards if a project has been marked INTERNAL
* Updates tests for GraphicProject and GraphicCard