### PR TITLE
Vid downloads

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -15,11 +15,22 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
+
       - name: Set up environment
         uses: actions/setup-node@v1
         with:
           node-version: '10.15.1'
+
+      - name: Prepare dependency cache
+        uses: actions/cache@v2
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+
       - name: Install dependencies
         run: npm install
+
       - name: Run tests
         run: npm run test -- --colors --ci --silent

--- a/components/Video/Download/__tests__/DownloadCaption.test.js
+++ b/components/Video/Download/__tests__/DownloadCaption.test.js
@@ -44,7 +44,7 @@ describe( '<DownloadCaption />', () => {
     const expectedDownload = 'English_SRT';
     const expectedHeader = 'Download English SRT';
     const expectedHover = 'Download English SRT';
-    const expectedUrl = 'https://amgov-publisher-dev.s3.amazonaws.com/v1/task/download/eyJrZXkiOiJodHRwczovL2FtZ292LXB1Ymxpc2hlci1kZXYuczMuYW1hem9uYXdzLmNvbS8yMDIwLzA3ODhsd2Z2YWVwNy9jOWE0NTMzMTU3YTk3OTdhMWVjZWU2Y2EyZDhjMzgyYy5zcnQiLCJmaWxlbmFtZSI6ImM5YTQ1MzMxNTdhOTc5N2ExZWNlZTZjYTJkOGMzODJjLnNydCJ9';
+    const expectedUrl = 'https://amgov-publisher-dev.s3.amazonaws.com/v1/task/download/eyJrZXkiOiIiLCJmaWxlbmFtZSI6ImM5YTQ1MzMxNTdhOTc5N2ExZWNlZTZjYTJkOGMzODJjLnNydCIsInVybCI6Imh0dHBzOi8vYW1nb3YtcHVibGlzaGVyLWRldi5zMy5hbWF6b25hd3MuY29tLzIwMjAvMDc4OGx3ZnZhZXA3L2M5YTQ1MzMxNTdhOTc5N2ExZWNlZTZjYTJkOGMzODJjLnNydCJ9';
 
     const wrapper = mount( <DownloadCaption item={ mockItem } /> );
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -130,7 +130,9 @@ export const getS3Url = assetPath => `${getPathToS3Bucket( 'authoring' )}/${asse
 export const getS3UrlKey = ( url, bucket ) => {
   const path = getPathToS3Bucket( bucket );
 
-  return url.replace( `${path}/`, '' );
+  const key = url.includes( path ) ? url.replace( `${path}/`, '' ) : '';
+
+  return key;
 };
 
 export const escapeRegExp = string => string.replace( /[.*+-=&!?^~${}()|[\]\\]/g, '\\$&' );
@@ -455,7 +457,7 @@ export const getFileDownloadUrl = ( url, filename ) => {
   const { publicRuntimeConfig } = getConfig();
   const endpoint = `${publicRuntimeConfig.REACT_APP_PUBLIC_API}/v1/task/download`;
 
-  const params = JSON.stringify( { key: getS3UrlKey( url ), filename } );
+  const params = JSON.stringify( { key: getS3UrlKey( url ), filename, url } );
 
   return `${endpoint}/${btoa( unescape( encodeURIComponent( params ) ) )}`;
 };


### PR DESCRIPTION
- Ensure that a URL is always passed and a key only sent when relevant

Incidentally takes an opportunity to add dependency caching for GitHub actions, which should speed up the automated on pull requests test runner.