### PR TITLE
CDP-2155 (includes CDP-2143): Disable Language dropdown and set to English for Clean videos

### DIFF
--- a/components/Package/Package.test.js
+++ b/components/Package/Package.test.js
@@ -2,7 +2,7 @@ import { mount } from 'enzyme';
 import Router from 'next/router';
 import wait from 'waait';
 import { normalizeItem } from 'lib/elastic/parser';
-import { getPluralStringOrNot } from 'lib/utils';
+import { getPluralStringOrNot, suppressActWarning } from 'lib/utils';
 import DownloadPkgFiles from 'components/admin/download/DownloadPkgFiles/DownloadPkgFiles';
 import { getDateTimeTerms, normalizeDocumentItemByAPI } from './utils';
 import Package from './Package';
@@ -192,16 +192,7 @@ describe( '<Package /> (GraphQL API)', () => {
 describe( '<Package /> (Elastic API)', () => {
   const consoleError = console.error;
 
-  beforeAll( () => {
-    const actMsg = 'Warning: An update to %s inside a test was not wrapped in act';
-
-    jest.spyOn( console, 'error' ).mockImplementation( ( ...args ) => {
-      if ( !args[0].includes( actMsg ) ) {
-        consoleError( ...args );
-      }
-    } );
-  } );
-
+  beforeAll( () => suppressActWarning( consoleError ) );
   afterAll( () => {
     console.error = consoleError;
   } );

--- a/components/Package/PackageItem/PackageItem.test.js
+++ b/components/Package/PackageItem/PackageItem.test.js
@@ -2,6 +2,7 @@ import { mount } from 'enzyme';
 
 import PackageItem from './PackageItem';
 
+import { suppressActWarning } from 'lib/utils';
 import { normalizeDocumentItemByAPI } from '../utils.js';
 
 jest.mock( 'components/Document/DocumentCard/DocumentCard', () => 'document-card' );
@@ -166,22 +167,7 @@ const Component = (
   />
 );
 
-const suppressActWarning = consoleError => {
-  const actMsg = 'Warning: An update to %s inside a test was not wrapped in act';
-
-  jest.spyOn( console, 'error' ).mockImplementation( ( ...args ) => {
-    if ( !args[0].includes( actMsg ) ) {
-      consoleError( ...args );
-    }
-  } );
-};
-
 describe( '<PackageItem />', () => {
-  /**
-   * @todo Suppress React 16.8 `act()` warnings globally.
-   * The React team's fix won't be out of alpha until 16.9.0.
-   * @see https://github.com/facebook/react/issues/14769
-   */
   const consoleError = console.error;
 
   beforeAll( () => suppressActWarning( consoleError ) );

--- a/components/ScrollableTableWithMenu/TableActionsMenu/DeleteProjects/DeleteProjects.test.js
+++ b/components/ScrollableTableWithMenu/TableActionsMenu/DeleteProjects/DeleteProjects.test.js
@@ -5,7 +5,7 @@ import toJSON from 'enzyme-to-json';
 // import { MockedProvider } from '@apollo/react-testing';
 
 import DeleteProjects from './DeleteProjects';
-import { getPluralStringOrNot } from 'lib/utils';
+import { getPluralStringOrNot, suppressActWarning } from 'lib/utils';
 import { DashboardContext } from 'context/dashboardContext';
 
 import {
@@ -78,22 +78,7 @@ const NonDraftsComponent = (
   </DashboardContext.Provider>
 );
 
-const suppressActWarning = consoleError => {
-  const actMsg = 'Warning: An update to %s inside a test was not wrapped in act';
-
-  jest.spyOn( console, 'error' ).mockImplementation( ( ...args ) => {
-    if ( !args[0].includes( actMsg ) ) {
-      consoleError( ...args );
-    }
-  } );
-};
-
 describe.skip( '<DeleteProjects />', () => {
-  /**
-   * @todo Suppress React 16.8 `act()` warnings globally.
-   * The React team's fix won't be out of alpha until 16.9.0.
-   * @see https://github.com/facebook/react/issues/14769
-   */
   const consoleError = console.error;
 
   beforeAll( () => suppressActWarning( consoleError ) );

--- a/components/User/User.test.js
+++ b/components/User/User.test.js
@@ -1,7 +1,7 @@
 import { mount } from 'enzyme';
 import wait from 'waait';
 import { MockedProvider } from '@apollo/react-testing';
-
+import { suppressActWarning } from 'lib/utils';
 import User, { CURRENT_USER_QUERY } from './User';
 
 const props = {
@@ -41,16 +41,6 @@ const Component = (
     <User { ...props } />
   </MockedProvider>
 );
-
-const suppressActWarning = consoleError => {
-  const actMsg = 'Warning: An update to %s inside a test was not wrapped in act';
-
-  jest.spyOn( console, 'error' ).mockImplementation( ( ...args ) => {
-    if ( !args[0].includes( actMsg ) ) {
-      consoleError( ...args );
-    }
-  } );
-};
 
 describe( '<User />', () => {
   const consoleError = console.error;

--- a/components/admin/Dashboard/MyProjects/DetailsPopup/VideoDetailsPopup.test.js
+++ b/components/admin/Dashboard/MyProjects/DetailsPopup/VideoDetailsPopup.test.js
@@ -3,7 +3,7 @@ import toJSON from 'enzyme-to-json';
 import wait from 'waait';
 import { MockedProvider } from '@apollo/react-testing';
 import ApolloError from 'components/errors/ApolloError';
-import { formatBytes, getCount } from 'lib/utils';
+import { formatBytes, getCount, suppressActWarning } from 'lib/utils';
 import VideoDetailsPopup, {
   getValidFiles, getVideoFiles, VIDEO_PROJECT_FILES_QUERY,
 } from './VideoDetailsPopup';
@@ -170,16 +170,6 @@ const Component = (
     <VideoDetailsPopup { ...props } />
   </MockedProvider>
 );
-
-const suppressActWarning = consoleError => {
-  const actMsg = 'Warning: An update to %s inside a test was not wrapped in act';
-
-  jest.spyOn( console, 'error' ).mockImplementation( ( ...args ) => {
-    if ( !args[0].includes( actMsg ) ) {
-      consoleError( ...args );
-    }
-  } );
-};
 
 describe( '<VideoDetailsPopup />', () => {
   const consoleError = console.error;

--- a/components/admin/Dashboard/TeamProjects/DetailsPopup/VideoDetailsPopup.test.js
+++ b/components/admin/Dashboard/TeamProjects/DetailsPopup/VideoDetailsPopup.test.js
@@ -3,7 +3,7 @@ import toJSON from 'enzyme-to-json';
 import wait from 'waait';
 import { MockedProvider } from '@apollo/react-testing';
 import ApolloError from 'components/errors/ApolloError';
-import { formatBytes, getCount } from 'lib/utils';
+import { formatBytes, getCount, suppressActWarning } from 'lib/utils';
 import VideoDetailsPopup, {
   getValidFiles, getVideoFiles, VIDEO_PROJECT_FILES_QUERY,
 } from './VideoDetailsPopup';
@@ -171,16 +171,6 @@ const Component = (
     <VideoDetailsPopup { ...props } />
   </MockedProvider>
 );
-
-const suppressActWarning = consoleError => {
-  const actMsg = 'Warning: An update to %s inside a test was not wrapped in act';
-
-  jest.spyOn( console, 'error' ).mockImplementation( ( ...args ) => {
-    if ( !args[0].includes( actMsg ) ) {
-      consoleError( ...args );
-    }
-  } );
-};
 
 describe( '<VideoDetailsPopup />', () => {
   const consoleError = console.error;

--- a/components/admin/PackageEdit/PackageDetailsFormContainer/PackageDetailsFormContainer.test.js
+++ b/components/admin/PackageEdit/PackageDetailsFormContainer/PackageDetailsFormContainer.test.js
@@ -4,6 +4,7 @@ import { MockedProvider, wait } from '@apollo/react-testing';
 import PackageDetailsFormContainer from './PackageDetailsFormContainer';
 import { AWS_URL, AWS_SIGNED_URL_QUERY_STRING } from 'components/admin/PackageEdit/PackageFiles/mocks';
 import { UPDATE_PACKAGE_MUTATION } from 'lib/graphql/queries/package';
+import { suppressActWarning } from 'lib/utils';
 
 jest.mock( 'components/admin/PackageEdit/PackageDetailsFormContainer/PackageDetailsForm/PackageDetailsForm', () => 'package-details-form' );
 
@@ -277,23 +278,9 @@ const Component = (
 );
 
 describe( '<PackageDetailsFormContainer />', () => {
-  /**
-   * @todo Suppress React 16.8 `act()` warnings globally.
-   * The React team's fix won't be out of alpha until 16.9.0.
-   * @see https://github.com/facebook/react/issues/14769
-   */
   const consoleError = console.error;
 
-  beforeAll( () => {
-    const actMsg = 'Warning: An update to %s inside a test was not wrapped in act';
-
-    jest.spyOn( console, 'error' ).mockImplementation( ( ...args ) => {
-      if ( !args[0].includes( actMsg ) ) {
-        consoleError( ...args );
-      }
-    } );
-  } );
-
+  beforeAll( () => suppressActWarning( consoleError ) );
   afterAll( () => {
     console.error = consoleError;
   } );

--- a/components/admin/PackageEdit/PackageEdit.test.js
+++ b/components/admin/PackageEdit/PackageEdit.test.js
@@ -2,6 +2,8 @@ import { mount } from 'enzyme';
 import { MockedProvider, wait } from '@apollo/react-testing';
 import { RouterContext } from 'next/dist/next-server/lib/router-context';
 import PackageEdit from './PackageEdit';
+
+import { suppressActWarning } from 'lib/utils';
 import {
   errorMocks, mocks, noDocumentsMocks, props, undefinedDataMocks,
 } from './mocks';
@@ -24,15 +26,6 @@ jest.mock(
 jest.mock( 'next/config', () => () => ( { publicRuntimeConfig: { REACT_APP_AWS_S3_AUTHORING_BUCKET: 's3-bucket-url' } } ) );
 
 const getBtn = ( str, buttons ) => buttons.findWhere( n => n.text() === str && n.name() === 'button' );
-const suppressActWarning = consoleError => {
-  const actMsg = 'Warning: An update to %s inside a test was not wrapped in act';
-
-  jest.spyOn( console, 'error' ).mockImplementation( ( ...args ) => {
-    if ( !args[0].includes( actMsg ) ) {
-      consoleError( ...args );
-    }
-  } );
-};
 
 describe( '<PackageEdit />, if DRAFT status', () => {
   const router = {

--- a/components/admin/PackageEdit/PackageFiles/PackageFiles.test.js
+++ b/components/admin/PackageEdit/PackageFiles/PackageFiles.test.js
@@ -1,39 +1,28 @@
 import { mount } from 'enzyme';
+import { suppressActWarning } from 'lib/utils';
 import { props } from './mocks';
 import PackageFiles from './PackageFiles';
 
 jest.mock( 'next/dynamic', () => () => 'Press-Package-File' );
 jest.mock(
   'components/admin/PackageEdit/EditPackageFilesModal/EditPackageFilesModal',
-  () => function EditPackageFiles() { return ''; }
+  () => function EditPackageFiles() { return ''; },
 );
 
 jest.mock( 'lib/hooks/useCrudActionsDocument', () => ( {
   useCrudActionsDocument: () => ( {
     createFile: jest.fn(),
     deleteFile: jest.fn(),
-    updateFile: jest.fn()
-  } )
+    updateFile: jest.fn(),
+  } ),
 } ) );
 
 jest.mock( 'next/config', () => ( { publicRuntimeConfig: { REACT_APP_AWS_S3_AUTHORING_BUCKET: 's3-bucket-url' } } ) );
 
 describe( '<PackageFiles />', () => {
-  /**
-   * @todo Suppress React 16.8 `act()` warnings globally.
-   * The React team's fix won't be out of alpha until 16.9.0.
-   * @see https://github.com/facebook/react/issues/14769
-   */
   const consoleError = console.error;
-  beforeAll( () => {
-    const actMsg = 'Warning: An update to %s inside a test was not wrapped in act';
-    jest.spyOn( console, 'error' ).mockImplementation( ( ...args ) => {
-      if ( !args[0].includes( actMsg ) ) {
-        consoleError( ...args );
-      }
-    } );
-  } );
 
+  beforeAll( () => suppressActWarning( consoleError ) );
   afterAll( () => {
     console.error = consoleError;
   } );
@@ -113,6 +102,7 @@ describe( '<PackageFiles />', () => {
 
   it( 'renders the no files message and heading if there are no package documents', () => {
     const msg = 'This package does not have any uploaded files. Please upload at least one file to publish this package to Content Commons.';
+
     wrapper.setProps( { pkg: { documents: [] } } );
 
     expect( wrapper.contains( 'Uploaded File (0)' ) ).toEqual( true );

--- a/components/admin/PackageEdit/PackageFiles/PressPackageFile/PressPackageFile.test.js
+++ b/components/admin/PackageEdit/PackageFiles/PressPackageFile/PressPackageFile.test.js
@@ -1,5 +1,6 @@
 import { mount } from 'enzyme';
 import { HandleOnChangeContext } from 'components/admin/PackageEdit/PackageDetailsFormContainer/PackageDetailsForm/PackageDetailsForm';
+import { suppressActWarning } from 'lib/utils';
 import { AWS_URL, AWS_SIGNED_URL_QUERY_STRING } from '../mocks';
 import PressPackageFile from './PressPackageFile';
 
@@ -109,23 +110,9 @@ const Component = (
 );
 
 describe.skip( '<PressPackageFile />', () => {
-  /**
-   * @todo Suppress React 16.8 `act()` warnings globally.
-   * The React team's fix won't be out of alpha until 16.9.0.
-   * @see https://github.com/facebook/react/issues/14769
-   */
   const consoleError = console.error;
 
-  beforeAll( () => {
-    const actMsg = 'Warning: An update to %s inside a test was not wrapped in act';
-
-    jest.spyOn( console, 'error' ).mockImplementation( ( ...args ) => {
-      if ( !args[0].includes( actMsg ) ) {
-        consoleError( ...args );
-      }
-    } );
-  } );
-
+  beforeAll( () => suppressActWarning( consoleError ) );
   afterAll( () => {
     console.error = consoleError;
   } );

--- a/components/admin/Previews/PackagePreview/PackagePreview.test.js
+++ b/components/admin/Previews/PackagePreview/PackagePreview.test.js
@@ -1,7 +1,9 @@
 import { mount } from 'enzyme';
 import { MockedProvider, wait } from '@apollo/react-testing';
-import { errorMocks, mocks, undefinedDataMocks } from 'components/admin/PackageEdit/mocks';
 import PackagePreview from './PackagePreview';
+
+import { suppressActWarning } from 'lib/utils';
+import { errorMocks, mocks, undefinedDataMocks } from 'components/admin/PackageEdit/mocks';
 
 jest.mock(
   'components/Package/Package',
@@ -14,22 +16,7 @@ const getComponent = ( data, props = { id: 'test-123' } ) => (
   </MockedProvider>
 );
 
-const suppressActWarning = consoleError => {
-  const actMsg = 'Warning: An update to %s inside a test was not wrapped in act';
-
-  jest.spyOn( console, 'error' ).mockImplementation( ( ...args ) => {
-    if ( !args[0].includes( actMsg ) ) {
-      consoleError( ...args );
-    }
-  } );
-};
-
 describe( '<PackagePreview />', () => {
-  /**
-   * @todo Suppress React 16.8 `act()` warnings globally.
-   * The React team's fix won't be out of alpha until 16.9.0.
-   * @see https://github.com/facebook/react/issues/14769
-   */
   const consoleError = console.error;
 
   beforeAll( () => suppressActWarning( consoleError ) );

--- a/components/admin/Previews/ProjectPreview/ProjectPreviewContent/ProjectPreviewContent.test.js
+++ b/components/admin/Previews/ProjectPreview/ProjectPreviewContent/ProjectPreviewContent.test.js
@@ -6,6 +6,7 @@ import { Loader } from 'semantic-ui-react';
 
 import ProjectPreviewContent from './ProjectPreviewContent';
 
+import { suppressActWarning } from 'lib/utils';
 import {
   errorMocks,
   mocks,
@@ -17,32 +18,32 @@ import {
   vimeoMocks,
 } from './mocks';
 
-jest.mock( 'lib/utils', () => ( {
-  getStreamData: jest.fn( ( stream, site = 'youtube', field = 'url' ) => {
-    const uri = stream.find( s => s.site.toLowerCase() === site );
+// jest.mock( 'lib/utils', () => ( {
+//   getStreamData: jest.fn( ( stream, site = 'youtube', field = 'url' ) => {
+//     const uri = stream.find( s => s.site.toLowerCase() === site );
 
-    if ( uri && Object.keys( uri ).length > 0 ) {
-      return uri[field];
-    }
+//     if ( uri && Object.keys( uri ).length > 0 ) {
+//       return uri[field];
+//     }
 
-    return null;
-  } ),
-  getVimeoId: jest.fn( () => '340239507' ),
-  getYouTubeId: jest.fn( () => '1evw4fRu3bo' ),
-  contentRegExp: jest.fn( () => false ),
-  getApolloErrors: jest.fn( error => {
-    let errs = [];
-    const { graphQLErrors, networkError, otherError } = error;
+//     return null;
+//   } ),
+//   getVimeoId: jest.fn( () => '340239507' ),
+//   getYouTubeId: jest.fn( () => '1evw4fRu3bo' ),
+//   contentRegExp: jest.fn( () => false ),
+//   getApolloErrors: jest.fn( error => {
+//     let errs = [];
+//     const { graphQLErrors, networkError, otherError } = error;
 
-    if ( graphQLErrors ) {
-      errs = graphQLErrors.map( error => error.message );
-    }
-    if ( networkError ) errs.push( networkError );
-    if ( otherError ) errs.push( otherError );
+//     if ( graphQLErrors ) {
+//       errs = graphQLErrors.map( error => error.message );
+//     }
+//     if ( networkError ) errs.push( networkError );
+//     if ( otherError ) errs.push( otherError );
 
-    return errs;
-  } ),
-} ) );
+//     return errs;
+//   } ),
+// } ) );
 
 jest.mock( 'next/config', () => () => ( {
   publicRuntimeConfig: {},
@@ -57,16 +58,6 @@ const Component = (
     <ProjectPreviewContent { ...props } />
   </MockedProvider>
 );
-
-const suppressActWarning = consoleError => {
-  const actMsg = 'Warning: An update to %s inside a test was not wrapped in act';
-
-  jest.spyOn( console, 'error' ).mockImplementation( ( ...args ) => {
-    if ( !args[0].includes( actMsg ) ) {
-      consoleError( ...args );
-    }
-  } );
-};
 
 describe( '<ProjectPreviewContent />', () => {
   const consoleError = console.error;

--- a/components/admin/ProjectEdit/EditProjectFilesModal/EditVideoFileRow/EditVideoFileRow.js
+++ b/components/admin/ProjectEdit/EditProjectFilesModal/EditVideoFileRow/EditVideoFileRow.js
@@ -29,8 +29,8 @@ import './EditVideoFileRow.scss';
 const EditVideoFileRow = props => {
   const {
     file: {
-      id, name, language, use, quality, videoBurnedInStatus
-    }, update, removeFile, accept, step
+      id, name, language, use, quality, videoBurnedInStatus,
+    }, update, removeFile, accept, step,
   } = props;
 
   const files = useContext( FilesContext );
@@ -39,7 +39,7 @@ const EditVideoFileRow = props => {
   // item in first index shows the first capturing group in regex
   // let fileType = /(\w+)\/(\w+)/.exec( type );
   // fileType = ( fileType ) ? fileType[1] : '';
-  const filename = ( name && name.length > 25 ) ? truncateAndReplaceStr( name, 20, 8 ) : name;
+  const filename = name && name.length > 25 ? truncateAndReplaceStr( name, 20, 8 ) : name;
 
   return (
     <Grid.Row>
@@ -59,17 +59,17 @@ const EditVideoFileRow = props => {
       </Grid.Column>
 
       { step === 1 && (
-      <Fragment>
-        { /* Language */ }
-        <Grid.Column width={ 4 }>
-          <LanguageDropdown id={ id } value={ language } onChange={ update } required />
-        </Grid.Column>
+        <Fragment>
+          { /* Language */ }
+          <Grid.Column width={ 4 }>
+            <LanguageDropdown id={ id } value={ language } onChange={ update } required />
+          </Grid.Column>
 
-        { /* VideoBurnedInStatus */ }
-        <Grid.Column width={ 4 }>
-          <VideoBurnedInStatusDropdown id={ id } value={ videoBurnedInStatus } onChange={ update } required />
-        </Grid.Column>
-      </Fragment>
+          { /* VideoBurnedInStatus */ }
+          <Grid.Column width={ 4 }>
+            <VideoBurnedInStatusDropdown id={ id } value={ videoBurnedInStatus } onChange={ update } required />
+          </Grid.Column>
+        </Fragment>
       ) }
 
       { step === 2 && (
@@ -108,12 +108,12 @@ EditVideoFileRow.propTypes = {
     language: PropTypes.string,
     use: PropTypes.string,
     quality: PropTypes.string,
-    videoBurnedInStatus: PropTypes.string
+    videoBurnedInStatus: PropTypes.string,
   } ),
   accept: PropTypes.string,
   step: PropTypes.number,
   update: PropTypes.func,
-  removeFile: PropTypes.func
+  removeFile: PropTypes.func,
 };
 
 

--- a/components/admin/ProjectEdit/EditProjectFilesModal/EditVideoFilesGrid/EditVideoFilesGrid.js
+++ b/components/admin/ProjectEdit/EditProjectFilesModal/EditVideoFilesGrid/EditVideoFilesGrid.js
@@ -3,32 +3,44 @@ import PropTypes from 'prop-types';
 import { Grid } from 'semantic-ui-react';
 import EditVideoFileRow from '../EditVideoFileRow/EditVideoFileRow';
 
-const EditVideoFilesGrid = ( {
-  files, update, removeFile, accept, step
-} ) => (
+const EditVideoFilesGrid = ( { files, update, removeFile, accept, step } ) => (
   <Grid>
     <Grid.Row>
       <Grid.Column width={ 6 }>Files Selected</Grid.Column>
-      { step === 1 && (
+      {step === 1 && (
         <Fragment>
-          <Grid.Column width={ 4 }>Language<span className="required"> *</span></Grid.Column>
-          <Grid.Column width={ 4 }>Subtitles<span className="required"> *</span></Grid.Column>
+          <Grid.Column width={ 4 }>
+            Language
+            {' '}
+            <span className="required"> *</span>
+          </Grid.Column>
+          <Grid.Column width={ 4 }>
+            On-Screen Text
+            {' '}
+            <span className="required"> *</span>
+          </Grid.Column>
         </Fragment>
-      )
-      }
+      )}
 
-      { step === 2 && (
+      {step === 2 && (
         <Fragment>
-          <Grid.Column width={ 4 }>Type/Use<span className="required"> *</span></Grid.Column>
-          <Grid.Column width={ 4 }>Quality<span className="required"> *</span></Grid.Column>
+          <Grid.Column width={ 4 }>
+            Type/Use
+            {' '}
+            <span className="required"> *</span>
+          </Grid.Column>
+          <Grid.Column width={ 4 }>
+            Quality
+            {' '}
+            <span className="required"> *</span>
+          </Grid.Column>
         </Fragment>
-      )
-      }
+      )}
 
-      <Grid.Column width={ 2 }></Grid.Column>
+      <Grid.Column width={ 2 } />
     </Grid.Row>
 
-    { files.map( file => (
+    {files.map( file => (
       <EditVideoFileRow
         key={ file.id }
         file={ file }
@@ -37,7 +49,7 @@ const EditVideoFilesGrid = ( {
         accept={ accept }
         step={ step }
       />
-    ) ) }
+    ) )}
   </Grid>
 );
 
@@ -47,7 +59,7 @@ EditVideoFilesGrid.propTypes = {
   update: PropTypes.func,
   removeFile: PropTypes.func,
   accept: PropTypes.string,
-  step: PropTypes.number
+  step: PropTypes.number,
 };
 
 export default EditVideoFilesGrid;

--- a/components/admin/ProjectEdit/EditProjectFilesModal/__snapshots__/EditProjectFilesModal.test.js.snap
+++ b/components/admin/ProjectEdit/EditProjectFilesModal/__snapshots__/EditProjectFilesModal.test.js.snap
@@ -19,7 +19,33 @@ exports[`<EditSupportFiles /> renders without crashing 1`] = `
             "selections": Array [
               Object {
                 "alias": undefined,
-                "arguments": Array [],
+                "arguments": Array [
+                  Object {
+                    "kind": "Argument",
+                    "name": Object {
+                      "kind": "Name",
+                      "value": "orderBy",
+                    },
+                    "value": Object {
+                      "kind": "EnumValue",
+                      "value": "name_ASC",
+                    },
+                  },
+                  Object {
+                    "kind": "Argument",
+                    "name": Object {
+                      "kind": "Name",
+                      "value": "where",
+                    },
+                    "value": Object {
+                      "kind": "Variable",
+                      "name": Object {
+                        "kind": "Name",
+                        "value": "where",
+                      },
+                    },
+                  },
+                ],
                 "directives": Array [],
                 "kind": "Field",
                 "name": Object {
@@ -56,17 +82,42 @@ exports[`<EditSupportFiles /> renders without crashing 1`] = `
               },
             ],
           },
-          "variableDefinitions": Array [],
+          "variableDefinitions": Array [
+            Object {
+              "defaultValue": undefined,
+              "directives": Array [],
+              "kind": "VariableDefinition",
+              "type": Object {
+                "kind": "NamedType",
+                "name": Object {
+                  "kind": "Name",
+                  "value": "VideoUseWhereInput",
+                },
+              },
+              "variable": Object {
+                "kind": "Variable",
+                "name": Object {
+                  "kind": "Name",
+                  "value": "where",
+                },
+              },
+            },
+          ],
         },
       ],
       "kind": "Document",
       "loc": Object {
-        "end": 73,
+        "end": 135,
         "start": 0,
       },
     }
   }
   skip={false}
+  variables={
+    Object {
+      "where": undefined,
+    }
+  }
 >
   <Component />
 </Query>

--- a/components/admin/ProjectEdit/EditVideoModal/ModalForms/FileDataForm/FileDataForm.js
+++ b/components/admin/ProjectEdit/EditVideoModal/ModalForms/FileDataForm/FileDataForm.js
@@ -65,7 +65,6 @@ const FileDataForm = ( {
 
   const cleanUseId = cleanUseQuery?.videoUses?.[0]?.id || '';
   const englishId = englishLanguageQuery?.languages?.[0]?.id || '';
-  const isClean = values.use === cleanUseId;
 
   const growl = () => {
     // Update projectUpdate Redux state
@@ -170,6 +169,12 @@ const FileDataForm = ( {
             cachedData.file.use.id = value;
             if ( value === cleanUseId ) {
               setLangId( englishId );
+              videoBurnedInStatusVideoFileMutation( {
+                variables: {
+                  id: selectedFile,
+                  videoBurnedInStatus: 'CLEAN',
+                },
+              } );
             }
           } else {
             cachedData.file[name] = value;
@@ -364,7 +369,7 @@ const FileDataForm = ( {
               onChange={ ( e, { value } ) => handleLanguageChange( value ) }
               required
               value={ values.language }
-              disabled={ isClean }
+              disabled={ values.use === cleanUseId && values.videoBurnedInStatus === 'CLEAN' }
             />
 
             <VideoBurnedInStatusDropdown
@@ -375,6 +380,7 @@ const FileDataForm = ( {
               required
               type="video"
               value={ values.videoBurnedInStatus }
+              disabled={ values.use === cleanUseId }
             />
 
             <UseDropdown

--- a/components/admin/ProjectEdit/EditVideoModal/ModalForms/FileDataForm/FileDataForm.js
+++ b/components/admin/ProjectEdit/EditVideoModal/ModalForms/FileDataForm/FileDataForm.js
@@ -12,6 +12,7 @@ import * as actions from 'lib/redux/actions/projectUpdate';
 import { Confirm, Form, Grid } from 'semantic-ui-react';
 import { withFormik } from 'formik';
 
+import ApolloError from 'components/errors/ApolloError';
 import ConfirmModalContent from 'components/admin/ConfirmModalContent/ConfirmModalContent';
 import LanguageDropdown, { LANGUAGE_BY_NAME_QUERY } from 'components/admin/dropdowns/LanguageDropdown/LanguageDropdown';
 import Loader from 'components/admin/ProjectEdit/EditVideoModal/Loader/Loader';
@@ -128,7 +129,11 @@ const FileDataForm = ( {
     changeLanguage( langId, selectedFile );
   }, [langId] );
 
-  const { file, loading } = videoFileQuery;
+  const { file, error, loading } = videoFileQuery;
+
+  if ( error ) {
+    return <ApolloError error={ error } />;
+  }
 
   if ( !file || loading ) return <Loader height="330px" text="Loading the file data..." />;
 

--- a/components/admin/ProjectEdit/EditVideoModal/ModalForms/FileDataForm/FileDataForm.js
+++ b/components/admin/ProjectEdit/EditVideoModal/ModalForms/FileDataForm/FileDataForm.js
@@ -63,6 +63,10 @@ const FileDataForm = ( {
   const { project } = videoProjectQuery;
   const units = project && project.units ? project.units : [];
 
+  const cleanUseId = cleanUseQuery?.videoUses?.[0]?.id || '';
+  const englishId = englishLanguageQuery?.languages?.[0]?.id || '';
+  const isClean = values.use === cleanUseId;
+
   const growl = () => {
     // Update projectUpdate Redux state
     projectUpdated( selectedProject, true );
@@ -164,6 +168,9 @@ const FileDataForm = ( {
 
           if ( name === 'use' ) {
             cachedData.file.use.id = value;
+            if ( value === cleanUseId ) {
+              setLangId( englishId );
+            }
           } else {
             cachedData.file[name] = value;
           }
@@ -357,6 +364,7 @@ const FileDataForm = ( {
               onChange={ ( e, { value } ) => handleLanguageChange( value ) }
               required
               value={ values.language }
+              disabled={ isClean }
             />
 
             <VideoBurnedInStatusDropdown

--- a/components/admin/ProjectEdit/EditVideoModal/ModalForms/FileDataForm/FileDataForm.js
+++ b/components/admin/ProjectEdit/EditVideoModal/ModalForms/FileDataForm/FileDataForm.js
@@ -355,7 +355,7 @@ const FileDataForm = ( {
 
             <VideoBurnedInStatusDropdown
               id="video-subtitles"
-              label="Subtitles & Captions"
+              label="On-Screen Text"
               name="videoBurnedInStatus"
               onChange={ handleDropdownSave }
               required

--- a/components/admin/ProjectEdit/EditVideoModal/ModalForms/FileDataForm/FileDataForm.scss
+++ b/components/admin/ProjectEdit/EditVideoModal/ModalForms/FileDataForm/FileDataForm.scss
@@ -25,6 +25,14 @@
     flex-direction: column;
     justify-content: space-between;
   }
+
+  &.ui.form .disabled.field {
+    opacity: initial;
+
+    > label {
+      opacity: initial;
+    }
+  }
 }
 
 .video-links {

--- a/components/admin/ProjectEdit/EditVideoModal/ModalForms/FileDataForm/FileDataForm.test.js
+++ b/components/admin/ProjectEdit/EditVideoModal/ModalForms/FileDataForm/FileDataForm.test.js
@@ -1,0 +1,396 @@
+import { mount } from 'enzyme';
+import toJSON from 'enzyme-to-json';
+import wait from 'waait';
+import { MockedProvider } from '@apollo/react-testing';
+import configureStore from 'redux-mock-store';
+import { Provider } from 'react-redux';
+
+import { mocks, props, reduxState } from './mocks';
+import { suppressActWarning } from 'lib/utils';
+import { EditSingleProjectItemContext } from 'components/admin/ProjectEdit/EditSingleProjectItem/EditSingleProjectItem';
+import FileDataForm from './FileDataForm';
+
+jest.mock(
+  'next/dynamic',
+  () => function DynamicComponent() { return ''; },
+);
+jest.mock(
+  'components/admin/ConfirmModalContent/ConfirmModalContent',
+  () => function ConfirmModalContent() { return ''; },
+);
+jest.mock(
+  'components/admin/dropdowns/QualityDropdown/QualityDropdown',
+  () => function QualityDropdown() { return ''; },
+);
+jest.mock(
+  'components/admin/dropdowns/VideoBurnedInStatusDropdown/VideoBurnedInStatusDropdown',
+  () => function VideoBurnedInStatusDropdown() { return ''; },
+);
+
+const value = {
+  language: {
+    id: 'ck2lzfx710hkq07206thus6pt',
+    displayName: 'English',
+    locale: 'en-us',
+    __typename: 'Language',
+  },
+  selectedFile: 'ckcoospf10bjh0720ftniacm3',
+  selectedProject: 'ckcoositc0biv0720dwlj4l0g',
+  selectedUnit: 'ckcoospdp0bjc07207x6j8xhw',
+  setLanguage: jest.fn(),
+  setSelectedFile: jest.fn(),
+  setSelectedUnit: jest.fn(),
+  setSelectedProject: jest.fn(),
+  setShowNotification: jest.fn(),
+  showNotication: jest.fn(),
+  startTimeout: jest.fn(),
+  updateSelectedUnit: jest.fn(),
+};
+
+const mockStore = configureStore( [] );
+
+describe( '<FileDataForm />, when the video use is Clean', () => {
+  const consoleError = console.error;
+
+  beforeAll( () => suppressActWarning( consoleError ) );
+  afterAll( () => {
+    console.error = consoleError;
+  } );
+
+  let store;
+  let Component;
+  let wrapper;
+
+  beforeEach( () => {
+    store = mockStore( reduxState );
+    Component = (
+      <EditSingleProjectItemContext.Provider value={ value }>
+        <Provider store={ store }>
+          <MockedProvider mocks={ mocks } addTypename={ false }>
+            <FileDataForm { ...{ ...props, ...value } } />
+          </MockedProvider>
+        </Provider>
+      </EditSingleProjectItemContext.Provider>
+    );
+    wrapper = mount( Component );
+  } );
+
+  it( 'renders initial loading state without crashing', () => {
+    const fileDataForm = wrapper.find( 'FileDataForm' );
+    const loader = wrapper.find( 'Loader' );
+    const msg = 'Loading the file data...';
+
+    expect( fileDataForm.exists() ).toEqual( true );
+    expect( loader.exists() ).toEqual( true );
+    expect( loader.contains( msg ) ).toEqual( true );
+  } );
+
+  it( 'renders final state without crashing', async () => {
+    await wait( 0 );
+    wrapper.update();
+    const form = wrapper.find( 'Form' );
+    const loader = wrapper.find( 'Loader' );
+
+    expect( form.exists() ).toEqual( true );
+    expect( form.hasClass( 'edit-video__form video-file-form' ) )
+      .toEqual( true );
+    expect( loader.exists() ).toEqual( false );
+  } );
+
+  it( 'renders file meta data', async () => {
+    await wait( 0 );
+    wrapper.update();
+    const fileMeta = wrapper.find( '.file_meta' );
+
+    expect( toJSON( fileMeta ) ).toMatchSnapshot();
+  } );
+
+  it( 'renders the Confirm modal', async () => {
+    await wait( 0 );
+    wrapper.update();
+    const confirm = wrapper.find( 'Confirm' );
+
+    expect( toJSON( confirm ) ).toMatchSnapshot();
+  } );
+
+  it( 'renders video links', async () => {
+    await wait( 0 );
+    wrapper.update();
+    const videoLinks = wrapper.find( '.video-links' );
+
+    expect( toJSON( videoLinks ) ).toMatchSnapshot();
+  } );
+
+  it( 'renders the LanguageDropdown', async () => {
+    await wait( 0 );
+    wrapper.update();
+    const languageDropdown = wrapper.find( 'LanguageDropdown' );
+    const languageId = mocks[1].result.data.file.language.id;
+
+    expect( languageDropdown.exists() ).toEqual( true );
+    expect( languageDropdown.prop( 'label' ) ).toEqual( 'Language' );
+    expect( languageDropdown.prop( 'required' ) ).toEqual( true );
+    expect( languageDropdown.prop( 'value' ) ).toEqual( languageId );
+    // disabled since file (i.e., mocks[1]) has Clean video use
+    expect( languageDropdown.prop( 'disabled' ) ).toEqual( true );
+  } );
+
+  it( 'renders the VideoBurnedInStatusDropdown', async () => {
+    await wait( 0 );
+    wrapper.update();
+    const burnedInStatusDropdown = wrapper.find( 'VideoBurnedInStatusDropdown' );
+
+    expect( burnedInStatusDropdown.prop( 'label' ) )
+      .toEqual( 'On-Screen Text' );
+    expect( burnedInStatusDropdown.prop( 'name' ) )
+      .toEqual( 'videoBurnedInStatus' );
+    expect( burnedInStatusDropdown.prop( 'type' ) )
+      .toEqual( 'video' );
+    expect( burnedInStatusDropdown.prop( 'required' ) )
+      .toEqual( true );
+    // disabled since file (i.e., mocks[1]) has Clean video use
+    expect( burnedInStatusDropdown.prop( 'disabled' ) )
+      .toEqual( true );
+    expect( burnedInStatusDropdown.prop( 'onChange' ).name )
+      .toEqual( 'handleDropdownSave' );
+  } );
+
+  it( 'renders the UseDropdown', async () => {
+    await wait( 0 );
+    wrapper.update();
+    const useDropdown = wrapper.find( 'UseDropdown' );
+    const useId = mocks[1].result.data.file.use.id;
+
+    expect( useDropdown.prop( 'label' ) ).toEqual( 'Video Type' );
+    expect( useDropdown.prop( 'name' ) ).toEqual( 'use' );
+    expect( useDropdown.prop( 'type' ) ).toEqual( 'video' );
+    expect( useDropdown.prop( 'required' ) ).toEqual( true );
+    expect( useDropdown.prop( 'value' ) ).toEqual( useId );
+    expect( useDropdown.prop( 'onChange' ).name )
+      .toEqual( 'handleDropdownSave' );
+  } );
+
+  it( 'renders the QualityDropdown', async () => {
+    await wait( 0 );
+    wrapper.update();
+    const qualityDropdown = wrapper.find( 'QualityDropdown' );
+    const infoTip = 'Web: small - for social sharing, Broadcast: large - ambassador videos';
+
+    expect( qualityDropdown.prop( 'label' ) )
+      .toEqual( 'Video Quality' );
+    expect( qualityDropdown.prop( 'name' ) ).toEqual( 'quality' );
+    expect( qualityDropdown.prop( 'type' ) ).toEqual( 'video' );
+    expect( qualityDropdown.prop( 'infotip' ) ).toEqual( infoTip );
+    expect( qualityDropdown.prop( 'required' ) ).toEqual( true );
+    expect( qualityDropdown.prop( 'onChange' ).name )
+      .toEqual( 'handleDropdownSave' );
+  } );
+} );
+
+describe( '<FileDataForm />, when the video use is not Clean', () => {
+  const consoleError = console.error;
+
+  beforeAll( () => suppressActWarning( consoleError ) );
+  afterAll( () => {
+    console.error = consoleError;
+  } );
+
+  let store;
+  let Component;
+  let wrapper;
+
+  const french = {
+    id: 'ck2lzfx710hkp07206oo0icbv',
+    displayName: 'French',
+    locale: 'fr-fr',
+    __typename: 'Language',
+  };
+
+  const newCtxValue = {
+    ...value,
+    language: french,
+  };
+
+  const newProps = {
+    ...props,
+    values: {
+      ...props.values,
+      language: french.id,
+      use: 'ck2lzfx5y0hhz07207nol9j6r',
+      videoBurnedInStatus: 'SUBTITLED',
+    },
+  };
+
+  const newMocks = mocks.reduce( ( acc, curr, i ) => {
+    if ( i === 1 ) {
+      acc.push( {
+        ...curr,
+        result: {
+          data: {
+            file: {
+              ...curr.result.data.file,
+              language: french,
+              use: {
+                id: 'ck2lzfx5y0hhz07207nol9j6r',
+                name: 'Full Video',
+              },
+            },
+          },
+        },
+      } );
+    } else {
+      acc.push( curr );
+    }
+
+    return acc;
+  }, [] );
+
+  beforeEach( () => {
+    store = mockStore( reduxState );
+    Component = (
+      <EditSingleProjectItemContext.Provider value={ newCtxValue }>
+        <Provider store={ store }>
+          <MockedProvider mocks={ newMocks } addTypename={ false }>
+            <FileDataForm { ...{ ...newProps, ...newCtxValue } } />
+          </MockedProvider>
+        </Provider>
+      </EditSingleProjectItemContext.Provider>
+    );
+    wrapper = mount( Component );
+  } );
+
+  it( 'renders initial loading state without crashing', () => {
+    const fileDataForm = wrapper.find( 'FileDataForm' );
+    const loader = wrapper.find( 'Loader' );
+    const msg = 'Loading the file data...';
+
+    expect( fileDataForm.exists() ).toEqual( true );
+    expect( loader.exists() ).toEqual( true );
+    expect( loader.contains( msg ) ).toEqual( true );
+  } );
+
+  it( 'renders final state without crashing', async () => {
+    await wait( 0 );
+    wrapper.update();
+    const form = wrapper.find( 'Form' );
+    const loader = wrapper.find( 'Loader' );
+
+    expect( form.exists() ).toEqual( true );
+    expect( form.hasClass( 'edit-video__form video-file-form' ) )
+      .toEqual( true );
+    expect( loader.exists() ).toEqual( false );
+  } );
+
+  it( 'renders the LanguageDropdown', async () => {
+    await wait( 0 );
+    wrapper.update();
+    const languageDropdown = wrapper.find( 'LanguageDropdown' );
+    const languageId = newMocks[1].result.data.file.language.id;
+
+    expect( languageDropdown.exists() ).toEqual( true );
+    expect( languageDropdown.prop( 'label' ) ).toEqual( 'Language' );
+    expect( languageDropdown.prop( 'required' ) ).toEqual( true );
+    expect( languageDropdown.prop( 'value' ) ).toEqual( languageId );
+    // disabled since file (i.e., mocks[1]) has Clean video use
+    expect( languageDropdown.prop( 'disabled' ) ).toEqual( false );
+  } );
+
+  it( 'renders the VideoBurnedInStatusDropdown', async () => {
+    await wait( 0 );
+    wrapper.update();
+    const burnedInStatusDropdown = wrapper.find( 'VideoBurnedInStatusDropdown' );
+
+    expect( burnedInStatusDropdown.prop( 'label' ) )
+      .toEqual( 'On-Screen Text' );
+    expect( burnedInStatusDropdown.prop( 'name' ) )
+      .toEqual( 'videoBurnedInStatus' );
+    expect( burnedInStatusDropdown.prop( 'type' ) )
+      .toEqual( 'video' );
+    expect( burnedInStatusDropdown.prop( 'required' ) )
+      .toEqual( true );
+    // disabled since file (i.e., mocks[1]) has Clean video use
+    expect( burnedInStatusDropdown.prop( 'disabled' ) )
+      .toEqual( false );
+    expect( burnedInStatusDropdown.prop( 'onChange' ).name )
+      .toEqual( 'handleDropdownSave' );
+  } );
+
+  it( 'renders the UseDropdown', async () => {
+    await wait( 0 );
+    wrapper.update();
+    const useDropdown = wrapper.find( 'UseDropdown' );
+    const useId = newMocks[1].result.data.file.use.id;
+
+    expect( useDropdown.prop( 'label' ) ).toEqual( 'Video Type' );
+    expect( useDropdown.prop( 'name' ) ).toEqual( 'use' );
+    expect( useDropdown.prop( 'type' ) ).toEqual( 'video' );
+    expect( useDropdown.prop( 'required' ) ).toEqual( true );
+    expect( useDropdown.prop( 'value' ) ).toEqual( useId );
+    expect( useDropdown.prop( 'onChange' ).name )
+      .toEqual( 'handleDropdownSave' );
+  } );
+} );
+
+describe( '<FileDataForm />, when there is a GraphQL error for the videoFileQuery', () => {
+  const consoleError = console.error;
+
+  beforeAll( () => suppressActWarning( consoleError ) );
+  afterAll( () => {
+    console.error = consoleError;
+  } );
+
+  let store;
+  let Component;
+  let wrapper;
+
+  const newMocks = mocks.reduce( ( acc, curr, i ) => {
+    if ( i === 1 ) {
+      acc.push( {
+        ...curr,
+        result: {
+          errors: [{ message: 'There was an error.' }],
+        },
+      } );
+    } else {
+      acc.push( curr );
+    }
+
+    return acc;
+  }, [] );
+
+  beforeEach( () => {
+    store = mockStore( reduxState );
+    Component = (
+      <EditSingleProjectItemContext.Provider value={ value }>
+        <Provider store={ store }>
+          <MockedProvider mocks={ newMocks } addTypename={ false }>
+            <FileDataForm { ...{ ...props, ...value } } />
+          </MockedProvider>
+        </Provider>
+      </EditSingleProjectItemContext.Provider>
+    );
+    wrapper = mount( Component );
+  } );
+
+  it( 'renders initial loading state without crashing', () => {
+    const fileDataForm = wrapper.find( 'FileDataForm' );
+    const loader = wrapper.find( 'Loader' );
+    const msg = 'Loading the file data...';
+
+    expect( fileDataForm.exists() ).toEqual( true );
+    expect( loader.exists() ).toEqual( true );
+    expect( loader.contains( msg ) ).toEqual( true );
+  } );
+
+  it( 'renders the GraphQL error message', async () => {
+    await wait( 0 );
+    wrapper.update();
+    const form = wrapper.find( 'Form' );
+    const apolloError = wrapper.find( 'ApolloError' );
+    const msg = 'There was an error.';
+
+    expect( form.exists() ).toEqual( false );
+    expect( apolloError.exists() ).toEqual( true );
+    expect( apolloError.contains( msg ) ).toEqual( true );
+  } );
+} );

--- a/components/admin/ProjectEdit/EditVideoModal/ModalForms/FileDataForm/__snapshots__/FileDataForm.test.js.snap
+++ b/components/admin/ProjectEdit/EditVideoModal/ModalForms/FileDataForm/__snapshots__/FileDataForm.test.js.snap
@@ -1,0 +1,223 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<FileDataForm />, when the video use is Clean renders file meta data 1`] = `
+<div
+  className="file_meta"
+>
+  <span
+    className="file_meta_content file_meta_content--filetype"
+    lang="en"
+  >
+    Mexico City 1.mp4
+  </span>
+  <span
+    className="file_meta_content file_meta_content--filesize"
+  >
+    Filesize: 15.1  MB
+  </span>
+  <span
+    className="file_meta_content file_meta_content--dimensions"
+  >
+    Dimensions: 1920 x 1080
+  </span>
+  <span
+    className="file_meta_content file_meta_content--uploaded"
+  >
+    Uploaded: July 16, 2020
+  </span>
+  <span
+    className="file_meta_content file_meta_content--duration"
+  >
+    Duration: 0:14
+  </span>
+  <span
+    className="delete-file-link"
+    onClick={[Function]}
+    onKeyUp={[Function]}
+    role="button"
+    tabIndex={0}
+  >
+    Delete file from project
+  </span>
+</div>
+`;
+
+exports[`<FileDataForm />, when the video use is Clean renders the Confirm modal 1`] = `
+<Confirm
+  cancelButton="No, take me back"
+  className="delete"
+  confirmButton="Yes, delete forever"
+  content={
+    <ConfirmModalContent
+      className="delete_confirm delete_confirm--video"
+      headline="Are you sure you want to delete this video?"
+    >
+      <p>
+        This video will be permanently removed from the Content Commons and any other projects or collections it appears on.
+      </p>
+    </ConfirmModalContent>
+  }
+  onCancel={[Function]}
+  onConfirm={[Function]}
+  open={false}
+  size="small"
+>
+  <Modal
+    centered={true}
+    className="delete"
+    closeOnDimmerClick={true}
+    closeOnDocumentClick={false}
+    dimmer={true}
+    eventPool="Modal"
+    onClose={[Function]}
+    open={false}
+    size="small"
+  >
+    <Portal
+      closeOnDocumentClick={false}
+      closeOnEscape={true}
+      eventPool="Modal"
+      mountNode={<body />}
+      onClose={[Function]}
+      onMount={[Function]}
+      onOpen={[Function]}
+      onUnmount={[Function]}
+      open={false}
+      openOnTriggerClick={true}
+    />
+  </Modal>
+</Confirm>
+`;
+
+exports[`<FileDataForm />, when the video use is Clean renders video links 1`] = `
+<div
+  className="video-links"
+>
+  <FormInput
+    as={[Function]}
+    control={[Function]}
+    id="video-youtube"
+    label="YouTube URL"
+    name="youtube"
+    onBlur={[Function]}
+    onChange={[Function]}
+    value=""
+  >
+    <FormField
+      control={[Function]}
+      id="video-youtube"
+      label="YouTube URL"
+      name="youtube"
+      onBlur={[Function]}
+      onChange={[Function]}
+      value=""
+    >
+      <div
+        className="field"
+      >
+        <label
+          htmlFor="video-youtube"
+        >
+          YouTube URL
+        </label>
+        <Input
+          id="video-youtube"
+          name="youtube"
+          onBlur={[Function]}
+          onChange={[Function]}
+          type="text"
+          value=""
+        >
+          <div
+            className="ui input"
+          >
+            <input
+              id="video-youtube"
+              name="youtube"
+              onBlur={[Function]}
+              onChange={[Function]}
+              type="text"
+              value=""
+            />
+          </div>
+        </Input>
+      </div>
+    </FormField>
+  </FormInput>
+  <FormInput
+    as={[Function]}
+    control={[Function]}
+    id="video-vimeo"
+    label="Vimeo URL"
+    name="vimeo"
+    onBlur={[Function]}
+    onChange={[Function]}
+    readOnly={true}
+    style={
+      Object {
+        "opacity": "0.45",
+      }
+    }
+    value="https://vimeo.com/438865910"
+  >
+    <FormField
+      control={[Function]}
+      id="video-vimeo"
+      label="Vimeo URL"
+      name="vimeo"
+      onBlur={[Function]}
+      onChange={[Function]}
+      readOnly={true}
+      style={
+        Object {
+          "opacity": "0.45",
+        }
+      }
+      value="https://vimeo.com/438865910"
+    >
+      <div
+        className="field"
+      >
+        <label
+          htmlFor="video-vimeo"
+        >
+          Vimeo URL
+        </label>
+        <Input
+          id="video-vimeo"
+          name="vimeo"
+          onBlur={[Function]}
+          onChange={[Function]}
+          readOnly={true}
+          style={
+            Object {
+              "opacity": "0.45",
+            }
+          }
+          type="text"
+          value="https://vimeo.com/438865910"
+        >
+          <div
+            className="ui input"
+            style={
+              Object {
+                "opacity": "0.45",
+              }
+            }
+          >
+            <input
+              id="video-vimeo"
+              name="vimeo"
+              onBlur={[Function]}
+              onChange={[Function]}
+              readOnly={true}
+              type="text"
+              value="https://vimeo.com/438865910"
+            />
+          </div>
+        </Input>
+      </div>
+    </FormField>
+  </FormInput>
+</div>
+`;

--- a/components/admin/ProjectEdit/EditVideoModal/ModalForms/FileDataForm/mocks.js
+++ b/components/admin/ProjectEdit/EditVideoModal/ModalForms/FileDataForm/mocks.js
@@ -1,0 +1,421 @@
+import * as query from './FileDataFormQueries';
+import { LANGUAGES_QUERY, LANGUAGE_BY_NAME_QUERY } from 'components/admin/dropdowns/LanguageDropdown/LanguageDropdown';
+import { VIDEO_UNIT_QUERY } from 'components/admin/ProjectEdit/EditVideoModal/ModalSections/FileSection/FileSection';
+import { VIDEO_USE_QUERY } from 'components/admin/dropdowns/UseDropdown/UseDropdown';
+
+const props = {
+  fileCount: 2,
+  setFieldValue: jest.fn(),
+  values: {
+    language: 'ck2lzfx710hkq07206thus6pt',
+    quality: 'WEB',
+    use: 'ckcm6aii005dv0720fapgz92p',
+    videoBurnedInStatus: 'CLEAN',
+    vimeo: 'https://vimeo.com/438865910',
+    youtube: '',
+  },
+};
+
+const reduxState = {
+  projectUpdated: false,
+};
+
+const mocks = [
+  {
+    request: {
+      query: query.VIDEO_PROJECT_QUERY,
+      variables: {
+        id: 'ckcoositc0biv0720dwlj4l0g',
+      },
+    },
+    result: {
+      data: {
+        project: {
+          id: 'ckcoositc0biv0720dwlj4l0g',
+          units: [
+            {
+              id: 'ckcoospdp0bjc07207x6j8xhw',
+              language: {
+                id: 'ck2lzfx710hkq07206thus6pt',
+                locale: 'en-us',
+                __typename: 'Language',
+              },
+              __typename: 'VideoUnit',
+            },
+            {
+              id: 'ckcovuyt30co70720tp5w6oem',
+              language: {
+                id: 'ck2lzfx710hkp07206oo0icbv',
+                locale: 'fr-fr',
+                __typename: 'Language',
+              },
+              __typename: 'VideoUnit',
+            },
+          ],
+          __typename: 'VideoProject',
+        },
+      },
+    },
+  },
+  {
+    request: {
+      query: query.VIDEO_FILE_QUERY,
+      variables: {
+        // props.selectedFile from redux
+        id: 'ckcoospf10bjh0720ftniacm3',
+      },
+    },
+    result: {
+      data: {
+        file: {
+          id: 'ckcoospf10bjh0720ftniacm3',
+          createdAt: '2020-07-16T11:05:08.192Z',
+          duration: 14.889875,
+          filename: 'Mexico City 1.mp4',
+          filesize: 15829673,
+          quality: 'WEB',
+          videoBurnedInStatus: 'CLEAN',
+          dimensions: {
+            id: 'ckcoosph00bjm07205nrbnxpu',
+            height: 1080,
+            width: 1920,
+            __typename: 'Dimensions',
+          },
+          language: {
+            id: 'ck2lzfx710hkq07206thus6pt',
+            displayName: 'English',
+            __typename: 'Language',
+          },
+          stream: [
+            {
+              id: 'ckcoospi00bjn0720nt6p5ful',
+              site: 'vimeo',
+              url: 'https://vimeo.com/438865910',
+              __typename: 'VideoStream',
+            },
+          ],
+          use: {
+            id: 'ckcm6aii005dv0720fapgz92p',
+            name: 'Clean',
+            __typename: 'VideoUse',
+          },
+          __typename: 'VideoFile',
+        },
+      },
+    },
+  },
+  {
+    request: {
+      query: query.VIDEO_FILE_LANG_MUTATION,
+      variables: {
+        data: {
+          language: {
+            connect: { id: 'ck2lzfx710hkp07206oo0icbv' },
+          },
+        },
+        where: { id: 'ckcoospf10bjh0720ftniacm3' },
+      },
+    },
+    result: {
+      data: {
+        updateVideoFile: {
+          id: 'ckcoospf10bjh0720ftniacm3',
+          language: { id: 'ck2lzfx710hkp07206oo0icbv' },
+        },
+      },
+    },
+  },
+  {
+    request: {
+      query: query.VIDEO_UNIT_CONNECT_FILE_MUTATION,
+      variables: {
+        data: {
+          files: {
+            connect: { id: 'ckcoospf10bjh0720ftniacm3' },
+          },
+        },
+        where: { id: 'ckcoospdp0bjc07207x6j8xhw' },
+      },
+    },
+    result: {
+      data: {
+        updateVideoUnit: {
+          id: 'ckcoospdp0bjc07207x6j8xhw',
+          files: { id: 'ckcoospf10bjh0720ftniacm3' },
+        },
+      },
+    },
+  },
+  {
+    request: {
+      query: query.VIDEO_UNIT_DISCONNECT_FILE_MUTATION,
+      variables: {
+        data: {
+          files: {
+            disconnect: { id: 'ckcoospf10bjh0720ftniacm3' },
+          },
+        },
+        where: { id: 'ckcoospdp0bjc07207x6j8xhw' },
+      },
+    },
+    result: {
+      data: {
+        updateVideoUnit: {
+          id: 'ckcoospdp0bjc07207x6j8xhw',
+          files: { id: 'ckcoospf10bjh0720ftniacm3' },
+        },
+      },
+    },
+  },
+  {
+    request: {
+      query: query.VIDEO_FILE_SUBTITLES_MUTATION,
+      variables: {
+        data: {
+          videoBurnedInStatus: 'SUBTITLED',
+        },
+        where: { id: 'ckcoospf10bjh0720ftniacm3' },
+      },
+    },
+    result: {
+      data: {
+        updateVideoFile: {
+          id: 'ckcoospf10bjh0720ftniacm3',
+          videoBurnedInStatus: 'SUBTITLED',
+        },
+      },
+    },
+  },
+  {
+    request: {
+      query: query.VIDEO_FILE_USE_MUTATION,
+      variables: {
+        data: {
+          use: {
+            connect: { id: 'ck2lzfx5y0hhz07207nol9j6r' },
+          },
+        },
+        where: { id: 'ckcoospf10bjh0720ftniacm3' },
+      },
+    },
+    result: {
+      data: {
+        updateVideoFile: {
+          id: 'ckcoospf10bjh0720ftniacm3',
+          use: { id: 'ck2lzfx5y0hhz07207nol9j6r' },
+        },
+      },
+    },
+  },
+  {
+    request: {
+      query: query.VIDEO_FILE_QUALITY_MUTATION,
+      variables: {
+        data: {
+          quality: 'WEB',
+        },
+        where: { id: 'ckcoospf10bjh0720ftniacm3' },
+      },
+    },
+    result: {
+      data: {
+        updateVideoFile: {
+          id: 'ckcoospf10bjh0720ftniacm3',
+          quality: 'WEB',
+        },
+      },
+    },
+  },
+  {
+    request: {
+      query: query.VIDEO_FILE_CREATE_STREAM_MUTATION,
+      variables: {
+        data: {
+          stream: {
+            create: {
+              site: 'thesite',
+              url: 'https://thesite.com/the-site-stream-id',
+            },
+          },
+        },
+        where: { id: 'ckcoospf10bjh0720ftniacm3' },
+      },
+    },
+    result: {
+      data: {
+        updateVideoFile: {
+          id: 'ckcoospf10bjh0720ftniacm3',
+          stream: { id: 'the-site-stream-id' },
+        },
+      },
+    },
+  },
+  {
+    request: {
+      query: query.VIDEO_FILE_UPDATE_STREAM_MUTATION,
+      variables: {
+        data: {
+          stream: {
+            update: {
+              data: {
+                url: 'https://thesite.com/the-new-site-stream-id',
+              },
+              where: {
+                id: 'the-new-site-stream-id',
+              },
+            },
+          },
+        },
+        where: { id: 'ckcoospf10bjh0720ftniacm3' },
+      },
+    },
+    result: {
+      data: {
+        updateVideoFile: {
+          id: 'ckcoospf10bjh0720ftniacm3',
+          stream: { id: 'the-new-site-stream-id' },
+        },
+      },
+    },
+  },
+  {
+    request: {
+      query: query.VIDEO_FILE_DELETE_STREAM_MUTATION,
+      variables: {
+        data: {
+          stream: {
+            'delete': {
+              id: 'the-site-stream-id',
+            },
+          },
+        },
+        where: { id: 'ckcoospf10bjh0720ftniacm3' },
+      },
+    },
+    result: {
+      data: {
+        updateVideoFile: {
+          id: 'ckcoospf10bjh0720ftniacm3',
+          stream: { id: 'the-site-stream-id' },
+        },
+      },
+    },
+  },
+  {
+    request: {
+      query: query.VIDEO_FILE_DELETE_MUTATION,
+      variables: {
+        id: 'ckcoospf10bjh0720ftniacm3',
+      },
+    },
+    result: {
+      data: {
+        deleteVideoFile: {
+          id: 'ckcoospf10bjh0720ftniacm3',
+        },
+      },
+    },
+  },
+  {
+    request: {
+      query: LANGUAGE_BY_NAME_QUERY,
+      variables: {
+        where: { displayName: 'English' },
+      },
+    },
+    result: {
+      data: {
+        languages: [
+          {
+            id: 'ck2lzfx710hkq07206thus6pt',
+            displayName: 'English',
+            locale: 'en-us',
+          },
+        ],
+      },
+    },
+  },
+  {
+    request: {
+      query: VIDEO_USE_QUERY,
+      variables: {
+        where: { name: 'Clean' },
+      },
+    },
+    result: {
+      data: {
+        videoUses: [
+          {
+            id: 'ckcm6aii005dv0720fapgz92p',
+            name: 'Clean',
+          },
+        ],
+      },
+    },
+  },
+  {
+    request: {
+      query: VIDEO_UNIT_QUERY,
+      variables: { id: 'ckcoospdp0bjc07207x6j8xhw' },
+    },
+    result: {
+      data: {
+        videoUnit: {
+          id: 'ckcoospdp0bjc07207x6j8xhw',
+          files: [
+            {
+              id: 'ckcoospf10bjh0720ftniacm3',
+            },
+          ],
+          language: {
+            id: 'ck2lzfx710hkq07206thus6pt',
+            displayName: 'English',
+            locale: 'en-us',
+          },
+        },
+      },
+    },
+  },
+  {
+    request: {
+      query: LANGUAGES_QUERY,
+    },
+    result: {
+      data: {
+        languages: [
+          {
+            id: 'ck2lzfx710hkp07206oo0icbv',
+            displayName: 'French',
+            locale: 'fr-fr',
+          },
+          {
+            id: 'ck2lzfx710hkq07206thus6pt',
+            displayName: 'English',
+            locale: 'en-us',
+          },
+        ],
+      },
+    },
+  },
+  {
+    request: {
+      query: VIDEO_USE_QUERY,
+    },
+    result: {
+      data: {
+        videoUses: [
+          {
+            id: 'ckcm6aii005dv0720fapgz92p',
+            name: 'Clean',
+          },
+          {
+            id: 'ck2lzfx5y0hhz07207nol9j6r',
+            name: 'Full Video',
+          },
+        ],
+      },
+    },
+  },
+];
+
+export { mocks, props, reduxState };

--- a/components/admin/ProjectEdit/GraphicEdit/GraphicEdit.test.js
+++ b/components/admin/ProjectEdit/GraphicEdit/GraphicEdit.test.js
@@ -5,6 +5,7 @@ import { RouterContext } from 'next/dist/next-server/lib/router-context';
 
 import GraphicEdit from './GraphicEdit';
 
+import { suppressActWarning } from 'lib/utils';
 import {
   errorMocks,
   mocks,
@@ -14,7 +15,6 @@ import {
   getLocalEditableFiles,
   localGraphicFiles,
   supportFilesConfig,
-  suppressActWarning,
 } from './testHelpers';
 
 const router = {

--- a/components/admin/ProjectEdit/GraphicEdit/GraphicFilesFormContainer/GraphicFilesForm/GraphicFilesForm.test.js
+++ b/components/admin/ProjectEdit/GraphicEdit/GraphicFilesFormContainer/GraphicFilesForm/GraphicFilesForm.test.js
@@ -2,7 +2,7 @@ import { mount } from 'enzyme';
 import toJSON from 'enzyme-to-json';
 import wait from 'waait';
 import { MockedProvider } from '@apollo/react-testing';
-import { formatBytes, truncateAndReplaceStr } from 'lib/utils';
+import { formatBytes, suppressActWarning, truncateAndReplaceStr } from 'lib/utils';
 import { mocks, props } from './mocks';
 import GraphicFilesForm from './GraphicFilesForm';
 
@@ -40,16 +40,6 @@ jest.mock(
   'components/admin/dropdowns/SocialPlatformDropdown/SocialPlatformDropdown',
   () => function SocialPlatformDropdown() { return ''; },
 );
-
-const suppressActWarning = consoleError => {
-  const actMsg = 'Warning: An update to %s inside a test was not wrapped in act';
-
-  jest.spyOn( console, 'error' ).mockImplementation( ( ...args ) => {
-    if ( !args[0].includes( actMsg ) ) {
-      consoleError( ...args );
-    }
-  } );
-};
 
 describe( '<GraphicFilesForm />', () => {
   const consoleError = console.error;

--- a/components/admin/ProjectEdit/GraphicEdit/testHelpers.js
+++ b/components/admin/ProjectEdit/GraphicEdit/testHelpers.js
@@ -848,10 +848,7 @@ const localGraphicFiles = mocks[2].result.data.localGraphicProject.files.filter(
   return file.style && !isShell;
 } );
 
-const sortFiles = ( files, field = 'name' ) => (
-  sortBy( files, file => file[field].toLowerCase() )
-);
-
+const sortFiles = ( files, field = 'name' ) => sortBy( files, file => file[field].toLowerCase() );
 const getLocalEditableFiles = () => {
   const { files } = mocks[2].result.data.localGraphicProject;
   const editableFiles = files.filter( file => getIsEditable( file ) );
@@ -888,16 +885,6 @@ const supportFilesConfig = [
   },
 ];
 
-const suppressActWarning = consoleError => {
-  const actMsg = 'Warning: An update to %s inside a test was not wrapped in act';
-
-  jest.spyOn( console, 'error' ).mockImplementation( ( ...args ) => {
-    if ( !args[0].includes( actMsg ) ) {
-      consoleError( ...args );
-    }
-  } );
-};
-
 export {
   errorMocks,
   mocks,
@@ -907,5 +894,4 @@ export {
   getLocalEditableFiles,
   localGraphicFiles,
   supportFilesConfig,
-  suppressActWarning,
 };

--- a/components/admin/ProjectReview/VideoProjectData/VideoProjectData.test.js
+++ b/components/admin/ProjectReview/VideoProjectData/VideoProjectData.test.js
@@ -6,6 +6,7 @@ import { Icon, Loader } from 'semantic-ui-react';
 
 import VideoProjectData from './VideoProjectData';
 
+import { suppressActWarning } from 'lib/utils';
 import {
   emptyAuthorTeamMocks,
   emptyCatTagsMocks,
@@ -22,16 +23,6 @@ const Component = (
     <VideoProjectData { ...props } />
   </MockedProvider>
 );
-
-const suppressActWarning = consoleError => {
-  const actMsg = 'Warning: An update to %s inside a test was not wrapped in act';
-
-  jest.spyOn( console, 'error' ).mockImplementation( ( ...args ) => {
-    if ( !args[0].includes( actMsg ) ) {
-      consoleError( ...args );
-    }
-  } );
-};
 
 describe( '<VideoProjectData />', () => {
   const consoleError = console.error;

--- a/components/admin/ProjectReview/VideoProjectFiles/VideoProjectFile/VideoProjectFile.js
+++ b/components/admin/ProjectReview/VideoProjectFiles/VideoProjectFile/VideoProjectFile.js
@@ -91,8 +91,8 @@ const VideoProjectFile = ( { file, thumbnail } ) => {
           { ` ${secondsToHMS( duration )}` }
         </p>
         <p>
-          <b className="label">Subtitles & Captions:</b>
-          { ` ${videoBurnedInStatus}${videoBurnedInStatus === 'CLEAN' ? ' - No Captions' : ''}` }
+          <b className="label">On-Screen Text:</b>
+          { ` ${videoBurnedInStatus === 'SUBTITLED' ? 'Yes' : 'No'}` }
         </p>
         <p>
           <b className="label">Video Type:</b>

--- a/components/admin/ProjectReview/VideoProjectFiles/VideoProjectFile/__snapshots__/VideoProjectFile.test.js.snap
+++ b/components/admin/ProjectReview/VideoProjectFiles/VideoProjectFile/__snapshots__/VideoProjectFile.test.js.snap
@@ -180,9 +180,9 @@ exports[`<VideoProjectFile /> renders without crashing 1`] = `
             <b
               className="label"
             >
-              Subtitles & Captions:
+              On-Screen Text:
             </b>
-             CLEAN - No Captions
+             No
           </p>
           <p>
             <b

--- a/components/admin/ProjectReview/VideoProjectFiles/VideoProjectFiles.test.js
+++ b/components/admin/ProjectReview/VideoProjectFiles/VideoProjectFiles.test.js
@@ -7,6 +7,7 @@ import { Loader } from 'semantic-ui-react';
 
 import VideoProjectFiles from './VideoProjectFiles';
 
+import { suppressActWarning } from 'lib/utils';
 import {
   errorMocks,
   mocks,
@@ -20,21 +21,21 @@ import {
 
 jest.mock( 'next/config', () => () => ( { publicRuntimeConfig: { REACT_APP_AWS_S3_AUTHORING_BUCKET: 's3-bucket-url' } } ) );
 
-jest.mock( 'lib/utils', () => ( {
-  getPluralStringOrNot: jest.fn( ( array, string ) => `${string}${array && array.length > 1 ? 's' : ''}` ),
-  getApolloErrors: jest.fn( error => {
-    let errs = [];
-    const { graphQLErrors, networkError, otherError } = error;
+// jest.mock( 'lib/utils', () => ( {
+//   getPluralStringOrNot: jest.fn( ( array, string ) => `${string}${array && array.length > 1 ? 's' : ''}` ),
+//   getApolloErrors: jest.fn( error => {
+//     let errs = [];
+//     const { graphQLErrors, networkError, otherError } = error;
 
-    if ( graphQLErrors ) {
-      errs = graphQLErrors.map( error => error.message );
-    }
-    if ( networkError ) errs.push( networkError );
-    if ( otherError ) errs.push( otherError );
+//     if ( graphQLErrors ) {
+//       errs = graphQLErrors.map( error => error.message );
+//     }
+//     if ( networkError ) errs.push( networkError );
+//     if ( otherError ) errs.push( otherError );
 
-    return errs;
-  } ),
-} ) );
+//     return errs;
+//   } ),
+// } ) );
 
 jest.mock( './VideoProjectFile/VideoProjectFile', () => 'video-project-file' );
 
@@ -43,16 +44,6 @@ const Component = (
     <VideoProjectFiles { ...props } />
   </MockedProvider>
 );
-
-const suppressActWarning = consoleError => {
-  const actMsg = 'Warning: An update to %s inside a test was not wrapped in act';
-
-  jest.spyOn( console, 'error' ).mockImplementation( ( ...args ) => {
-    if ( !args[0].includes( actMsg ) ) {
-      consoleError( ...args );
-    }
-  } );
-};
 
 describe( '<VideoProjectFiles />', () => {
   const consoleError = console.error;

--- a/components/admin/ProjectReview/VideoReview/VideoReview.test.js
+++ b/components/admin/ProjectReview/VideoReview/VideoReview.test.js
@@ -8,6 +8,7 @@ import { Icon, Loader } from 'semantic-ui-react';
 import ProjectNotFound from 'components/admin/ProjectNotFound/ProjectNotFound';
 import VideoReviewUnitTest from './VideoReview';
 
+import { suppressActWarning } from 'lib/utils';
 import {
   draftMocks,
   errorMocks,
@@ -65,21 +66,11 @@ const DraftComponent = (
 );
 
 describe( '<VideoReview />', () => {
-  /**
-   * @todo Suppress React 16.8 `act()` warnings globally.
-   * The React team's fix won't be out of alpha until 16.9.0.
-   * @see https://github.com/facebook/react/issues/14769
-   */
   const consoleError = console.error;
 
-  beforeAll( () => {
-    const actMsg = 'Warning: An update to %s inside a test was not wrapped in act';
-
-    jest.spyOn( console, 'error' ).mockImplementation( ( ...args ) => {
-      if ( !args[0].includes( actMsg ) ) {
-        consoleError( ...args );
-      }
-    } );
+  beforeAll( () => suppressActWarning( consoleError ) );
+  afterAll( () => {
+    console.error = consoleError;
   } );
 
   const getBtn = ( buttons, str ) => buttons.filterWhere( btn => btn.text() === str );

--- a/components/admin/ProjectReview/VideoSupportFiles/VideoSupportFiles.test.js
+++ b/components/admin/ProjectReview/VideoSupportFiles/VideoSupportFiles.test.js
@@ -4,7 +4,7 @@ import wait from 'waait';
 import { MockedProvider } from '@apollo/react-testing';
 import { Icon, Loader } from 'semantic-ui-react';
 
-import { getCount } from 'lib/utils';
+import { getCount, suppressActWarning } from 'lib/utils';
 import VideoSupportFiles, {
   VIDEO_PROJECT_REVIEW_SUPPORT_FILES_QUERY,
 } from './VideoSupportFiles';
@@ -96,16 +96,6 @@ const Component = (
     <VideoSupportFiles { ...props } />
   </MockedProvider>
 );
-
-const suppressActWarning = consoleError => {
-  const actMsg = 'Warning: An update to %s inside a test was not wrapped in act';
-
-  jest.spyOn( console, 'error' ).mockImplementation( ( ...args ) => {
-    if ( !args[0].includes( actMsg ) ) {
-      consoleError( ...args );
-    }
-  } );
-};
 
 describe( '<VideoSupportFiles />', () => {
   const consoleError = console.error;

--- a/components/admin/ProjectSupportFiles/SupportItem/SupportItem.test.js
+++ b/components/admin/ProjectSupportFiles/SupportItem/SupportItem.test.js
@@ -20,6 +20,7 @@ import {
   props,
   uploadErrorProps,
 } from './mocks';
+import { suppressActWarning } from 'lib/utils';
 
 jest.mock( 'next/dynamic', () => () => 'Dynamic' );
 jest.mock( 'next/config', () => () => ( { publicRuntimeConfig: { REACT_APP_AWS_S3_AUTHORING_BUCKET: 's3-bucket-url' } } ) );
@@ -107,22 +108,10 @@ const NullItemComponent = (
 describe( '<SupportItem />', () => {
   // store console.dir & mock its call in axios.catch
   const consoleDir = console.dir;
-
-  /**
-   * @todo Suppress React 16.8 `act()` warnings globally.
-   * The React team's fix won't be out of alpha until 16.9.0.
-   * @see https://github.com/facebook/react/issues/14769
-   */
   const consoleError = console.error;
 
   beforeAll( () => {
-    const actMsg = 'Warning: An update to %s inside a test was not wrapped in act';
-
-    jest.spyOn( console, 'error' ).mockImplementation( ( ...args ) => {
-      if ( !args[0].includes( actMsg ) ) {
-        consoleError( ...args );
-      }
-    } );
+    suppressActWarning( consoleError );
 
     const resp = { status: 200 };
 

--- a/components/admin/Upload/modals/GraphicUpload/GraphicUpload.test.js
+++ b/components/admin/Upload/modals/GraphicUpload/GraphicUpload.test.js
@@ -1,6 +1,7 @@
 import { mount } from 'enzyme';
 import toJSON from 'enzyme-to-json';
 import { useFileStateManager } from 'lib/hooks/useFileStateManager';
+import { suppressActWarning } from 'lib/utils';
 import GraphicUpload from './GraphicUpload';
 
 jest.mock(
@@ -111,16 +112,6 @@ const files = [
     loaded: 0,
   },
 ];
-
-const suppressActWarning = consoleError => {
-  const actMsg = 'Warning: An update to %s inside a test was not wrapped in act';
-
-  jest.spyOn( console, 'error' ).mockImplementation( ( ...args ) => {
-    if ( !args[0].includes( actMsg ) ) {
-      consoleError( ...args );
-    }
-  } );
-};
 
 describe( '<GraphicUpload />, if graphic files have been selected for upload', () => {
   const props = {

--- a/components/admin/Upload/modals/VideoUpload/VideoProjectFiles/VideoProjectFileDesktop/VideoProjectFileDesktop.js
+++ b/components/admin/Upload/modals/VideoUpload/VideoProjectFiles/VideoProjectFileDesktop/VideoProjectFileDesktop.js
@@ -47,7 +47,7 @@ const VideoProjectFilesDesktop = () => {
   } );
 
   return (
-    // Context API is used to avoind having to pass props down multiple levels
+    // Context API is used to avoid having to pass props down multiple levels
     <VideoUploadContext.Consumer>
       { ( {
         files,
@@ -68,11 +68,23 @@ const VideoProjectFilesDesktop = () => {
             <Grid>
               <Grid.Row className="videoProjectFilesDesktop__row-header">
                 <Grid.Column width={ 6 }>Files Selected</Grid.Column>
-                <Grid.Column width={ 4 } style={ show( 1 ) }>Language<span className="required">*</span></Grid.Column>
-                <Grid.Column width={ 4 } style={ show( 1 ) }>Subtitles<span className="required">*</span></Grid.Column>
-                <Grid.Column width={ 4 } style={ show( 2 ) }>Type / Use<span className="required">*</span></Grid.Column>
-                <Grid.Column width={ 4 } style={ show( 2 ) }>Quality<span className="required">*</span></Grid.Column>
-                <Grid.Column width={ 2 }></Grid.Column>
+                <Grid.Column width={ 4 } style={ show( 1 ) }>
+                  Language
+                  <span className="required">*</span>
+                </Grid.Column>
+                <Grid.Column width={ 4 } style={ show( 1 ) }>
+                  On-Screen Text
+                  <span className="required">*</span>
+                </Grid.Column>
+                <Grid.Column width={ 4 } style={ show( 2 ) }>
+                  Type / Use
+                  <span className="required">*</span>
+                </Grid.Column>
+                <Grid.Column width={ 4 } style={ show( 2 ) }>
+                  Quality
+                  <span className="required">*</span>
+                </Grid.Column>
+                <Grid.Column width={ 2 } />
               </Grid.Row>
 
               { files.sort( compareFilenames ).map( file => (

--- a/components/admin/download/DownloadCaption/DownloadCaption.test.js
+++ b/components/admin/download/DownloadCaption/DownloadCaption.test.js
@@ -3,7 +3,10 @@ import toJSON from 'enzyme-to-json';
 import wait from 'waait';
 import { MockedProvider } from '@apollo/react-testing';
 import { Loader } from 'semantic-ui-react';
+
 import DownloadCaption from './DownloadCaption';
+
+import { suppressActWarning } from 'lib/utils';
 import {
   emptyProjectMocks,
   errorMocks,
@@ -16,6 +19,7 @@ import {
 jest.mock( 'lib/hooks/useSignedUrl', () => jest.fn( () => ( { signedUrl: 'https://example.jpg' } ) ) );
 
 jest.mock( 'lib/utils', () => ( {
+  ...jest.requireActual( '../../../../lib/utils' ),
   getS3Url: jest.fn( assetPath => `https://s3-url.com/${assetPath}` ),
   getApolloErrors: error => {
     let errs = [];
@@ -43,16 +47,6 @@ const Component = (
     <DownloadCaption { ...props } />
   </MockedProvider>
 );
-
-const suppressActWarning = consoleError => {
-  const actMsg = 'Warning: An update to %s inside a test was not wrapped in act';
-
-  jest.spyOn( console, 'error' ).mockImplementation( ( ...args ) => {
-    if ( !args[0].includes( actMsg ) ) {
-      consoleError( ...args );
-    }
-  } );
-};
 
 describe( '<DownloadCaption />', () => {
   const consoleError = console.error;
@@ -178,6 +172,7 @@ describe( '<DownloadCaption />', () => {
     expect( items.length ).toEqual( files.length );
     items.forEach( ( item, i ) => {
       const assetPath = files[i].url;
+
       expect( item.prop( 'srcUrl' ) ).toEqual( `${s3Bucket}/${assetPath}` );
       expect( item.find( '.download-item' ).prop( 'href' ) ).toEqual( 'https://example.jpg' );
       expect( item.find( '.download-item' ).prop( 'download' ) ).toEqual( true );

--- a/components/admin/download/DownloadOtherFiles/DownloadOtherFiles.test.js
+++ b/components/admin/download/DownloadOtherFiles/DownloadOtherFiles.test.js
@@ -6,6 +6,7 @@ import { Loader } from 'semantic-ui-react';
 
 import DownloadOtherFiles from './DownloadOtherFiles';
 
+import { suppressActWarning } from 'lib/utils';
 import {
   emptyProjectMocks,
   errorMocks,
@@ -18,6 +19,7 @@ import {
 jest.mock( 'lib/hooks/useSignedUrl', () => jest.fn( () => ( { signedUrl: 'https://example.jpg' } ) ) );
 
 jest.mock( 'lib/utils', () => ( {
+  ...jest.requireActual( '../../../../lib/utils' ),
   getS3Url: jest.fn( assetPath => `https://s3-url.com/${assetPath}` ),
   getApolloErrors: error => {
     let errs = [];
@@ -45,16 +47,6 @@ const Component = (
     <DownloadOtherFiles { ...props } />
   </MockedProvider>
 );
-
-const suppressActWarning = consoleError => {
-  const actMsg = 'Warning: An update to %s inside a test was not wrapped in act';
-
-  jest.spyOn( console, 'error' ).mockImplementation( ( ...args ) => {
-    if ( !args[0].includes( actMsg ) ) {
-      consoleError( ...args );
-    }
-  } );
-};
 
 describe( '<DownloadOtherFiles />', () => {
   const consoleError = console.error;
@@ -180,6 +172,7 @@ describe( '<DownloadOtherFiles />', () => {
     expect( items.length ).toEqual( files.length );
     items.forEach( ( item, i ) => {
       const { url: assetPath } = files[i];
+
       expect( item.prop( 'srcUrl' ) ).toEqual( `${s3Bucket}/${assetPath}` );
       expect( item.find( '.download-item' ).prop( 'href' ) ).toEqual( 'https://example.jpg' );
       expect( item.find( '.download-item' ).prop( 'download' ) ).toEqual( true );

--- a/components/admin/download/DownloadThumbnail/DownloadThumbnail.test.js
+++ b/components/admin/download/DownloadThumbnail/DownloadThumbnail.test.js
@@ -6,6 +6,7 @@ import { Loader } from 'semantic-ui-react';
 
 import DownloadThumbnail from './DownloadThumbnail';
 
+import { suppressActWarning } from 'lib/utils';
 import {
   emptyProjectMocks,
   errorMocks,
@@ -16,6 +17,7 @@ import {
 } from './mocks';
 
 jest.mock( 'lib/utils', () => ( {
+  ...jest.requireActual( '../../../../lib/utils' ),
   getS3Url: jest.fn( assetPath => `https://s3-url.com/${assetPath}` ),
   getApolloErrors: error => {
     let errs = [];
@@ -45,16 +47,6 @@ const Component = (
     <DownloadThumbnail { ...props } />
   </MockedProvider>
 );
-
-const suppressActWarning = consoleError => {
-  const actMsg = 'Warning: An update to %s inside a test was not wrapped in act';
-
-  jest.spyOn( console, 'error' ).mockImplementation( ( ...args ) => {
-    if ( !args[0].includes( actMsg ) ) {
-      consoleError( ...args );
-    }
-  } );
-};
 
 describe( '<DownloadThumbnail />', () => {
   const consoleError = console.error;
@@ -178,9 +170,10 @@ describe( '<DownloadThumbnail />', () => {
     const s3Bucket = 'https://s3-url.com';
 
     expect( items.length ).toEqual( thumbnails.length );
-    
+
     items.forEach( ( item, i ) => {
       const assetPath = thumbnails[i].url;
+
       expect( item.prop( 'srcUrl' ) ).toEqual( `${s3Bucket}/${assetPath}` );
       expect( item.find( '.download-item' ).prop( 'href' ) ).toEqual( 'https://example.jpg' );
       expect( item.find( '.download-item' ).prop( 'download' ) ).toEqual( true );

--- a/components/admin/dropdowns/BureauOfficesDropdown/BureauOfficesDropdown.test.js
+++ b/components/admin/dropdowns/BureauOfficesDropdown/BureauOfficesDropdown.test.js
@@ -3,16 +3,17 @@ import wait from 'waait';
 import { MockedProvider } from '@apollo/react-testing';
 import sortBy from 'lodash/sortBy';
 import BureauOfficesDropdown, { BUREAU_OFFICES_QUERY } from './BureauOfficesDropdown';
+import { suppressActWarning } from 'lib/utils';
 
 const props = {
   id: '123xyz',
-  label: 'Bureau/Offices'
+  label: 'Bureau/Offices',
 };
 
 const mocks = [
   {
     request: {
-      query: BUREAU_OFFICES_QUERY
+      query: BUREAU_OFFICES_QUERY,
     },
     result: {
       data: {
@@ -30,9 +31,9 @@ const mocks = [
               {
                 id: 'eiwo',
                 name: 'Office 2',
-                abbr: 'O2'
-              }
-            ]
+                abbr: 'O2',
+              },
+            ],
           },
           {
             id: 'weio',
@@ -42,9 +43,9 @@ const mocks = [
               {
                 id: 'eiwo',
                 name: 'Office 2',
-                abbr: 'O2'
-              }
-            ]
+                abbr: 'O2',
+              },
+            ],
           },
           {
             id: 'xzwi',
@@ -54,9 +55,9 @@ const mocks = [
               {
                 id: 'kglf',
                 name: 'Office 1',
-                abbr: 'O1'
-              }
-            ]
+                abbr: 'O1',
+              },
+            ],
           },
           {
             id: 'zxcw',
@@ -66,46 +67,46 @@ const mocks = [
               {
                 id: 'kglf',
                 name: 'Office 1',
-                abbr: 'O1'
+                abbr: 'O1',
               },
               {
                 id: 'eiwo',
                 name: 'Office 2',
-                abbr: 'O2'
-              }
-            ]
-          }
-        ]
-      }
-    }
-  }
+                abbr: 'O2',
+              },
+            ],
+          },
+        ],
+      },
+    },
+  },
 ];
 
 const errorMocks = [
   {
     ...mocks[0],
     result: {
-      errors: [{ message: 'There was an error.' }]
-    }
-  }
+      errors: [{ message: 'There was an error.' }],
+    },
+  },
 ];
 
 const nullMocks = [
   {
     ...mocks[0],
     result: {
-      data: { bureaus: null }
-    }
-  }
+      data: { bureaus: null },
+    },
+  },
 ];
 
 const emptyMocks = [
   {
     ...mocks[0],
     result: {
-      data: { bureaus: [] }
-    }
-  }
+      data: { bureaus: [] },
+    },
+  },
 ];
 
 const Component = (
@@ -133,21 +134,9 @@ const EmptyComponent = (
 );
 
 describe( '<BureauOfficesDropdown />', () => {
-  /**
-   * @todo Suppress React 16.8 `act()` warnings globally.
-   * The React team's fix won't be out of alpha until 16.9.0.
-   * @see https://github.com/facebook/react/issues/14769
-   */
   const consoleError = console.error;
-  beforeAll( () => {
-    const actMsg = 'Warning: An update to %s inside a test was not wrapped in act';
-    jest.spyOn( console, 'error' ).mockImplementation( ( ...args ) => {
-      if ( !args[0].includes( actMsg ) ) {
-        consoleError( ...args );
-      }
-    } );
-  } );
 
+  beforeAll( () => suppressActWarning( consoleError ) );
   afterAll( () => {
     console.error = consoleError;
   } );
@@ -163,6 +152,7 @@ describe( '<BureauOfficesDropdown />', () => {
 
   it( 'renders an error message if there is a GraphQL error', async () => {
     const wrapper = mount( ErrorComponent );
+
     await wait( 0 );
     wrapper.update();
     const dropdown = wrapper.find( 'BureauOfficesDropdown' );
@@ -174,6 +164,7 @@ describe( '<BureauOfficesDropdown />', () => {
 
   it( 'does not crash if bureaus is null', async () => {
     const wrapper = mount( NullComponent );
+
     await wait( 0 );
     wrapper.update();
     const formDropdown = wrapper.find( 'FormDropdown' );
@@ -183,6 +174,7 @@ describe( '<BureauOfficesDropdown />', () => {
 
   it( 'does not crash if bureaus is []', async () => {
     const wrapper = mount( EmptyComponent );
+
     await wait( 0 );
     wrapper.update();
     const formDropdown = wrapper.find( 'FormDropdown' );
@@ -192,6 +184,7 @@ describe( '<BureauOfficesDropdown />', () => {
 
   it( 'renders the final state without crashing', async () => {
     const wrapper = mount( Component );
+
     await wait( 0 );
     wrapper.update();
     const formDropdown = wrapper.find( 'FormDropdown' );
@@ -201,7 +194,7 @@ describe( '<BureauOfficesDropdown />', () => {
       .map( bureau => ( {
         key: bureau.id,
         text: `${bureau.name} (${bureau.abbr})`,
-        value: bureau.id
+        value: bureau.id,
       } ) );
 
     expect( formDropdown.prop( 'options' ) ).toEqual( options );
@@ -210,6 +203,7 @@ describe( '<BureauOfficesDropdown />', () => {
 
   it( 'assigns a matching id & htmlFor value to the Dropdown and label, respectively', async () => {
     const wrapper = mount( Component );
+
     await wait( 0 );
     wrapper.update();
     const dropdown = wrapper.find( 'Dropdown div[name="bureaus"]' );

--- a/components/admin/dropdowns/CategoryDropdown/CategoryDropdown.test.js
+++ b/components/admin/dropdowns/CategoryDropdown/CategoryDropdown.test.js
@@ -1,7 +1,7 @@
 import { mount } from 'enzyme';
 import wait from 'waait';
 import { MockedProvider } from '@apollo/react-testing';
-import { titleCase } from 'lib/utils';
+import { suppressActWarning, titleCase } from 'lib/utils';
 import CategoryDropdown, { CATEGORIES_QUERY } from './CategoryDropdown';
 import { categories } from './mocks';
 
@@ -10,46 +10,46 @@ jest.mock( 'next/config', () => () => ( { publicRuntimeConfig: { REACT_APP_AWS_S
 const props = {
   id: '123xyz',
   label: 'Categories',
-  locale: 'en-us'
+  locale: 'en-us',
 };
 
 const mocks = [
   {
     request: {
       query: CATEGORIES_QUERY,
-      variables: { locale: props.locale }
+      variables: { locale: props.locale },
     },
     result: {
-      data: { categories }
-    }
-  }
+      data: { categories },
+    },
+  },
 ];
 
 const errorMocks = [
   {
     ...mocks[0],
     result: {
-      errors: [{ message: 'There was an error.' }]
-    }
-  }
+      errors: [{ message: 'There was an error.' }],
+    },
+  },
 ];
 
 const nullMocks = [
   {
     ...mocks[0],
     result: {
-      data: { categories: null }
-    }
-  }
+      data: { categories: null },
+    },
+  },
 ];
 
 const emptyMocks = [
   {
     ...mocks[0],
     result: {
-      data: { categories: [] }
-    }
-  }
+      data: { categories: [] },
+    },
+  },
 ];
 
 const Component = (
@@ -75,16 +75,6 @@ const EmptyComponent = (
     <CategoryDropdown { ...props } />
   </MockedProvider>
 );
-
-const suppressActWarning = consoleError => {
-  const actMsg = 'Warning: An update to %s inside a test was not wrapped in act';
-
-  jest.spyOn( console, 'error' ).mockImplementation( ( ...args ) => {
-    if ( !args[0].includes( actMsg ) ) {
-      consoleError( ...args );
-    }
-  } );
-};
 
 describe( '<CategoryDropdown />', () => {
   const consoleError = console.error;
@@ -147,7 +137,7 @@ describe( '<CategoryDropdown />', () => {
       value: category.id,
       text: category.translations.length
         ? titleCase( category.translations[0].name )
-        : ''
+        : '',
     } ) );
 
     expect( formDropdown.prop( 'options' ) ).toEqual( semanticUICats );

--- a/components/admin/dropdowns/CopyrightDropdown/CopyrightDropdown.test.js
+++ b/components/admin/dropdowns/CopyrightDropdown/CopyrightDropdown.test.js
@@ -3,36 +3,38 @@ import wait from 'waait';
 import { MockedProvider } from '@apollo/react-testing';
 import CopyrightDropdown, { COPYRIGHT_QUERY } from './CopyrightDropdown';
 
+import { suppressActWarning } from 'lib/utils';
+
 const props = {
   id: 'copyright',
-  label: 'Copyright'
+  label: 'Copyright',
 };
 
 const mocks = [
   {
     request: {
-      query: COPYRIGHT_QUERY
+      query: COPYRIGHT_QUERY,
     },
     result: {
       data: {
         __type: {
           enumValues: [
             { name: 'COPYRIGHT' },
-            { name: 'NO_COPYRIGHT' }
-          ]
-        }
-      }
-    }
-  }
+            { name: 'NO_COPYRIGHT' },
+          ],
+        },
+      },
+    },
+  },
 ];
 
 const errorMocks = [
   {
     ...mocks[0],
     result: {
-      errors: [{ message: 'There was an error.' }]
-    }
-  }
+      errors: [{ message: 'There was an error.' }],
+    },
+  },
 ];
 
 const nullMocks = [
@@ -40,10 +42,10 @@ const nullMocks = [
     ...mocks[0],
     result: {
       data: {
-        __type: { enumValues: null }
-      }
-    }
-  }
+        __type: { enumValues: null },
+      },
+    },
+  },
 ];
 
 const emptyMocks = [
@@ -51,21 +53,11 @@ const emptyMocks = [
     ...mocks[0],
     result: {
       data: {
-        __type: { enumValues: [] }
-      }
-    }
-  }
+        __type: { enumValues: [] },
+      },
+    },
+  },
 ];
-
-const suppressActWarning = consoleError => {
-  const actMsg = 'Warning: An update to %s inside a test was not wrapped in act';
-
-  jest.spyOn( console, 'error' ).mockImplementation( ( ...args ) => {
-    if ( !args[0].includes( actMsg ) ) {
-      consoleError( ...args );
-    }
-  } );
-};
 
 describe( '<CopyrightDropdown />', () => {
   const consoleError = console.error;
@@ -156,7 +148,7 @@ describe( '<CopyrightDropdown />', () => {
       return {
         key: obj.name,
         text,
-        value: obj.name
+        value: obj.name,
       };
     } );
 

--- a/components/admin/dropdowns/CountriesRegionsDropdown/CountriesRegionsDropdown.test.js
+++ b/components/admin/dropdowns/CountriesRegionsDropdown/CountriesRegionsDropdown.test.js
@@ -3,17 +3,18 @@ import wait from 'waait';
 import { MockedProvider } from '@apollo/react-testing';
 import sortBy from 'lodash/sortBy';
 import { COUNTRIES_REGIONS_QUERY } from 'lib/graphql/queries/document';
+import { suppressActWarning } from 'lib/utils';
 import CountriesRegionsDropdown from './CountriesRegionsDropdown';
 
 const props = {
   id: '123xyz',
-  label: 'Countries/Regions Tags'
+  label: 'Countries/Regions Tags',
 };
 
 const mocks = [
   {
     request: {
-      query: COUNTRIES_REGIONS_QUERY
+      query: COUNTRIES_REGIONS_QUERY,
     },
     result: {
       data: {
@@ -27,8 +28,8 @@ const mocks = [
               __typename: 'Region',
               id: 'ck6krp96o3f3k0720aoufd395',
               name: 'Bureau of Western Hemisphere Affairs',
-              abbr: 'WHA'
-            }
+              abbr: 'WHA',
+            },
           },
           {
             __typename: 'Country',
@@ -39,8 +40,8 @@ const mocks = [
               __typename: 'Region',
               id: 'ck6krp96g3f3c0720c1w09bx1',
               name: 'Bureau of African Affairs',
-              abbr: 'AF'
-            }
+              abbr: 'AF',
+            },
           },
           {
             __typename: 'Country',
@@ -51,8 +52,8 @@ const mocks = [
               __typename: 'Region',
               id: 'ck6krp96o3f3i07201zo5ai59',
               name: 'Bureau of Near Eastern Affairs',
-              abbr: 'NEA'
-            }
+              abbr: 'NEA',
+            },
           },
           {
             __typename: 'Country',
@@ -63,40 +64,40 @@ const mocks = [
               __typename: 'Region',
               id: 'ck6krp96o3f3h07201q3rj4n7',
               name: 'Bureau of European and Eurasian Affairs',
-              abbr: 'EUR'
-            }
-          }
-        ]
-      }
-    }
-  }
+              abbr: 'EUR',
+            },
+          },
+        ],
+      },
+    },
+  },
 ];
 
 const errorMocks = [
   {
     ...mocks[0],
     result: {
-      errors: [{ message: 'There was an error.' }]
-    }
-  }
+      errors: [{ message: 'There was an error.' }],
+    },
+  },
 ];
 
 const nullMocks = [
   {
     ...mocks[0],
     result: {
-      data: { countries: null }
-    }
-  }
+      data: { countries: null },
+    },
+  },
 ];
 
 const emptyMocks = [
   {
     ...mocks[0],
     result: {
-      data: { countries: [] }
-    }
-  }
+      data: { countries: [] },
+    },
+  },
 ];
 
 const Component = (
@@ -124,21 +125,9 @@ const EmptyComponent = (
 );
 
 describe( '<CountriesRegionsDropdown />', () => {
-  /**
-   * @todo Suppress React 16.8 `act()` warnings globally.
-   * The React team's fix won't be out of alpha until 16.9.0.
-   * @see https://github.com/facebook/react/issues/14769
-   */
   const consoleError = console.error;
-  beforeAll( () => {
-    const actMsg = 'Warning: An update to %s inside a test was not wrapped in act';
-    jest.spyOn( console, 'error' ).mockImplementation( ( ...args ) => {
-      if ( !args[0].includes( actMsg ) ) {
-        consoleError( ...args );
-      }
-    } );
-  } );
 
+  beforeAll( () => suppressActWarning( consoleError ) );
   afterAll( () => {
     console.error = consoleError;
   } );
@@ -154,6 +143,7 @@ describe( '<CountriesRegionsDropdown />', () => {
 
   it( 'renders an error message if there is a GraphQL error', async () => {
     const wrapper = mount( ErrorComponent );
+
     await wait( 0 );
     wrapper.update();
     const dropdown = wrapper.find( 'CountriesRegionsDropdown' );
@@ -165,6 +155,7 @@ describe( '<CountriesRegionsDropdown />', () => {
 
   it( 'does not crash if countries is null', async () => {
     const wrapper = mount( NullComponent );
+
     await wait( 0 );
     wrapper.update();
     const formDropdown = wrapper.find( 'FormDropdown' );
@@ -174,6 +165,7 @@ describe( '<CountriesRegionsDropdown />', () => {
 
   it( 'does not crash if countries is []', async () => {
     const wrapper = mount( EmptyComponent );
+
     await wait( 0 );
     wrapper.update();
     const formDropdown = wrapper.find( 'FormDropdown' );
@@ -183,6 +175,7 @@ describe( '<CountriesRegionsDropdown />', () => {
 
   it( 'renders the final state without crashing', async () => {
     const wrapper = mount( Component );
+
     await wait( 0 );
     wrapper.update();
     const formDropdown = wrapper.find( 'FormDropdown' );
@@ -192,7 +185,7 @@ describe( '<CountriesRegionsDropdown />', () => {
       .map( country => ( {
         key: country.id,
         text: `${country.name} (${country.abbr})`,
-        value: country.id
+        value: country.id,
       } ) );
 
     expect( formDropdown.prop( 'options' ) ).toEqual( options );
@@ -201,6 +194,7 @@ describe( '<CountriesRegionsDropdown />', () => {
 
   it( 'assigns a matching id & htmlFor value to the Dropdown and label, respectively', async () => {
     const wrapper = mount( Component );
+
     await wait( 0 );
     wrapper.update();
     const dropdown = wrapper.find( 'Dropdown div[name="countries"]' );

--- a/components/admin/dropdowns/GraphicStyleDropdown/GraphicStyleDropdown.test.js
+++ b/components/admin/dropdowns/GraphicStyleDropdown/GraphicStyleDropdown.test.js
@@ -3,7 +3,7 @@ import wait from 'waait';
 import { MockedProvider } from '@apollo/react-testing';
 import sortBy from 'lodash/sortBy';
 import GraphicStyleDropdown, { GRAPHIC_STYLES_QUERY } from './GraphicStyleDropdown';
-import { addEmptyOption } from 'lib/utils';
+import { addEmptyOption, suppressActWarning } from 'lib/utils';
 
 const props = {
   id: '123xyz',
@@ -99,23 +99,9 @@ const OmitComponent = (
 
 
 describe( '<GraphicStyleDropdown />', () => {
-  /**
-      * @todo Suppress React 16.8 `act()` warnings globally.
-      * The React team's fix won't be out of alpha until 16.9.0.
-      * @see https://github.com/facebook/react/issues/14769
-      */
   const consoleError = console.error;
 
-  beforeAll( () => {
-    const actMsg = 'Warning: An update to %s inside a test was not wrapped in act';
-
-    jest.spyOn( console, 'error' ).mockImplementation( ( ...args ) => {
-      if ( !args[0].includes( actMsg ) ) {
-        consoleError( ...args );
-      }
-    } );
-  } );
-
+  beforeAll( () => suppressActWarning( consoleError ) );
   afterAll( () => {
     console.error = consoleError;
   } );

--- a/components/admin/dropdowns/LanguageDropdown/LanguageDropdown.js
+++ b/components/admin/dropdowns/LanguageDropdown/LanguageDropdown.js
@@ -1,5 +1,5 @@
 /* eslint-disable no-bitwise */
-import React, { Fragment, useState } from 'react';
+import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
 import VisuallyHidden from 'components/VisuallyHidden/VisuallyHidden';
 import { Form } from 'semantic-ui-react';
@@ -30,7 +30,9 @@ const LANGUAGE_BY_NAME_QUERY = gql`
   }
 `;
 
-const areEqual = ( prevProps, nextProps ) => prevProps.value === nextProps.value;
+const areEqual = ( prevProps, nextProps ) => (
+  prevProps.value === nextProps.value && prevProps.disabled === nextProps.disabled
+);
 
 const getIds = ( languages, selected ) => {
   const _languages = selected.map( _selected => {

--- a/components/admin/dropdowns/LanguageDropdown/LanguageDropdown.test.js
+++ b/components/admin/dropdowns/LanguageDropdown/LanguageDropdown.test.js
@@ -2,56 +2,58 @@ import { mount } from 'enzyme';
 import wait from 'waait';
 import { MockedProvider } from '@apollo/react-testing';
 import sortBy from 'lodash/sortBy';
-import { addEmptyOption } from 'lib/utils';
+import { addEmptyOption, suppressActWarning } from 'lib/utils';
 import LanguageDropdown, { LANGUAGES_QUERY } from './LanguageDropdown';
+
+
 import { languages } from './mocks';
 
 const props = {
   id: '123xyz',
-  label: 'Language'
+  label: 'Language',
 };
 
 const localesProps = {
   ...props,
-  locales: ['en-us', 'fr-fr']
+  locales: ['en-us', 'fr-fr'],
 };
 
 const mocks = [
   {
     request: {
-      query: LANGUAGES_QUERY
+      query: LANGUAGES_QUERY,
     },
     result: {
-      data: { languages }
-    }
-  }
+      data: { languages },
+    },
+  },
 ];
 
 const errorMocks = [
   {
     ...mocks[0],
     result: {
-      errors: [{ message: 'There was an error.' }]
-    }
-  }
+      errors: [{ message: 'There was an error.' }],
+    },
+  },
 ];
 
 const nullMocks = [
   {
     ...mocks[0],
     result: {
-      data: { languages: null }
-    }
-  }
+      data: { languages: null },
+    },
+  },
 ];
 
 const emptyMocks = [
   {
     ...mocks[0],
     result: {
-      data: { languages: [] }
-    }
-  }
+      data: { languages: [] },
+    },
+  },
 ];
 
 const Component = (
@@ -83,16 +85,6 @@ const EmptyComponent = (
     <LanguageDropdown { ...props } />
   </MockedProvider>
 );
-
-const suppressActWarning = consoleError => {
-  const actMsg = 'Warning: An update to %s inside a test was not wrapped in act';
-
-  jest.spyOn( console, 'error' ).mockImplementation( ( ...args ) => {
-    if ( !args[0].includes( actMsg ) ) {
-      consoleError( ...args );
-    }
-  } );
-};
 
 describe( '<LanguageDropdown />', () => {
   const consoleError = console.error;
@@ -133,8 +125,8 @@ describe( '<LanguageDropdown />', () => {
       {
         key: '-',
         text: '-',
-        value: null
-      }
+        value: null,
+      },
     ];
 
     expect( formDropdown.prop( 'options' ) ).toEqual( emptyOption );
@@ -150,8 +142,8 @@ describe( '<LanguageDropdown />', () => {
       {
         key: '-',
         text: '-',
-        value: null
-      }
+        value: null,
+      },
     ];
 
     expect( formDropdown.prop( 'options' ) ).toEqual( emptyOption );
@@ -168,7 +160,7 @@ describe( '<LanguageDropdown />', () => {
       .map( lang => ( {
         key: lang.id,
         text: lang.displayName,
-        value: lang.id
+        value: lang.id,
       } ) );
     const options = addEmptyOption( semanticUILangs );
 
@@ -192,7 +184,7 @@ describe( '<LanguageDropdown />', () => {
       .map( lang => ( {
         key: lang.id,
         text: lang.displayName,
-        value: lang.id
+        value: lang.id,
       } ) );
     const options = addEmptyOption( semanticUILangs );
 

--- a/components/admin/dropdowns/QualityDropdown/QualityDropdown.test.js
+++ b/components/admin/dropdowns/QualityDropdown/QualityDropdown.test.js
@@ -1,67 +1,67 @@
 import { mount } from 'enzyme';
 import wait from 'waait';
 import { MockedProvider } from '@apollo/react-testing';
-import { addEmptyOption } from 'lib/utils';
+import { addEmptyOption, suppressActWarning } from 'lib/utils';
 import QualityDropdown, { VIDEO_QUALITY_QUERY, IMAGE_QUALITY_QUERY } from './QualityDropdown';
 
 const props = {
   id: 'q123',
   label: 'Quality',
   infotip: 'tooltip message',
-  type: 'Video'
+  type: 'Video',
 };
 
 const imageProps = {
   ...props,
-  type: 'Image'
+  type: 'Image',
 };
 
 const mocks = [
   {
     request: {
-      query: VIDEO_QUALITY_QUERY
+      query: VIDEO_QUALITY_QUERY,
     },
     result: {
       data: {
         __type: {
           enumValues: [
             { name: 'WEB' },
-            { name: 'BROADCAST' }
-          ]
-        }
-      }
-    }
+            { name: 'BROADCAST' },
+          ],
+        },
+      },
+    },
   },
   {
     request: {
-      query: IMAGE_QUALITY_QUERY
+      query: IMAGE_QUALITY_QUERY,
     },
     result: {
       data: {
         __type: {
           enumValues: [
             { name: 'WEB' },
-            { name: 'PRINT' }
-          ]
-        }
-      }
-    }
-  }
+            { name: 'PRINT' },
+          ],
+        },
+      },
+    },
+  },
 ];
 
 const errorMocks = [
   {
     ...mocks[0],
     result: {
-      errors: [{ message: 'There was an error.' }]
-    }
+      errors: [{ message: 'There was an error.' }],
+    },
   },
   {
     ...mocks[1],
     result: {
-      errors: [{ message: 'There was an error.' }]
-    }
-  }
+      errors: [{ message: 'There was an error.' }],
+    },
+  },
 ];
 
 const nullMocks = [
@@ -69,18 +69,18 @@ const nullMocks = [
     ...mocks[0],
     result: {
       data: {
-        __type: { enumValues: null }
-      }
-    }
+        __type: { enumValues: null },
+      },
+    },
   },
   {
     ...mocks[1],
     result: {
       data: {
-        __type: { enumValues: null }
-      }
-    }
-  }
+        __type: { enumValues: null },
+      },
+    },
+  },
 ];
 
 const emptyMocks = [
@@ -88,29 +88,19 @@ const emptyMocks = [
     ...mocks[0],
     result: {
       data: {
-        __type: { enumValues: [] }
-      }
-    }
+        __type: { enumValues: [] },
+      },
+    },
   },
   {
     ...mocks[1],
     result: {
       data: {
-        __type: { enumValues: [] }
-      }
-    }
-  }
+        __type: { enumValues: [] },
+      },
+    },
+  },
 ];
-
-const suppressActWarning = consoleError => {
-  const actMsg = 'Warning: An update to %s inside a test was not wrapped in act';
-
-  jest.spyOn( console, 'error' ).mockImplementation( ( ...args ) => {
-    if ( !args[0].includes( actMsg ) ) {
-      consoleError( ...args );
-    }
-  } );
-};
 
 describe( '<QualityDropdown /> for video type', () => {
   const consoleError = console.error;
@@ -175,8 +165,8 @@ describe( '<QualityDropdown /> for video type', () => {
       {
         key: '-',
         text: '-',
-        value: null
-      }
+        value: null,
+      },
     ];
 
     expect( formDropdown.prop( 'options' ) ).toEqual( emptyOption );
@@ -192,8 +182,8 @@ describe( '<QualityDropdown /> for video type', () => {
       {
         key: '-',
         text: '-',
-        value: null
-      }
+        value: null,
+      },
     ];
 
     expect( formDropdown.prop( 'options' ) ).toEqual( emptyOption );
@@ -213,7 +203,7 @@ describe( '<QualityDropdown /> for video type', () => {
       return {
         key: name,
         text: `For ${name.toLowerCase()}`,
-        value: name
+        value: name,
       };
     } );
     const options = addEmptyOption( semanticUIValues );
@@ -299,8 +289,8 @@ describe( '<QualityDropdown /> for image type', () => {
       {
         key: '-',
         text: '-',
-        value: null
-      }
+        value: null,
+      },
     ];
 
     expect( formDropdown.prop( 'options' ) ).toEqual( emptyOption );
@@ -316,8 +306,8 @@ describe( '<QualityDropdown /> for image type', () => {
       {
         key: '-',
         text: '-',
-        value: null
-      }
+        value: null,
+      },
     ];
 
     expect( formDropdown.prop( 'options' ) ).toEqual( emptyOption );
@@ -338,7 +328,7 @@ describe( '<QualityDropdown /> for image type', () => {
       return {
         key: name,
         text: `For ${name.toLowerCase()}`,
-        value: name
+        value: name,
       };
     } );
     const options = addEmptyOption( semanticUIValues );

--- a/components/admin/dropdowns/SocialPlatformDropdown/SocialPlatformDropdown.test.js
+++ b/components/admin/dropdowns/SocialPlatformDropdown/SocialPlatformDropdown.test.js
@@ -3,7 +3,7 @@ import wait from 'waait';
 import { MockedProvider } from '@apollo/react-testing';
 import sortBy from 'lodash/sortBy';
 import SocialPlatformDropdown, { SOCIAL_PLATFORMS_QUERY } from './SocialPlatformDropdown';
-import { addEmptyOption } from 'lib/utils';
+import { addEmptyOption, suppressActWarning } from 'lib/utils';
 
 const props = {
   id: '123xyz',
@@ -100,23 +100,9 @@ const EmptyComponent = (
 );
 
 describe( '<SocialPlatformDropdown />', () => {
-  /**
-   * @todo Suppress React 16.8 `act()` warnings globally.
-   * The React team's fix won't be out of alpha until 16.9.0.
-   * @see https://github.com/facebook/react/issues/14769
-   */
   const consoleError = console.error;
 
-  beforeAll( () => {
-    const actMsg = 'Warning: An update to %s inside a test was not wrapped in act';
-
-    jest.spyOn( console, 'error' ).mockImplementation( ( ...args ) => {
-      if ( !args[0].includes( actMsg ) ) {
-        consoleError( ...args );
-      }
-    } );
-  } );
-
+  beforeAll( () => suppressActWarning( consoleError ) );
   afterAll( () => {
     console.error = consoleError;
   } );

--- a/components/admin/dropdowns/TagDropdown/TagDropdown.test.js
+++ b/components/admin/dropdowns/TagDropdown/TagDropdown.test.js
@@ -1,7 +1,7 @@
 import { mount } from 'enzyme';
 import wait from 'waait';
 import { MockedProvider } from '@apollo/react-testing';
-import { titleCase } from 'lib/utils';
+import { titleCase, suppressActWarning } from 'lib/utils';
 import TagDropdown, { TAG_QUERY } from './TagDropdown';
 import { rtlTags, tags } from './mocks';
 
@@ -10,60 +10,60 @@ jest.mock( 'next/config', () => () => ( { publicRuntimeConfig: { REACT_APP_AWS_S
 const props = {
   id: '123xyz',
   label: 'Tags',
-  locale: 'en-us'
+  locale: 'en-us',
 };
 
 const rtlProps = {
   ...props,
-  locale: 'fa-ir'
+  locale: 'fa-ir',
 };
 
 const mocks = [
   {
     request: {
       query: TAG_QUERY,
-      variables: { locale: props.locale }
+      variables: { locale: props.locale },
     },
     result: {
-      data: { tags }
-    }
+      data: { tags },
+    },
   },
   {
     request: {
       query: TAG_QUERY,
-      variables: { locale: rtlProps.locale }
+      variables: { locale: rtlProps.locale },
     },
     result: {
-      data: { tags: rtlTags }
-    }
-  }
+      data: { tags: rtlTags },
+    },
+  },
 ];
 
 const errorMocks = [
   {
     ...mocks[0],
     result: {
-      errors: [{ message: 'There was an error.' }]
-    }
-  }
+      errors: [{ message: 'There was an error.' }],
+    },
+  },
 ];
 
 const nullMocks = [
   {
     ...mocks[0],
     result: {
-      data: { tags: null }
-    }
-  }
+      data: { tags: null },
+    },
+  },
 ];
 
 const emptyMocks = [
   {
     ...mocks[0],
     result: {
-      data: { tags: [] }
-    }
-  }
+      data: { tags: [] },
+    },
+  },
 ];
 
 const Component = (
@@ -95,16 +95,6 @@ const EmptyComponent = (
     <TagDropdown { ...props } />
   </MockedProvider>
 );
-
-const suppressActWarning = consoleError => {
-  const actMsg = 'Warning: An update to %s inside a test was not wrapped in act';
-
-  jest.spyOn( console, 'error' ).mockImplementation( ( ...args ) => {
-    if ( !args[0].includes( actMsg ) ) {
-      consoleError( ...args );
-    }
-  } );
-};
 
 describe( '<TagDropdown />', () => {
   const consoleError = console.error;
@@ -166,7 +156,7 @@ describe( '<TagDropdown />', () => {
       value: tag.id,
       text: tag.translations.length
         ? titleCase( tag.translations[0].name )
-        : ''
+        : '',
     } ) )
       .sort( ( tagA, tagB ) => {
         const textA = tagA.text.toLowerCase();

--- a/components/admin/dropdowns/TeamDropdown/TeamDropdown.test.js
+++ b/components/admin/dropdowns/TeamDropdown/TeamDropdown.test.js
@@ -3,19 +3,11 @@ import wait from 'waait';
 import { MockedProvider } from '@apollo/react-testing';
 import sortBy from 'lodash/sortBy';
 import TeamDropdown from './TeamDropdown';
+
+import { suppressActWarning } from 'lib/utils';
 import {
   emptyMocks, errorMocks, mocks, nullMocks,
 } from './mocks';
-
-const suppressActWarning = consoleError => {
-  const actMsg = 'Warning: An update to %s inside a test was not wrapped in act';
-
-  jest.spyOn( console, 'error' ).mockImplementation( ( ...args ) => {
-    if ( !args[0].includes( actMsg ) ) {
-      consoleError( ...args );
-    }
-  } );
-};
 
 const getComponent = ( data, props ) => (
   <MockedProvider mocks={ data } addTypename={ false }>

--- a/components/admin/dropdowns/UseDropdown/UseDropdown.js
+++ b/components/admin/dropdowns/UseDropdown/UseDropdown.js
@@ -7,8 +7,8 @@ import VisuallyHidden from 'components/VisuallyHidden/VisuallyHidden';
 import { addEmptyOption } from 'lib/utils';
 
 const VIDEO_USE_QUERY = gql`
-  query VIDEO_USE_QUERY {
-    videoUses(orderBy: name_ASC) {
+  query VIDEO_USE_QUERY($where: VideoUseWhereInput) {
+    videoUses(orderBy: name_ASC, where: $where) {
       id
       name
     }
@@ -16,8 +16,8 @@ const VIDEO_USE_QUERY = gql`
 `;
 
 const IMAGE_USE_QUERY = gql`
-  query IMAGE_USE_QUERY {
-    imageUses(orderBy: name_ASC) {
+  query IMAGE_USE_QUERY($where: ImageUseWhereInput)  {
+    imageUses(orderBy: name_ASC, where: $where) {
       id
       name
     }
@@ -25,8 +25,8 @@ const IMAGE_USE_QUERY = gql`
 `;
 
 const DOCUMENT_USE_QUERY = gql`
-  query DocumentUses {
-    documentUses(orderBy: name_ASC) {
+  query DocumentUses($where: DocumentUseWhereInput)  {
+    documentUses(orderBy: name_ASC, where: $where) {
       id
       name
     }
@@ -40,6 +40,7 @@ const UseDropdown = ( {
   label,
   name,
   type,
+  variables,
   ...rest
 } ) => {
   let query;
@@ -56,7 +57,7 @@ const UseDropdown = ( {
       break;
   }
 
-  const { data, loading, error } = useQuery( query );
+  const { data, loading, error } = useQuery( query, { variables } );
 
   if ( error ) return `Error! ${error.message}`;
 
@@ -101,6 +102,7 @@ const UseDropdown = ( {
 UseDropdown.defaultProps = {
   id: '',
   name: 'use',
+  variables: {},
 };
 
 UseDropdown.propTypes = {
@@ -108,6 +110,7 @@ UseDropdown.propTypes = {
   label: PropTypes.string,
   name: PropTypes.string,
   type: PropTypes.string,
+  variables: PropTypes.object,
 };
 
 export default React.memo( UseDropdown, areEqual );

--- a/components/admin/dropdowns/UseDropdown/UseDropdown.test.js
+++ b/components/admin/dropdowns/UseDropdown/UseDropdown.test.js
@@ -1,30 +1,29 @@
 import { mount } from 'enzyme';
 import wait from 'waait';
 import { MockedProvider } from '@apollo/react-testing';
-import sortBy from 'lodash/sortBy';
 import { addEmptyOption } from 'lib/utils';
 import UseDropdown from './UseDropdown';
 import {
-  emptyMocks, errorMocks, mocks, nullMocks
+  emptyMocks, errorMocks, mocks, nullMocks,
 } from './mocks';
 
 
 const videoProps = {
   id: 'ceae2',
   label: 'Type/Use',
-  type: 'Video'
+  type: 'Video',
 };
 
 const imageProps = {
   ...videoProps,
-  type: 'Image'
+  type: 'Image',
 };
 
 const documentProps = {
   id: 'adsf3',
   label: 'Release Type',
   name: 'use-20',
-  type: 'Document'
+  type: 'Document',
 };
 
 const getComponent = ( data, props ) => (
@@ -35,6 +34,7 @@ const getComponent = ( data, props ) => (
 
 const suppressActWarning = consoleError => {
   const actMsg = 'Warning: An update to %s inside a test was not wrapped in act';
+
   jest.spyOn( console, 'error' ).mockImplementation( ( ...args ) => {
     if ( !args[0].includes( actMsg ) ) {
       consoleError( ...args );
@@ -43,12 +43,8 @@ const suppressActWarning = consoleError => {
 };
 
 describe( '<UseDropdown /> for video type', () => {
-  /**
-   * @todo Suppress React 16.8 `act()` warnings globally.
-   * The React team's fix won't be out of alpha until 16.9.0.
-   * @see https://github.com/facebook/react/issues/14769
-   */
   const consoleError = console.error;
+
   beforeAll( () => suppressActWarning( consoleError ) );
 
   afterAll( () => {
@@ -72,6 +68,7 @@ describe( '<UseDropdown /> for video type', () => {
 
   it( 'renders an error message if there is a GraphQL error', async () => {
     const wrapper = mount( ErrorComponent );
+
     await wait( 0 );
     wrapper.update();
     const dropdown = wrapper.find( 'UseDropdown' );
@@ -83,41 +80,47 @@ describe( '<UseDropdown /> for video type', () => {
 
   it( 'does not crash if enumValues is null', async () => {
     const wrapper = mount( NullComponent );
+
     await wait( 0 );
     wrapper.update();
     const formDropdown = wrapper.find( 'FormDropdown' );
-    const emptyOption = [{
-      key: '-',
-      text: '-',
-      value: null
-    }];
+    const emptyOption = [
+      {
+        key: '-',
+        text: '-',
+        value: null,
+      },
+    ];
 
     expect( formDropdown.prop( 'options' ) ).toEqual( emptyOption );
   } );
 
   it( 'does not crash if enumValues is []', async () => {
     const wrapper = mount( EmptyComponent );
+
     await wait( 0 );
     wrapper.update();
     const formDropdown = wrapper.find( 'FormDropdown' );
-    const emptyOption = [{
-      key: '-',
-      text: '-',
-      value: null
-    }];
+    const emptyOption = [
+      {
+        key: '-',
+        text: '-',
+        value: null,
+      },
+    ];
 
     expect( formDropdown.prop( 'options' ) ).toEqual( emptyOption );
   } );
 
   it( 'renders the final state without crashing', async () => {
     const wrapper = mount( Component );
+
     await wait( 0 );
     wrapper.update();
     const formDropdown = wrapper.find( 'FormDropdown' );
     const dropdownItems = wrapper.find( 'DropdownItem' );
     const { videoUses } = mocks[0].result.data;
-    const semanticUIValues = sortBy( videoUses, use => use.name )
-      .map( u => ( { key: u.id, text: u.name, value: u.id } ) );
+    const semanticUIValues = videoUses.map( u => ( { key: u.id, text: u.name, value: u.id } ) );
     const options = addEmptyOption( semanticUIValues );
 
     expect( formDropdown.prop( 'options' ) ).toEqual( options );
@@ -126,6 +129,7 @@ describe( '<UseDropdown /> for video type', () => {
 
   it( 'assigns a matching id & htmlFor value to the Dropdown and label, respectively', async () => {
     const wrapper = mount( Component );
+
     await wait( 0 );
     wrapper.update();
     const dropdown = wrapper.find( 'Dropdown [role="listbox"]' );
@@ -138,6 +142,7 @@ describe( '<UseDropdown /> for video type', () => {
 
 describe( '<UseDropdown /> for image type', () => {
   const consoleError = console.error;
+
   beforeAll( () => suppressActWarning( consoleError ) );
 
   afterAll( () => {
@@ -160,6 +165,7 @@ describe( '<UseDropdown /> for image type', () => {
 
   it( 'renders an error message if there is a GraphQL error', async () => {
     const wrapper = mount( ErrorComponent );
+
     await wait( 0 );
     wrapper.update();
     const dropdown = wrapper.find( 'UseDropdown' );
@@ -171,41 +177,47 @@ describe( '<UseDropdown /> for image type', () => {
 
   it( 'does not crash if imageUses is null', async () => {
     const wrapper = mount( NullComponent );
+
     await wait( 0 );
     wrapper.update();
     const formDropdown = wrapper.find( 'FormDropdown' );
-    const emptyOption = [{
-      key: '-',
-      text: '-',
-      value: null
-    }];
+    const emptyOption = [
+      {
+        key: '-',
+        text: '-',
+        value: null,
+      },
+    ];
 
     expect( formDropdown.prop( 'options' ) ).toEqual( emptyOption );
   } );
 
   it( 'does not crash if imageUses is []', async () => {
     const wrapper = mount( EmptyComponent );
+
     await wait( 0 );
     wrapper.update();
     const formDropdown = wrapper.find( 'FormDropdown' );
-    const emptyOption = [{
-      key: '-',
-      text: '-',
-      value: null
-    }];
+    const emptyOption = [
+      {
+        key: '-',
+        text: '-',
+        value: null,
+      },
+    ];
 
     expect( formDropdown.prop( 'options' ) ).toEqual( emptyOption );
   } );
 
   it( 'renders the final state without crashing', async () => {
     const wrapper = mount( Component );
+
     await wait( 0 );
     wrapper.update();
     const formDropdown = wrapper.find( 'FormDropdown' );
     const dropdownItems = wrapper.find( 'DropdownItem' );
     const { imageUses } = mocks[1].result.data;
-    const semanticUIValues = sortBy( imageUses, use => use.name )
-      .map( u => ( { key: u.id, text: u.name, value: u.id } ) );
+    const semanticUIValues = imageUses.map( u => ( { key: u.id, text: u.name, value: u.id } ) );
     const options = addEmptyOption( semanticUIValues );
 
     expect( formDropdown.prop( 'options' ) ).toEqual( options );
@@ -214,6 +226,7 @@ describe( '<UseDropdown /> for image type', () => {
 
   it( 'assigns a matching id & htmlFor value to the Dropdown and label, respectively', async () => {
     const wrapper = mount( Component );
+
     await wait( 0 );
     wrapper.update();
     const dropdown = wrapper.find( 'Dropdown [role="listbox"]' );
@@ -226,6 +239,7 @@ describe( '<UseDropdown /> for image type', () => {
 
 describe( '<UseDropdown /> for document type', () => {
   const consoleError = console.error;
+
   beforeAll( () => suppressActWarning( consoleError ) );
 
   afterAll( () => {
@@ -248,6 +262,7 @@ describe( '<UseDropdown /> for document type', () => {
 
   it( 'renders an error message if there is a GraphQL error', async () => {
     const wrapper = mount( ErrorComponent );
+
     await wait( 0 );
     wrapper.update();
     const dropdown = wrapper.find( 'UseDropdown' );
@@ -259,41 +274,47 @@ describe( '<UseDropdown /> for document type', () => {
 
   it( 'does not crash if documentUses is null', async () => {
     const wrapper = mount( NullComponent );
+
     await wait( 0 );
     wrapper.update();
     const formDropdown = wrapper.find( 'FormDropdown' );
-    const emptyOption = [{
-      key: '-',
-      text: '-',
-      value: null
-    }];
+    const emptyOption = [
+      {
+        key: '-',
+        text: '-',
+        value: null,
+      },
+    ];
 
     expect( formDropdown.prop( 'options' ) ).toEqual( emptyOption );
   } );
 
   it( 'does not crash if documentUses is []', async () => {
     const wrapper = mount( EmptyComponent );
+
     await wait( 0 );
     wrapper.update();
     const formDropdown = wrapper.find( 'FormDropdown' );
-    const emptyOption = [{
-      key: '-',
-      text: '-',
-      value: null
-    }];
+    const emptyOption = [
+      {
+        key: '-',
+        text: '-',
+        value: null,
+      },
+    ];
 
     expect( formDropdown.prop( 'options' ) ).toEqual( emptyOption );
   } );
 
   it( 'renders the final state without crashing', async () => {
     const wrapper = mount( Component );
+
     await wait( 0 );
     wrapper.update();
     const formDropdown = wrapper.find( 'FormDropdown' );
     const dropdownItems = wrapper.find( 'DropdownItem' );
     const { documentUses } = mocks[2].result.data;
-    const semanticUIValues = sortBy( documentUses, use => use.name )
-      .map( u => ( { key: u.id, text: u.name, value: u.id } ) );
+    const semanticUIValues = documentUses.map( u => ( { key: u.id, text: u.name, value: u.id } ) );
     const options = addEmptyOption( semanticUIValues );
 
     expect( formDropdown.prop( 'options' ) ).toEqual( options );
@@ -302,6 +323,7 @@ describe( '<UseDropdown /> for document type', () => {
 
   it( 'assigns a matching id & htmlFor value to the Dropdown and label, respectively', async () => {
     const wrapper = mount( Component );
+
     await wait( 0 );
     wrapper.update();
     const dropdown = wrapper.find( 'Dropdown [role="listbox"]' );

--- a/components/admin/dropdowns/UseDropdown/UseDropdown.test.js
+++ b/components/admin/dropdowns/UseDropdown/UseDropdown.test.js
@@ -1,7 +1,7 @@
 import { mount } from 'enzyme';
 import wait from 'waait';
 import { MockedProvider } from '@apollo/react-testing';
-import { addEmptyOption } from 'lib/utils';
+import { addEmptyOption, suppressActWarning } from 'lib/utils';
 import UseDropdown from './UseDropdown';
 import {
   emptyMocks, errorMocks, mocks, nullMocks,
@@ -31,16 +31,6 @@ const getComponent = ( data, props ) => (
     <UseDropdown { ...props } />
   </MockedProvider>
 );
-
-const suppressActWarning = consoleError => {
-  const actMsg = 'Warning: An update to %s inside a test was not wrapped in act';
-
-  jest.spyOn( console, 'error' ).mockImplementation( ( ...args ) => {
-    if ( !args[0].includes( actMsg ) ) {
-      consoleError( ...args );
-    }
-  } );
-};
 
 describe( '<UseDropdown /> for video type', () => {
   const consoleError = console.error;

--- a/components/admin/dropdowns/UseDropdown/mocks.js
+++ b/components/admin/dropdowns/UseDropdown/mocks.js
@@ -3,202 +3,206 @@ import { VIDEO_USE_QUERY, IMAGE_USE_QUERY, DOCUMENT_USE_QUERY } from './UseDropd
 export const mocks = [
   {
     request: {
-      query: VIDEO_USE_QUERY
+      query: VIDEO_USE_QUERY,
     },
     result: {
       data: {
         videoUses: [
           {
+            id: 'ckcm6aii005dv0720fapgz92p',
+            name: 'Clean',
+          },
+          {
             id: 'cjsw78q6p00lp07566znbyatd',
-            name: 'Full Video'
-          },
-          {
-            id: 'cjubbldgd0uq3075628v0917u',
-            name: 'Video Assets (B-Roll)'
-          },
-          {
-            id: 'cjubbldgj0uq50756f9el8l5j',
-            name: 'Event Video'
+            name: 'Full Video',
           },
           {
             id: 'cjubbldgj0uq60756vtilh8w1',
-            name: 'Promotional Teaser'
-          }
-        ]
-      }
-    }
+            name: 'Promotional Teaser',
+          },
+          {
+            id: 'cjubbldgd0uq3075628v0917u',
+            name: 'Video Assets (B-Roll)',
+          },
+          {
+            id: 'cjubbldgj0uq50756f9el8l5j',
+            name: 'Web Chat',
+          },
+        ],
+      },
+    },
   },
   {
     request: {
-      query: IMAGE_USE_QUERY
+      query: IMAGE_USE_QUERY,
     },
     result: {
       data: {
         imageUses: [
           {
-            id: 'cjtkdq8kr0knf07569goo9eqe',
-            name: 'Thumbnail/Cover Image'
-          },
-          {
-            id: 'cjtkdqqjs0knk07565mgduq36',
-            name: 'Social Media Graphic'
+            id: 'cjubbldfo0upx0756pldnc0k0',
+            name: '3D Graphics',
           },
           {
             id: 'cjtkdr7j40knp0756ppap6gqm',
-            name: 'Email Graphic'
-          },
-          {
-            id: 'cjtkdrndt0knu0756gha65mhd',
-            name: 'Website Hero Image'
+            name: 'Email Graphic',
           },
           {
             id: 'cjubblddu0upq0756ioyonu50',
-            name: 'Infographic'
+            name: 'Infographic',
           },
           {
             id: 'cjubbldfl0upu0756imis0hxp',
-            name: 'Memes'
+            name: 'Memes',
           },
           {
-            id: 'cjubbldfo0upx0756pldnc0k0',
-            name: '3D Graphics'
-          }
-        ]
-      }
-    }
+            id: 'cjtkdqqjs0knk07565mgduq36',
+            name: 'Social Media Graphic',
+          },
+          {
+            id: 'cjtkdq8kr0knf07569goo9eqe',
+            name: 'Thumbnail/Cover Image',
+          },
+          {
+            id: 'cjtkdrndt0knu0756gha65mhd',
+            name: 'Website Hero Image',
+          },
+        ],
+      },
+    },
   },
   {
     request: {
-      query: DOCUMENT_USE_QUERY
+      query: DOCUMENT_USE_QUERY,
     },
     result: {
       data: {
         documentUses: [
           {
             id: 'ck2wbvj5h10kq0720hr0nkfgz',
-            name: 'Background Briefing'
+            name: 'Background Briefing',
           },
           {
             id: 'ck2wbvj6010kz0720c358mbrt',
-            name: 'Department Press Briefing'
+            name: 'Department Press Briefing',
           },
           {
             id: 'ck2wbvj6w10l80720gzhwlr9s',
-            name: 'Fact Sheet'
+            name: 'Fact Sheet',
           },
           {
             id: 'ck2wbvj7b10lg0720htdvmgru',
-            name: 'Interview'
+            name: 'Interview',
           },
           {
             id: 'ck2wbvj7u10lo07207aa55qmz',
-            name: 'Media Note'
+            name: 'Media Note',
           },
           {
             id: 'ck2wbvj8810lx0720ruj5eylz',
-            name: 'Notice to the Press'
+            name: 'Notice to the Press',
           },
           {
             id: 'ck2wbvj8n10m50720eu2ob3pq',
-            name: 'On-the-record Briefing'
+            name: 'On-the-record Briefing',
           },
           {
             id: 'ck2wbvj8y10md0720vsuqxq87',
-            name: 'Press Guidance'
-          },
-          {
-            id: 'ck2wbvj9b10ml0720245vk3uy',
-            name: 'Remarks'
-          },
-          {
-            id: 'ck2wbvj9v10mt0720hwq7013q',
-            name: 'Speeches'
-          },
-          {
-            id: 'ck2wbvjaa10n20720fg5ayhn9',
-            name: 'Statement'
-          },
-          {
-            id: 'ck2wbvjao10na0720ncwefnm6',
-            name: 'Taken Questions'
-          },
-          {
-            id: 'ck2wbvjb210nj07205m16k3xx',
-            name: 'Travel Alert'
+            name: 'Press Guidance',
           },
           {
             id: 'ck2wbvjbf10nr0720o6zpopyt',
-            name: 'Readout'
+            name: 'Readout',
+          },
+          {
+            id: 'ck2wbvj9b10ml0720245vk3uy',
+            name: 'Remarks',
+          },
+          {
+            id: 'ck2wbvj9v10mt0720hwq7013q',
+            name: 'Speeches',
+          },
+          {
+            id: 'ck2wbvjaa10n20720fg5ayhn9',
+            name: 'Statement',
+          },
+          {
+            id: 'ck2wbvjao10na0720ncwefnm6',
+            name: 'Taken Questions',
+          },
+          {
+            id: 'ck2wbvjb210nj07205m16k3xx',
+            name: 'Travel Alert',
           },
           {
             id: 'ck2wbvjbu10nz072060p67wk5',
-            name: 'Travel Warning'
-          }
-        ]
-      }
-    }
-  }
+            name: 'Travel Warning',
+          },
+        ],
+      },
+    },
+  },
 ];
 
 export const errorMocks = [
   {
     ...mocks[0],
     result: {
-      errors: [{ message: 'There was an error.' }]
-    }
+      errors: [{ message: 'There was an error.' }],
+    },
   },
   {
     ...mocks[1],
     result: {
-      errors: [{ message: 'There was an error.' }]
-    }
+      errors: [{ message: 'There was an error.' }],
+    },
   },
   {
     ...mocks[2],
     result: {
-      errors: [{ message: 'There was an error.' }]
-    }
-  }
+      errors: [{ message: 'There was an error.' }],
+    },
+  },
 ];
 
 export const nullMocks = [
   {
     ...mocks[0],
     result: {
-      data: { videoUses: null }
-    }
+      data: { videoUses: null },
+    },
   },
   {
     ...mocks[1],
     result: {
-      data: { imageUses: null }
-    }
+      data: { imageUses: null },
+    },
   },
   {
     ...mocks[2],
     result: {
-      data: { documentUses: null }
-    }
-  }
+      data: { documentUses: null },
+    },
+  },
 ];
 
 export const emptyMocks = [
   {
     ...mocks[0],
     result: {
-      data: { videoUses: [] }
-    }
+      data: { videoUses: [] },
+    },
   },
   {
     ...mocks[1],
     result: {
-      data: { imageUses: [] }
-    }
+      data: { imageUses: [] },
+    },
   },
   {
     ...mocks[2],
     result: {
-      data: { documentUses: [] }
-    }
-  }
+      data: { documentUses: [] },
+    },
+  },
 ];

--- a/components/admin/dropdowns/UserDropdown/UserDropdown.test.js
+++ b/components/admin/dropdowns/UserDropdown/UserDropdown.test.js
@@ -4,15 +4,17 @@ import { MockedProvider } from '@apollo/react-testing';
 import sortBy from 'lodash/sortBy';
 import UserDropdown, { USERS_QUERY } from './UserDropdown';
 
+import { suppressActWarning } from 'lib/utils';
+
 const props = {
   id: 'abc123',
-  label: 'Users'
+  label: 'Users',
 };
 
 const mocks = [
   {
     request: {
-      query: USERS_QUERY
+      query: USERS_QUERY,
     },
     result: {
       data: {
@@ -25,8 +27,8 @@ const mocks = [
             permissions: ['TEAM_ADMIN'],
             team: {
               id: 'cjrkzhvku000f0756l44blw33',
-              name: 'GPA Video Production'
-            }
+              name: 'GPA Video Production',
+            },
           },
           {
             id: 'cjsbxb5ur00t40756z7bzf706',
@@ -36,40 +38,40 @@ const mocks = [
             permissions: ['EDITOR'],
             team: {
               id: 'cjrkzhvku000f0756l44blw33',
-              name: 'GPA Video Production'
-            }
-          }
-        ]
-      }
-    }
-  }
+              name: 'GPA Video Production',
+            },
+          },
+        ],
+      },
+    },
+  },
 ];
 
 const errorMocks = [
   {
     ...mocks[0],
     result: {
-      errors: [{ message: 'There was an error.' }]
-    }
-  }
+      errors: [{ message: 'There was an error.' }],
+    },
+  },
 ];
 
 const nullMocks = [
   {
     ...mocks[0],
     result: {
-      data: { users: null }
-    }
-  }
+      data: { users: null },
+    },
+  },
 ];
 
 const emptyMocks = [
   {
     ...mocks[0],
     result: {
-      data: { users: [] }
-    }
-  }
+      data: { users: [] },
+    },
+  },
 ];
 
 const Component = (
@@ -95,16 +97,6 @@ const EmptyComponent = (
     <UserDropdown { ...props } />
   </MockedProvider>
 );
-
-const suppressActWarning = consoleError => {
-  const actMsg = 'Warning: An update to %s inside a test was not wrapped in act';
-
-  jest.spyOn( console, 'error' ).mockImplementation( ( ...args ) => {
-    if ( !args[0].includes( actMsg ) ) {
-      consoleError( ...args );
-    }
-  } );
-};
 
 describe( '<UserDropdown />', () => {
   const consoleError = console.error;
@@ -167,7 +159,7 @@ describe( '<UserDropdown />', () => {
     const semanticUIUsers = sortedUsers.map( user => ( {
       key: user.id,
       text: `${user.lastName}, ${user.firstName}`,
-      value: user.id
+      value: user.id,
     } ) );
 
     expect( formDropdown.prop( 'options' ) ).toEqual( semanticUIUsers );

--- a/components/admin/dropdowns/VideoBurnedInStatusDropdown/VideoBurnedInStatusDropdown.js
+++ b/components/admin/dropdowns/VideoBurnedInStatusDropdown/VideoBurnedInStatusDropdown.js
@@ -16,7 +16,9 @@ const VIDEO_BURNED_IN_STATUS_QUERY = gql`
   }
 `;
 
-const areEqual = ( prevProps, nextProps ) => prevProps.value === nextProps.value;
+const areEqual = ( prevProps, nextProps ) => (
+  prevProps.value === nextProps.value && prevProps.disabled === nextProps.disabled
+);
 
 const VideoBurnedInStatusDropdown = ( { id, label, ...rest } ) => {
   const { data, loading, error } = useQuery( VIDEO_BURNED_IN_STATUS_QUERY );

--- a/components/admin/dropdowns/VideoBurnedInStatusDropdown/VideoBurnedInStatusDropdown.test.js
+++ b/components/admin/dropdowns/VideoBurnedInStatusDropdown/VideoBurnedInStatusDropdown.test.js
@@ -1,18 +1,18 @@
 import { mount } from 'enzyme';
 import wait from 'waait';
 import { MockedProvider } from '@apollo/react-testing';
-import { addEmptyOption, titleCase } from 'lib/utils';
+import { addEmptyOption } from 'lib/utils';
 import VideoBurnedInStatusDropdown, { VIDEO_BURNED_IN_STATUS_QUERY } from './VideoBurnedInStatusDropdown';
 
 const props = {
   id: 's123',
-  label: 'Subtitles'
+  label: 'Subtitles',
 };
 
 const mocks = [
   {
     request: {
-      query: VIDEO_BURNED_IN_STATUS_QUERY
+      query: VIDEO_BURNED_IN_STATUS_QUERY,
     },
     result: {
       data: {
@@ -20,21 +20,21 @@ const mocks = [
           enumValues: [
             { name: 'SUBTITLED' },
             { name: 'CAPTIONED' },
-            { name: 'CLEAN' }
-          ]
-        }
-      }
-    }
-  }
+            { name: 'CLEAN' },
+          ],
+        },
+      },
+    },
+  },
 ];
 
 const errorMocks = [
   {
     ...mocks[0],
     result: {
-      errors: [{ message: 'There was an error.' }]
-    }
-  }
+      errors: [{ message: 'There was an error.' }],
+    },
+  },
 ];
 
 const nullMocks = [
@@ -42,10 +42,10 @@ const nullMocks = [
     ...mocks[0],
     result: {
       data: {
-        __type: { enumValues: null }
-      }
-    }
-  }
+        __type: { enumValues: null },
+      },
+    },
+  },
 ];
 
 const emptyMocks = [
@@ -53,10 +53,10 @@ const emptyMocks = [
     ...mocks[0],
     result: {
       data: {
-        __type: { enumValues: [] }
-      }
-    }
-  }
+        __type: { enumValues: [] },
+      },
+    },
+  },
 ];
 
 const Component = (
@@ -132,8 +132,8 @@ describe( '<VideoBurnedInStatusDropdown />', () => {
       {
         key: '-',
         text: '-',
-        value: null
-      }
+        value: null,
+      },
     ];
 
     expect( formDropdown.prop( 'options' ) ).toEqual( emptyOption );
@@ -149,8 +149,8 @@ describe( '<VideoBurnedInStatusDropdown />', () => {
       {
         key: '-',
         text: '-',
-        value: null
-      }
+        value: null,
+      },
     ];
 
     expect( formDropdown.prop( 'options' ) ).toEqual( emptyOption );
@@ -165,17 +165,11 @@ describe( '<VideoBurnedInStatusDropdown />', () => {
     const dropdownItems = wrapper.find( 'DropdownItem' );
     const { enumValues } = mocks[0].result.data.__type;
     const semanticUIValues = enumValues.filter( enumValue => enumValue.name !== 'CAPTIONED' )
-      .map( enumValue => {
-        let text = titleCase( enumValue.name );
-
-        text = ( text === 'Clean' ) ? `${text} - No captions` : text;
-
-        return {
-          key: enumValue.name,
-          text,
-          value: enumValue.name
-        };
-      } );
+      .map( ( { name } ) => ( {
+        key: name,
+        text: name === 'SUBTITLED' ? 'Yes' : 'No',
+        value: name,
+      } ) );
 
     expect( formDropdown.prop( 'options' ) )
       .toEqual( addEmptyOption( semanticUIValues ) );

--- a/components/admin/dropdowns/VideoBurnedInStatusDropdown/VideoBurnedInStatusDropdown.test.js
+++ b/components/admin/dropdowns/VideoBurnedInStatusDropdown/VideoBurnedInStatusDropdown.test.js
@@ -1,7 +1,7 @@
 import { mount } from 'enzyme';
 import wait from 'waait';
 import { MockedProvider } from '@apollo/react-testing';
-import { addEmptyOption } from 'lib/utils';
+import { addEmptyOption, suppressActWarning } from 'lib/utils';
 import VideoBurnedInStatusDropdown, { VIDEO_BURNED_IN_STATUS_QUERY } from './VideoBurnedInStatusDropdown';
 
 const props = {
@@ -82,16 +82,6 @@ const EmptyComponent = (
     <VideoBurnedInStatusDropdown { ...props } />
   </MockedProvider>
 );
-
-const suppressActWarning = consoleError => {
-  const actMsg = 'Warning: An update to %s inside a test was not wrapped in act';
-
-  jest.spyOn( console, 'error' ).mockImplementation( ( ...args ) => {
-    if ( !args[0].includes( actMsg ) ) {
-      consoleError( ...args );
-    }
-  } );
-};
 
 describe( '<VideoBurnedInStatusDropdown />', () => {
   const consoleError = console.error;

--- a/components/admin/dropdowns/VisibilityDropdown/VisibilityDropdown.test.js
+++ b/components/admin/dropdowns/VisibilityDropdown/VisibilityDropdown.test.js
@@ -3,6 +3,8 @@ import wait from 'waait';
 import { MockedProvider } from '@apollo/react-testing';
 import VisibilityDropdown, { VISIBILITY_QUERY } from './VisibilityDropdown';
 
+import { suppressActWarning } from 'lib/utils';
+
 const props = {
   id: 'v123',
   label: 'Visibility Setting',
@@ -80,16 +82,6 @@ const EmptyComponent = (
     <VisibilityDropdown { ...props } />
   </MockedProvider>
 );
-
-const suppressActWarning = consoleError => {
-  const actMsg = 'Warning: An update to %s inside a test was not wrapped in act';
-
-  jest.spyOn( console, 'error' ).mockImplementation( ( ...args ) => {
-    if ( !args[0].includes( actMsg ) ) {
-      consoleError( ...args );
-    }
-  } );
-};
 
 describe( '<VisibilityDropdown />', () => {
   const consoleError = console.error;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -604,3 +604,17 @@ export const getPreviewNotificationStyles = () => ( {
 export const parseHtml = htmlParser( {
   isValidNode: node => node.type !== 'script',
 } );
+
+/**
+ * Suppresses React's act warning in unit tests
+ * @param {*} consoleError
+ */
+export const suppressActWarning = consoleError => {
+  const actMsg = 'Warning: An update to %s inside a test was not wrapped in act';
+
+  jest.spyOn( console, 'error' ).mockImplementation( ( ...args ) => {
+    if ( !args[0].includes( actMsg ) ) {
+      consoleError( ...args );
+    }
+  } );
+};


### PR DESCRIPTION
## CDP-2143
* Changes the label on the video upload 2-step modal to "On-Screen Text" from "Subtitles"
* Changes the `VideoBurnedInStatusDropdown` text values to "Yes" and "No" from "Subtitled" and "Clean - no captions", respectively
* Update `VideoBurnedInStatusDropdown` label in `FileDataForm`
* Update display of "On-Screen Text` label on video review page
* Update relevant tests

## CDP-2155
* Disables Language dropdown and sets value to "English" if a video is marked as "Clean"
* Disables On-Screen Text dropdown and sets value to "No" if a video is marked as "Clean"
* Adds tests for `FileDataForm`
* Moves `suppressActWarning` testing function to `lib/utils` and updates relevant test files