### PR TITLE
CDP-2055: Open a PG package and see in order, 1. releases, 2. guidances, and 3. transcripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,7 @@ _This sections lists changes committed since most recent release_
 - Return the graphic project type when updateGraphicProject is called to delete a graphic file
 - Display "Internal Use Only" message in graphic project previews and card if project visibility is INTERNAL
 - Update tests for GraphicProject and GraphicCard
+- Display press guidance package documents in the order of releases, guidances, and transcripts
  
  
 

--- a/components/Package/Package.js
+++ b/components/Package/Package.js
@@ -1,24 +1,27 @@
 import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
-import { updateUrl } from 'lib/browser';
-import { getCount, getPluralStringOrNot, getPreviewNotificationStyles } from 'lib/utils';
+import sortBy from 'lodash/sortBy';
 import { Card } from 'semantic-ui-react';
+
 import DownloadPkgFiles from 'components/admin/download/DownloadPkgFiles/DownloadPkgFiles';
 import MetaTerms from 'components/admin/MetaTerms/MetaTerms';
 import ModalItem from 'components/modals/ModalItem/ModalItem';
 import Notification from 'components/Notification/Notification';
+import PackageItem from './PackageItem/PackageItem';
 import Popup from 'components/popups/Popup';
 import PopupTrigger from 'components/popups/PopupTrigger';
 import PopupTabbed from 'components/popups/PopupTabbed';
 import Share from 'components/Share/Share';
 import VisuallyHidden from 'components/VisuallyHidden/VisuallyHidden';
+
 import downloadIcon from 'static/icons/icon_download.svg';
 import shareIcon from 'static/icons/icon_share.svg';
 
-import PackageItem from './PackageItem/PackageItem';
 import {
   normalizeDocumentItemByAPI, getDateTimeTerms,
 } from './utils';
+import { updateUrl } from 'lib/browser';
+import { getCount, getPluralStringOrNot, getPreviewNotificationStyles } from 'lib/utils';
 
 import './Package.scss';
 
@@ -42,6 +45,17 @@ const Package = props => {
       updateUrl( `/package?id=${id}&site=${site}&language=en-us` );
     }
   }, [] );
+
+  const getSortedDocuments = array => {
+    if ( getCount( array ) === 0 ) {
+      return array;
+    }
+
+    const primarySortKey = useGraphQl ? 'use.name' : 'use';
+    const secondarySortKey = 'filename';
+
+    return sortBy( array, [primarySortKey, secondarySortKey] );
+  };
 
   const getCollatedDocuments = () => {
     /**
@@ -88,12 +102,14 @@ const Package = props => {
     } );
 
     return [
-      ...releases,
-      ...guidances,
-      ...transcripts,
-      ...otherDocs,
+      ...getSortedDocuments( releases ),
+      ...getSortedDocuments( guidances ),
+      ...getSortedDocuments( transcripts ),
+      ...getSortedDocuments( otherDocs ),
     ];
   };
+
+  const collatedDocuments = getCollatedDocuments();
 
   return (
     <ModalItem
@@ -175,7 +191,7 @@ const Package = props => {
       <div className="package-items">
         <Card.Group>
           { getCount( documents )
-            ? getCollatedDocuments().map( file => (
+            ? collatedDocuments.map( file => (
               <PackageItem
                 key={ file.id }
                 file={ normalizeDocumentItemByAPI( { file, useGraphQl } ) }

--- a/components/Package/Package.js
+++ b/components/Package/Package.js
@@ -43,6 +43,58 @@ const Package = props => {
     }
   }, [] );
 
+  const getCollatedDocuments = () => {
+    /**
+     * Collate in this order:
+     * 1. Releases, 2. Guidances, 3. Transcripts, 4. Other
+     */
+    const releases = [];
+    const guidances = [];
+    const transcripts = [];
+    const otherDocs = [];
+
+    documents.forEach( doc => {
+      const documentUse = useGraphQl ? doc.use.name : doc.use;
+
+      switch ( documentUse ) {
+        case 'Statement':
+        case 'Travel Alert':
+        case 'Travel Warning':
+        case 'Fact Sheet':
+        case 'Media Note':
+        case 'Readout':
+        case 'Notice to the Press':
+        case 'Taken Questions':
+          releases.push( doc );
+          break;
+
+        case 'Press Guidance':
+          guidances.push( doc );
+          break;
+
+        case 'Interview':
+        case 'On-the-record Briefing':
+        case 'Remarks':
+        case 'Background Briefing':
+        case 'Speeches':
+        case 'Department Press Briefing':
+          transcripts.push( doc );
+          break;
+
+        default:
+          otherDocs.push( doc );
+          break;
+      }
+    } );
+
+    return [
+      ...releases,
+      ...guidances,
+      ...transcripts,
+      ...otherDocs,
+    ];
+  };
+
   return (
     <ModalItem
       className={ isAdminPreview ? 'package package--preview' : 'package' }
@@ -122,8 +174,8 @@ const Package = props => {
 
       <div className="package-items">
         <Card.Group>
-          {getCount( documents )
-            ? documents.map( file => (
+          { getCount( documents )
+            ? getCollatedDocuments().map( file => (
               <PackageItem
                 key={ file.id }
                 file={ normalizeDocumentItemByAPI( { file, useGraphQl } ) }


### PR DESCRIPTION
* Displays press guidance package documents in the order of releases, guidances, and transcripts
* Groupings per press team:

**Releases**
* Fact Sheet
* Media Note
* Notice to the Press
* Readout
* Taken Questions
* Statement
* Travel Alert
* Travel Warning

**Guidances**
* Press Guidance

**Transcripts**
* Background Briefing
* Department Press Briefing
* Interview
* On-the-record Briefing
* Remarks
* Speeches