### PR TITLE
CDP-2159 - Unpublishing from Dashboard not working

### DIFF
--- a/components/ScrollableTableWithMenu/ScrollableTableWithMenu.js
+++ b/components/ScrollableTableWithMenu/ScrollableTableWithMenu.js
@@ -6,7 +6,6 @@
 import React, { useContext, useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import debounce from 'lodash/debounce';
-import gql from 'graphql-tag';
 import { Table, Grid } from 'semantic-ui-react';
 import { useQuery } from '@apollo/react-hooks';
 
@@ -36,16 +35,14 @@ const ScrollableTableWithMenu = ( { columnMenu, persistentTableHeaders, projectT
   const _breakpoint = 767;
 
   const { dispatch, state } = useContext( DashboardContext );
+
   const projectType = state?.projectType || '';
   const column = state?.column || 'createdAt';
   const direction = state?.direction || 'descending';
 
-  // No-op query is never called, but added to avoid reference error in cases where context has not yet loaded
-  const noopQuery = gql`query{ NOOP { noop } }`;
-
   // Get the content data
-  const contentQuery = state?.queries?.content || noopQuery;
-  const countQuery = state?.queries?.count || noopQuery;
+  const contentQuery = state.queries.content;
+  const countQuery = state.queries.count;
 
   // Set GraphQL query variables
   const variables = { team: team.name, searchTerm };

--- a/components/ScrollableTableWithMenu/TableActionsMenu/UnpublishProjects/UnpublishProjects.js
+++ b/components/ScrollableTableWithMenu/TableActionsMenu/UnpublishProjects/UnpublishProjects.js
@@ -16,12 +16,12 @@ const UnpublishProjects = ( {
   const [bulkUnpublish] = useMutation( state.queries.unpublish );
   const [bulkStatusUpdate] = useMutation( state.queries.status );
 
-  // 1 - Using new 'metaContent' query - only fetches id, publishedAt & status fields for graphic content query
-  // prior query for all graphic content causes a network strain, browser has to download all img files again which are not needed here
-  // 2 - Not using stopPolling, calling stopPolling doesn not allow bulk unpublishing to finish
-  const isGraphicType = state.team.contentTypes.includes( 'GRAPHIC' );
+  // 1 - Using new 'metaContent' query - only fetches id, publishedAt & status fields
+  // - prior query for all content causes a network strain, browser has to download all content type files again which are not needed here
+  // - Ensures that ScrollableTableWithMenu re-renders
+  // 2 - Not using stopPolling, calling stopPolling does not allow bulk unpublishing to finish
   const { data, startPolling, stopPolling } = useQuery(
-    isGraphicType ? state.queries.metaContent : state.queries.content,
+    state.queries.metaContent,
     { variables: { ...variables } },
   );
 

--- a/components/admin/Dashboard/TeamProjects/TeamProjects.js
+++ b/components/admin/Dashboard/TeamProjects/TeamProjects.js
@@ -10,6 +10,8 @@ import dynamic from 'next/dynamic';
 import { useAuth } from 'context/authContext';
 import { DashboardContext, dashboardReducer } from 'context/dashboardContext';
 
+import { setQueries } from '../utils';
+
 const ScrollableTableWithMenu = dynamic( () => import( /* webpackChunkName: "ScrollableTableWithMenu" */ 'components/ScrollableTableWithMenu/ScrollableTableWithMenu' ) );
 
 const persistentTableHeaders = [
@@ -29,7 +31,10 @@ const TeamProjects = () => {
   const { user } = useAuth();
   const team = user?.team;
 
-  const [state, dispatch] = useReducer( dashboardReducer );
+  const [state, dispatch] = useReducer( dashboardReducer, {
+    team: { ...team },
+    queries: setQueries( team ),
+  } );
 
   useEffect( () => {
     dispatch( { type: 'UPDATE_TEAM', payload: { team } } );

--- a/components/admin/Dashboard/utils.js
+++ b/components/admin/Dashboard/utils.js
@@ -1,0 +1,86 @@
+import { getProjectsType } from 'lib/graphql/util';
+import {
+  DELETE_GRAPHIC_PROJECT_MUTATION,
+  TEAM_GRAPHIC_PROJECTS_QUERY,
+  TEAM_GRAPHIC_PROJECTS_COUNT_QUERY,
+  GRAPHIC_PROJECT_IMAGE_FILES_QUERY,
+  UNPUBLISH_GRAPHIC_PROJECT_MUTATION,
+  UPDATE_GRAPHIC_STATUS_MUTATION,
+  GRAPHIC_PROJECTS_META_QUERY,
+} from 'lib/graphql/queries/graphic';
+import {
+  DELETE_PACKAGE_MUTATION,
+  PACKAGE_FILES_QUERY,
+  TEAM_PACKAGES_COUNT_QUERY,
+  TEAM_PACKAGES_QUERY,
+  UNPUBLISH_PACKAGE_MUTATION,
+  UPDATE_PACKAGE_STATUS_MUTATION,
+  PACKAGES_META_QUERY,
+} from 'lib/graphql/queries/package';
+import {
+  DELETE_VIDEO_PROJECT_MUTATION,
+  TEAM_VIDEO_PROJECTS_COUNT_QUERY,
+  TEAM_VIDEO_PROJECTS_QUERY,
+  UNPUBLISH_VIDEO_PROJECT_MUTATION,
+  UPDATE_VIDEO_STATUS_MUTATION,
+  VIDEO_PROJECT_FILES_QUERY,
+  VIDEO_PROJECTS_META_QUERY,
+} from 'lib/graphql/queries/video';
+
+/**
+ * Returns the project type based off of the content type available to a team
+ *
+ * @param {Object} team team data received from GraphQL
+ */
+export const getContentTypesFromTeam = team => {
+  const contentTypes = team?.contentTypes ? team.contentTypes : '';
+
+  const type = getProjectsType( contentTypes );
+
+  return type || null;
+};
+
+/**
+ * Returns the expected queries depending on what content types a team has access to
+ *
+ * @param {Object} team team data received from GraphQL
+ * @returns {Object} list of relevant queries
+ */
+export const setQueries = team => {
+  const queries = {};
+
+  switch ( getContentTypesFromTeam( team ) ) {
+    case 'graphicProjects':
+      queries.content = TEAM_GRAPHIC_PROJECTS_QUERY;
+      queries.count = TEAM_GRAPHIC_PROJECTS_COUNT_QUERY;
+      queries.files = GRAPHIC_PROJECT_IMAGE_FILES_QUERY;
+      queries.metaContent = GRAPHIC_PROJECTS_META_QUERY;
+      queries.remove = DELETE_GRAPHIC_PROJECT_MUTATION;
+      queries.status = UPDATE_GRAPHIC_STATUS_MUTATION;
+      queries.unpublish = UNPUBLISH_GRAPHIC_PROJECT_MUTATION;
+
+      return queries;
+    case 'videoProjects':
+      queries.content = TEAM_VIDEO_PROJECTS_QUERY;
+      queries.count = TEAM_VIDEO_PROJECTS_COUNT_QUERY;
+      queries.files = VIDEO_PROJECT_FILES_QUERY;
+      queries.metaContent = VIDEO_PROJECTS_META_QUERY;
+      queries.remove = DELETE_VIDEO_PROJECT_MUTATION;
+      queries.status = UPDATE_VIDEO_STATUS_MUTATION;
+      queries.unpublish = UNPUBLISH_VIDEO_PROJECT_MUTATION;
+
+      return queries;
+    case 'packages':
+      queries.content = TEAM_PACKAGES_QUERY;
+      queries.count = TEAM_PACKAGES_COUNT_QUERY;
+      queries.files = PACKAGE_FILES_QUERY;
+      queries.metaContent = PACKAGES_META_QUERY;
+      queries.remove = DELETE_PACKAGE_MUTATION;
+      queries.status = UPDATE_PACKAGE_STATUS_MUTATION;
+      queries.unpublish = UNPUBLISH_PACKAGE_MUTATION;
+
+      return queries;
+    default:
+      return queries;
+  }
+};

--- a/context/dashboardContext.js
+++ b/context/dashboardContext.js
@@ -1,68 +1,6 @@
 import React from 'react';
-
-import { getProjectsType, normalizeDashboardData } from 'lib/graphql/util';
-import {
-  DELETE_GRAPHIC_PROJECT_MUTATION,
-  TEAM_GRAPHIC_PROJECTS_QUERY,
-  TEAM_GRAPHIC_PROJECTS_COUNT_QUERY,
-  GRAPHIC_PROJECT_IMAGE_FILES_QUERY,
-  UNPUBLISH_GRAPHIC_PROJECT_MUTATION,
-  UPDATE_GRAPHIC_STATUS_MUTATION,
-  GRAPHIC_PROJECTS_META_QUERY,
-} from 'lib/graphql/queries/graphic';
-import {
-  DELETE_PACKAGE_MUTATION,
-  PACKAGE_FILES_QUERY,
-  TEAM_PACKAGES_COUNT_QUERY,
-  TEAM_PACKAGES_QUERY,
-  UNPUBLISH_PACKAGE_MUTATION,
-  UPDATE_PACKAGE_STATUS_MUTATION,
-} from 'lib/graphql/queries/package';
-import {
-  DELETE_VIDEO_PROJECT_MUTATION,
-  TEAM_VIDEO_PROJECTS_COUNT_QUERY,
-  TEAM_VIDEO_PROJECTS_QUERY,
-  UNPUBLISH_VIDEO_PROJECT_MUTATION,
-  UPDATE_VIDEO_STATUS_MUTATION,
-  VIDEO_PROJECT_FILES_QUERY,
-} from 'lib/graphql/queries/video';
-
-// Sets default values before any GraphQL query is executed
-const initialState = {
-  column: 'createdAt',
-  content: {},
-  count: {},
-  direction: 'descending',
-  files: {},
-  queries: {
-    content: null,
-    count: null,
-    files: null,
-    remove: null,
-    status: null,
-    unpublish: null,
-  },
-  selected: {
-    displayActionsMenu: false,
-    selectedItems: new Map(),
-  },
-  team: { contentTypes: null },
-};
-
-export const DashboardContext = React.createContext( initialState );
-
-/**
- * Returns the project type based off of the content type available to a team
- *
- * @param {Object} team team data received from GraphQL
- */
-const getContentTypesFromTeam = team => {
-  const contentTypes = team?.contentTypes ? team.contentTypes : '';
-
-  const type = getProjectsType( contentTypes );
-
-  return type || null;
-};
+import { normalizeDashboardData } from 'lib/graphql/util';
+import { getContentTypesFromTeam, setQueries } from 'components/admin/Dashboard/utils';
 
 /**
  * Checks whether there are and projects of a given type and returns their count
@@ -120,49 +58,6 @@ const toggleAllItemsSelection = selected => {
     displayActionsMenu: !hasSelected,
     selectedItems: newSelectedItems,
   };
-};
-
-/**
- * Returns the expected queries depending on what content types a team has access to
- *
- * @param {Object} team team data received from GraphQL
- * @returns {Object} list of relevant queries
- */
-export const setQueries = team => {
-  const queries = {};
-
-  switch ( getContentTypesFromTeam( team ) ) {
-    case 'graphicProjects':
-      queries.content = TEAM_GRAPHIC_PROJECTS_QUERY;
-      queries.count = TEAM_GRAPHIC_PROJECTS_COUNT_QUERY;
-      queries.files = GRAPHIC_PROJECT_IMAGE_FILES_QUERY;
-      queries.metaContent = GRAPHIC_PROJECTS_META_QUERY;
-      queries.remove = DELETE_GRAPHIC_PROJECT_MUTATION;
-      queries.status = UPDATE_GRAPHIC_STATUS_MUTATION;
-      queries.unpublish = UNPUBLISH_GRAPHIC_PROJECT_MUTATION;
-
-      return queries;
-    case 'videoProjects':
-      queries.content = TEAM_VIDEO_PROJECTS_QUERY;
-      queries.count = TEAM_VIDEO_PROJECTS_COUNT_QUERY;
-      queries.files = VIDEO_PROJECT_FILES_QUERY;
-      queries.remove = DELETE_VIDEO_PROJECT_MUTATION;
-      queries.status = UPDATE_VIDEO_STATUS_MUTATION;
-      queries.unpublish = UNPUBLISH_VIDEO_PROJECT_MUTATION;
-
-      return queries;
-    case 'packages':
-      queries.content = TEAM_PACKAGES_QUERY;
-      queries.count = TEAM_PACKAGES_COUNT_QUERY;
-      queries.files = PACKAGE_FILES_QUERY;
-      queries.remove = DELETE_PACKAGE_MUTATION;
-      queries.status = UPDATE_PACKAGE_STATUS_MUTATION;
-      queries.unpublish = UNPUBLISH_PACKAGE_MUTATION;
-
-      return queries;
-    default:
-      return queries;
-  }
 };
 
 export const dashboardReducer = ( state, action ) => {
@@ -233,3 +128,5 @@ export const dashboardReducer = ( state, action ) => {
       return { ...state };
   }
 };
+
+export const DashboardContext = React.createContext();

--- a/lib/graphql/queries/package.js
+++ b/lib/graphql/queries/package.js
@@ -216,6 +216,16 @@ export const TEAM_PACKAGES_QUERY = gql`
   ${PACKAGE_DETAILS_FRAGMENT}
 `;
 
+export const PACKAGES_META_QUERY = gql`
+  query PackagesMeta {
+    packages {
+      id
+      publishedAt
+      status
+    }
+  }
+`;
+
 export const TEAM_PACKAGES_COUNT_QUERY = gql`
   query PackagesCountByTeam( $team: String!, $searchTerm: String ) {
     packages(

--- a/lib/graphql/queries/video.js
+++ b/lib/graphql/queries/video.js
@@ -4,7 +4,7 @@ import {
   LANGUAGE_DETAILS_FRAGMENT,
   TAG_DETAILS_FRAGMENT,
   CATEGORY_DETAILS_FRAGMENT,
-  SUPPORT_FILE_DETAILS_FRAGMENT
+  SUPPORT_FILE_DETAILS_FRAGMENT,
 } from './common';
 
 /*----------------------------------------
@@ -444,6 +444,16 @@ export const TEAM_VIDEO_PROJECTS_COUNT_QUERY = gql`
       }
     ) {
       id
+    }
+  }
+`;
+
+export const VIDEO_PROJECTS_META_QUERY = gql`
+  query VideoProjectsMeta {
+    videoProjects {
+      id
+      publishedAt
+      status
     }
   }
 `;


### PR DESCRIPTION
- updated UnpublishProjects to use new metaContent query for all types 
   - this ensures ScrollableTableWithMenu is re-rendered
   - lowers network strain by reducing data requested

- refactored ScrollableTableWithMenu so NOOP query no longer needed
   - initialState not needed in dashboardContext
   - set initial state for dashboardReducer in TeamProjects, setting team and queries which is passed 
      onto DashboardContext provider 
