### PR TITLE
CDP-2135: Double signing of post featured image urls

### DIFF
--- a/components/Post/Post.js
+++ b/components/Post/Post.js
@@ -26,7 +26,6 @@ import Popup from 'components/popups/Popup';
 import Share from 'components/Share/Share';
 import EmbedPost from './EmbedPost';
 import EmbedHelp from './EmbedHelp';
-import useSignedUrl from 'lib/hooks/useSignedUrl';
 
 const Post = ( { item, router } ) => {
   const { publicRuntimeConfig } = getConfig();
@@ -39,8 +38,6 @@ const Post = ( { item, router } ) => {
     // eslint-disable-next-line camelcase
     item?.language?.text_direction ? item.language.text_direction : 'ltr',
   );
-
-  const { signedUrl } = useSignedUrl( selectedItem?.thumbnail ? selectedItem.thumbnail : '' );
 
   useEffect( () => {
     if ( selectedItem ) {
@@ -127,7 +124,7 @@ const Post = ( { item, router } ) => {
             />
           </div>
         </div>
-        <ModalImage thumbnail={ signedUrl } thumbnailMeta={ selectedItem.thumbnailMeta } />
+        <ModalImage thumbnail={ selectedItem?.thumbnail || '' } thumbnailMeta={ selectedItem.thumbnailMeta } />
         <ModalContentMeta type={ selectedItem.type } dateUpdated={ selectedItem.modified } />
         <ModalText textContent={ selectedItem.content } />
         <ModalPostMeta

--- a/components/Post/Post.test.js
+++ b/components/Post/Post.test.js
@@ -3,7 +3,6 @@ import { mount } from 'enzyme';
 import Post from './Post';
 import { mockItem } from './mocks';
 
-const mockSignedUrl = 'https://example.jpg';
 const mockRouter = { pathname: '/post' };
 
 jest.mock( 'next/config', () => () => ( {
@@ -12,8 +11,6 @@ jest.mock( 'next/config', () => () => ( {
     REACT_APP_SINGLE_ARTICLE_MODULE: '',
   },
 } ) );
-
-jest.mock( 'lib/hooks/useSignedUrl', () => jest.fn( () => ( { signedUrl: mockSignedUrl } ) ) );
 
 jest.mock( 'components/modals/ModalItem', () => 'modal-item' );
 jest.mock( 'components/modals/ModalLangDropdown/ModalLangDropdown', () => 'modal-lang-dropdown' );
@@ -48,7 +45,7 @@ describe( '<Post />', () => {
     const modalImage = wrapper.find( 'modal-image' );
 
     expect( modalImage.exists() ).toEqual( true );
-    expect( modalImage.prop( 'thumbnail' ) ).toEqual( mockSignedUrl );
+    expect( modalImage.prop( 'thumbnail' ) ).toEqual( mockItem.thumbnail );
     expect( modalImage.prop( 'thumbnailMeta' ) ).toEqual( mockItem.thumbnailMeta );
   } );
 

--- a/lib/hooks/useSignedUrl.js
+++ b/lib/hooks/useSignedUrl.js
@@ -32,7 +32,7 @@ const useSignedUrl = ( url, fallback ) => {
     };
 
     // Checks if url is to the S3 bucket and passes it through if not
-    if ( url.includes( path ) ) {
+    if ( url.includes( path ) && !url.includes( 'AWSAccessKeyId' ) ) {
       getSignedUrl();
     } else {
       setSignedUrl( url );


### PR DESCRIPTION
- Pass plain URL (rather than a signed URL) to the post modal image
- Update corresponding tests
- In `useSignedUrl` hook, check for presence of AWS access key in URL before attempting to convert to a signed URL.