### PR TITLE
[CDP-2066] Adds login reminder after 5 seconds, timeout and manual close

### DIFF
--- a/components/navs/global/LoggedOutNav/LoggedOutNav.js
+++ b/components/navs/global/LoggedOutNav/LoggedOutNav.js
@@ -4,7 +4,7 @@
  *
  */
 
-import React, { useEffect, useState } from 'react';
+import React, { Fragment, useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import Link from 'next/link';
 import {
@@ -85,7 +85,7 @@ const LoggedOutNav = props => {
   );
 
   const renderMenuItem = item => (
-    <Menu.Item key={ item.key } name={ item.name }>
+    <Menu.Item as="li" key={ item.key } name={ item.name }>
       <Link href={ item.to } passHref>
         <a>{ item.label }</a>
       </Link>
@@ -122,26 +122,26 @@ const LoggedOutNav = props => {
   };
 
   const renderDesktopNav = items => (
-    <Menu className="nav_loggedout">
-      {items.map( item => renderMenuItem( item ) )}
-      <Menu.Item key="4" name="login">
+    <Menu as="ul" className="nav_loggedout">
+      { items.map( item => renderMenuItem( item ) ) }
+      <Menu.Item as="li" key="4" name="login">
         <a href="/login">Login</a>
       </Menu.Item>
-      {reminder && (
-        <div className="login_reminder">
+      { reminder && (
+        <li className="login_reminder">
           DOS employees, you can log in to see more content.
-          <a href="/remove-login-reminder" aria-label="Close Login Reminder" className="login_reminder_close" onClick={ e => { e.preventDefault(); setReminder( false ); } }>
+          <button type="button" aria-label="Close Login Reminder" className="login_reminder_close" onClick={ () => setReminder( false ) }>
             Got it
-          </a>
-        </div>
-      )}
-      {renderFeedbackButton()}
+          </button>
+        </li>
+      ) }
+      { renderFeedbackButton() }
     </Menu>
   );
 
 
   return (
-    <>
+    <Fragment>
       { /* Desktop nav */ }
       { !mobileMenuVisible && (
         <div>
@@ -151,7 +151,7 @@ const LoggedOutNav = props => {
 
       { /* Mobile nav */ }
       <div>{ renderMobileNav( menuItems ) }</div>
-    </>
+    </Fragment>
   );
 };
 

--- a/components/navs/global/LoggedOutNav/LoggedOutNav.js
+++ b/components/navs/global/LoggedOutNav/LoggedOutNav.js
@@ -11,6 +11,7 @@ import {
   Menu, Icon,
 } from 'semantic-ui-react';
 import config from 'config';
+import useTimeout from 'lib/hooks/useTimeout';
 import HamburgerIcon from '../HamburgerIcon';
 
 const menuItems = [
@@ -46,12 +47,14 @@ const LoggedOutNav = props => {
 
   const [reminder, setReminder] = useState( false );
 
+  const { startTimeout: showReminder } = useTimeout( () => setReminder( true ), 5000 );
+  const { startTimeout: hideReminder } = useTimeout( () => setReminder( false ), 35000 );
 
   useEffect( () => {
     window.addEventListener( 'resize', closeMobileMenu );
 
-    setTimeout( () => setReminder( true ), 5000 );
-    setTimeout( () => setReminder( false ), 35000 );
+    showReminder();
+    hideReminder();
 
     return () => {
       window.removeEventListener( 'resize', closeMobileMenu );

--- a/components/navs/global/LoggedOutNav/LoggedOutNav.js
+++ b/components/navs/global/LoggedOutNav/LoggedOutNav.js
@@ -4,11 +4,11 @@
  *
  */
 
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import Link from 'next/link';
 import {
-  Menu, Icon
+  Menu, Icon,
 } from 'semantic-ui-react';
 import config from 'config';
 import HamburgerIcon from '../HamburgerIcon';
@@ -18,20 +18,20 @@ const menuItems = [
     key: 1,
     name: 'about',
     to: '/about',
-    label: 'About'
+    label: 'About',
   },
   {
     key: 2,
     name: 'help',
     to: '/help',
-    label: 'Help'
+    label: 'Help',
   },
   {
     key: 3,
     name: 'documentation',
     to: '/documentation',
-    label: 'Documentation'
-  }
+    label: 'Documentation',
+  },
 ];
 
 const LoggedOutNav = props => {
@@ -44,9 +44,15 @@ const LoggedOutNav = props => {
     toggleMobileMenu( false );
   };
 
+  const [reminder, setReminder] = useState( false );
+
 
   useEffect( () => {
     window.addEventListener( 'resize', closeMobileMenu );
+
+    setTimeout( () => setReminder( true ), 5000 );
+    setTimeout( () => setReminder( false ), 35000 );
+
     return () => {
       window.removeEventListener( 'resize', closeMobileMenu );
     };
@@ -96,19 +102,19 @@ const LoggedOutNav = props => {
         />
       );
     }
- 
+
     return (
       <ul>
         <li>
-          <Icon name="close" onClick={() => toggleMobileMenu(false)} onKeyUp={keyUp} tabIndex={0} />
+          <Icon name="close" onClick={ () => toggleMobileMenu( false ) } onKeyUp={ keyUp } tabIndex={ 0 } />
         </li>
-        {items.map((item) => renderListItem(item))}
-        <li> 
+        {items.map( item => renderListItem( item ) )}
+        <li>
           <a href="/login">
-            <span onClick={() => toggleMobileMenu(false)} onKeyUp={keyUp} role="presentation">
+            <span onClick={ () => toggleMobileMenu( false ) } onKeyUp={ keyUp } role="presentation">
               Login
             </span>
-          </a> 
+          </a>
         </li>
         {renderFeedbackButton()}
       </ul>
@@ -116,15 +122,21 @@ const LoggedOutNav = props => {
   };
 
   const renderDesktopNav = items => (
-    <>
-      <Menu className="nav_loggedout">
-        { items.map( item => renderMenuItem( item ) ) }
-        <Menu.Item key="4" name="login">
-          <a href="/login">Login</a>
-        </Menu.Item>
-        { renderFeedbackButton() }
-      </Menu>
-    </>
+    <Menu className="nav_loggedout">
+      {items.map( item => renderMenuItem( item ) )}
+      <Menu.Item key="4" name="login">
+        <a href="/login">Login</a>
+      </Menu.Item>
+      {reminder && (
+        <div className="login_reminder">
+          DOS employees, you can log in to see more content.
+          <a href="/remove-login-reminder" aria-label="Close Login Reminder" className="login_reminder_close" onClick={ e => { e.preventDefault(); setReminder( false ); } }>
+            Got it
+          </a>
+        </div>
+      )}
+      {renderFeedbackButton()}
+    </Menu>
   );
 
 
@@ -146,7 +158,7 @@ const LoggedOutNav = props => {
 LoggedOutNav.propTypes = {
   mobileMenuVisible: PropTypes.bool,
   toggleMobileMenu: PropTypes.func,
-  keyUp: PropTypes.func
+  keyUp: PropTypes.func,
 };
 
 export default LoggedOutNav;

--- a/components/navs/global/LoggedOutNav/LoggedOutNav.test.js
+++ b/components/navs/global/LoggedOutNav/LoggedOutNav.test.js
@@ -1,0 +1,83 @@
+import { mount } from 'enzyme';
+import LoggedOutNav from './LoggedOutNav';
+
+jest.mock(
+  '../HamburgerIcon',
+  () => function HamburgerIcon() { return ''; },
+);
+
+describe( '<LoggedOutNav />', () => {
+  const props = {
+    mobileMenuVisible: false,
+    toggleMobileMenu: jest.fn(),
+    keyUp: jest.fn(),
+  };
+
+  let Component;
+  let wrapper;
+
+  beforeEach( () => {
+    Component = <LoggedOutNav { ...props } />;
+    wrapper = mount( Component );
+  } );
+
+  it( 'renders without crashing', () => {
+    expect( wrapper.exists() ).toEqual( true );
+  } );
+
+  it( 'renders the ul', () => {
+    const unorderedList = wrapper.find( 'ul' );
+
+    expect( unorderedList.exists() ).toEqual( true );
+    expect( unorderedList.prop( 'className' ) )
+      .toEqual( 'ui nav_loggedout menu' );
+  } );
+
+  it( 'renders the correct menu items', () => {
+    const items = wrapper.find( 'MenuItem' );
+    const menuItems = [
+      {
+        name: 'about',
+        to: '/about',
+        label: 'About',
+      },
+      {
+        name: 'help',
+        to: '/help',
+        label: 'Help',
+      },
+      {
+        name: 'documentation',
+        to: '/documentation',
+        label: 'Documentation',
+      },
+      {
+        name: 'login',
+        to: '/login',
+        label: 'Login',
+      },
+    ];
+
+    items.forEach( ( item, i ) => {
+      const link = item.find( 'a' );
+      const { label, name, to } = menuItems[i];
+
+      expect( item.prop( 'name' ) ).toEqual( name );
+      expect( link.contains( label ) ).toEqual( true );
+      expect( link.prop( 'href' ) ).toEqual( to );
+    } );
+  } );
+
+  it( 'renders the feedback link', () => {
+    const feedback = wrapper.find( 'a.feedback' );
+
+    expect( feedback.exists() ).toEqual( true );
+    expect( feedback.props() ).toEqual( {
+      href: 'https://goo.gl/forms/9cJ3IBHH9QTld2Mj2',
+      target: '_blank',
+      className: 'item feedback',
+      rel: 'noopener noreferrer',
+      children: [' ', 'Feedback'],
+    } );
+  } );
+} );

--- a/components/navs/global/global.scss
+++ b/components/navs/global/global.scss
@@ -177,6 +177,29 @@ nav {
       color: #046b99;
       box-shadow: 0px 1px 2px rgba(0,0,0,0.2);
 
+      // animate the reminder
+      animation: shakeY 6000ms ease-in-out 1s 3;
+      @keyframes shakeY {
+        from,
+        to {
+          transform: translate3d(0, 0, 0);
+        }
+      
+        1%,
+        3%,
+        5%,
+        7% {
+          transform: translate3d(0, -2px, 0);
+        }
+      
+        2%,
+        4%,
+        6%,
+        8% {
+          transform: translate3d(0, 0, 0);
+        }
+      }
+
       &::after {
         content: "";
         position: absolute;

--- a/components/navs/global/global.scss
+++ b/components/navs/global/global.scss
@@ -1,4 +1,5 @@
-@import "../../../styles/colors.scss";
+@import "styles/mixins.scss";
+@import "styles/colors.scss";
 
 .bar--home nav {
   position: absolute;
@@ -148,6 +149,7 @@ nav {
     box-shadow: none;
     background: transparent;
     position: relative;
+    padding: 0;
     @media screen and (min-width: 993px) {
       display: flex;
       align-items: center;
@@ -163,15 +165,15 @@ nav {
     &.nav_loggedout .login_reminder {
       position: absolute;
       top: 50px;
-      background-color: #e1f3f8;
-      padding: 10px 25px;
+      background-color: $ice-blue;
+      padding: 0.5rem 1rem;
       border-radius: 4px;
       font-family: "Source Sans Pro";
-      font-size: 21px;
-      line-height: 30px;
+      font-size: 0.666666667rem;
+      line-height: initial;
       text-align: left;
-      width: 310px;
-      right: 24.5%;
+      width: 11rem;
+      right: 30%;
       color: #046b99;
       box-shadow: 0px 1px 2px rgba(0,0,0,0.2);
 
@@ -186,13 +188,19 @@ nav {
         height: 0;
         border-right: 10px solid transparent;
         border-left: 10px solid transparent;
-        border-bottom: 10px solid #e1f3f8;
+        border-bottom: 10px solid $ice-blue;
       }
 
-      a.login_reminder_close {
+      button.login_reminder_close {
+        @include button-style-reset($font-size: 0.666666667rem);
         display: block;
         margin-top: 10px;
         font-weight: 600;
+        cursor: pointer;
+
+        &:focus {
+          @include focus-styling;
+        }
       }
     }
 

--- a/components/navs/global/global.scss
+++ b/components/navs/global/global.scss
@@ -1,4 +1,4 @@
-@import '../../../styles/colors.scss';
+@import "../../../styles/colors.scss";
 
 .bar--home nav {
   position: absolute;
@@ -10,7 +10,7 @@
     z-index: 2;
   }
   @media screen and (max-width: 767px) {
-    position: fixed;    
+    position: fixed;
   }
 
   &.loader {
@@ -35,7 +35,7 @@
     &:hover,
     &:focus {
       &:after {
-        content: '';
+        content: "";
         position: absolute;
         left: 0;
         bottom: 0;
@@ -59,7 +59,7 @@ nav {
   @media screen and (max-width: 767px) {
     position: absolute;
     top: 0;
-    right: 0;    
+    right: 0;
   }
 
   .hamburger {
@@ -84,7 +84,7 @@ nav {
 
     &.hide {
       display: none;
-    }    
+    }
   }
 
   ul {
@@ -147,6 +147,7 @@ nav {
     border: none;
     box-shadow: none;
     background: transparent;
+    position: relative;
     @media screen and (min-width: 993px) {
       display: flex;
       align-items: center;
@@ -156,7 +157,43 @@ nav {
     &.nav_loggedout .item {
       @media screen and (min-width: 1300px) {
         margin-right: 0.5em;
-      }      
+      }
+    }
+
+    &.nav_loggedout .login_reminder {
+      position: absolute;
+      top: 50px;
+      background-color: #e1f3f8;
+      padding: 10px 25px;
+      border-radius: 4px;
+      font-family: "Source Sans Pro";
+      font-size: 21px;
+      line-height: 30px;
+      text-align: left;
+      width: 310px;
+      right: 24.5%;
+      color: #046b99;
+      box-shadow: 0px 1px 2px rgba(0,0,0,0.2);
+
+      &::after {
+        content: "";
+        position: absolute;
+        display: block;
+        top: 0;
+        right: 10%;
+        margin-top: -10px;
+        width: 0;
+        height: 0;
+        border-right: 10px solid transparent;
+        border-left: 10px solid transparent;
+        border-bottom: 10px solid #e1f3f8;
+      }
+
+      a.login_reminder_close {
+        display: block;
+        margin-top: 10px;
+        font-weight: 600;
+      }
     }
 
     a.item:hover {


### PR DESCRIPTION
## Issue - [CDP-2066](https://design.atlassian.net/browse/CDP-2066)

## Description
Subscribers should be able to land on the homepage and see a pop up near the login button to remind them, they have to login in order to see internal content like Press Guidances and Editable Graphics files.

![image](https://user-images.githubusercontent.com/204326/86821159-06164800-c058-11ea-9517-688afa88f6e3.png)


## Fixes
- Adds a new stateful variable to track the visibility
- Uses CSS positioning to match mocks
- Sets timeout in useEffect to delay showing
- Sets timeout in useEffect to delay removal
- Allows manual removal as well

![image](https://user-images.githubusercontent.com/204326/86821245-28a86100-c058-11ea-9bfa-a422c8157f36.png)
