### PR TITLE
CDP-2163: Delete button should be disabled for published graphic projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,8 @@ _This sections lists changes committed since most recent release_
 
 **Changed:**
 - Package 'Browse All' link sorts packages by created date
-- Lists of Documentw within a Package are displayed in the order of releases, guidances, transcripts 
+- Lists of Documents within a Package are displayed in the order of releases, guidances, transcripts
+- Delete button is disabled for published graphic projects
 
 
 # [5.0.0](https://github.com/IIP-Design/content-commons-client/compare/v4.2.0...5.0.0)(2020-07-10)

--- a/components/admin/ProjectEdit/GraphicEdit/GraphicEdit.js
+++ b/components/admin/ProjectEdit/GraphicEdit/GraphicEdit.js
@@ -602,6 +602,10 @@ const GraphicEdit = ( { id } ) => {
     />
   );
 
+  const hasProjectStatus = status => data?.graphicProject?.status === status;
+
+  const isDisabled = !projectId || disableBtns || !isFormValid;
+
   const graphicImageFiles = getFiles( 'images' );
 
   const supportFilesConfig = [
@@ -675,12 +679,12 @@ const GraphicEdit = ( { id } ) => {
             setDeleteConfirmOpen={ setDeleteConfirmOpen }
             previewNode={ getPreview() }
             disabled={ {
-              'delete': disableDeleteOnSave,
-              save: !projectId || disableBtns || !isFormValid,
-              preview: !projectId || disableBtns || !isFormValid,
-              publish: !projectId || disableBtns || !isFormValid, // having graphics required?
-              publishChanges: !projectId || disableBtns || !isFormValid,
-              unpublish: !projectId || disableBtns || !isFormValid,
+              'delete': disableDeleteOnSave || hasProjectStatus( 'PUBLISHED' ),
+              save: isDisabled,
+              preview: isDisabled,
+              publish: isDisabled, // having graphics required?
+              publishChanges: isDisabled,
+              unpublish: isDisabled,
             } }
             handle={ {
               deleteConfirm: projectId ? handleDeleteConfirm : handleExit,
@@ -693,9 +697,9 @@ const GraphicEdit = ( { id } ) => {
               'delete': true,
               save: true,
               preview: true,
-              publish: data?.graphicProject?.status === 'DRAFT',
+              publish: hasProjectStatus( 'DRAFT' ),
               publishChanges: data?.graphicProject?.publishedAt && isDirty,
-              unpublish: data?.graphicProject?.status === 'PUBLISHED',
+              unpublish: hasProjectStatus( 'PUBLISHED' ),
             } }
             loading={ {
               publish: publishing && publishOperation === 'publish',
@@ -800,7 +804,7 @@ const GraphicEdit = ( { id } ) => {
           <ActionHeadline
             className="headline"
             type="graphic project"
-            published={ data?.graphicProject?.status === 'PUBLISHED' }
+            published={ hasProjectStatus( 'PUBLISHED' ) }
             updated={ isDirty }
           />
 
@@ -810,7 +814,7 @@ const GraphicEdit = ( { id } ) => {
               <Button
                 className="action-btn btn--preview"
                 content="Preview"
-                disabled={ !projectId || disableBtns || !isFormValid }
+                disabled={ isDisabled }
                 primary
               />
             ) }
@@ -826,7 +830,7 @@ const GraphicEdit = ( { id } ) => {
             handleUnPublish={ handleUnPublish }
             status={ data?.graphicProject?.status || 'DRAFT' }
             updated={ isDirty }
-            disabled={ !projectId || disableBtns || !isFormValid }
+            disabled={ isDisabled }
           />
         </div>
       ) }

--- a/components/admin/ProjectEdit/GraphicEdit/__snapshots__/GraphicEdit.test.js.snap
+++ b/components/admin/ProjectEdit/GraphicEdit/__snapshots__/GraphicEdit.test.js.snap
@@ -591,7 +591,7 @@ exports[`<GraphicEdit />, when there is an existing PUBLISHED graphic project re
   deleteConfirmOpen={false}
   disabled={
     Object {
-      "delete": false,
+      "delete": true,
       "preview": false,
       "publish": false,
       "publishChanges": false,


### PR DESCRIPTION
* Disables the delete button on the details page for published graphic projects
* Updates `GraphicEdit` test snapshot