### PR TITLE
CDP-2139: When users are not logged in and they preview a Project Modal, the 'Other' tab displays weird download characters.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,7 @@ _This sections lists changes committed since most recent release_
 - Return the graphic project type when updateGraphicProject is called to delete a graphic file
 - Display "Internal Use Only" message in graphic project previews and card if project visibility is INTERNAL
 - Update tests for GraphicProject and GraphicCard
+- Use editable field to collate graphic project support files
  
  
 

--- a/components/GraphicProject/GraphicProject.js
+++ b/components/GraphicProject/GraphicProject.js
@@ -109,19 +109,12 @@ const GraphicProject = ( {
   const selectedUnitImages = images.filter( img => img.language.display_name === selectedUnitLanguage.display_name );
 
   const getSupportFiles = supportFileType => {
-    const editableExtensions = [
-      '.psd', '.ai', '.eps', '.ae', '.jpg', '.jpeg', '.png',
-    ];
     const editableFiles = [];
     const additionalFiles = [];
 
     if ( getCount( supportFiles ) ) {
       supportFiles.forEach( file => {
-        const extension = getFileExt( file.filename );
-
-        const hasEditableExt = editableExtensions.includes( extension );
-
-        if ( hasEditableExt ) {
+        if ( file.editable ) {
           editableFiles.push( file );
         } else {
           additionalFiles.push( file );


### PR DESCRIPTION
* Uses the support files editable field as the condition to collate graphic project support files. Previously, the condition was based on based on the presence of a file's extension in an array of editable extensions.