### PR TITLE
Change team name to 'GPA Design & Editorial'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 _This sections lists changes committed since most recent release_
 
+**Changed:**
+- 'GPA Editorial & Design' team name to 'GPA Design & Editorial'
+
 # [5.1.0](https://github.com/IIP-Design/content-commons-client/compare/v5.0.0...5.1.0)(2020-07-15)
 
 **Added:**

--- a/components/GraphicProject/GraphicProject.js
+++ b/components/GraphicProject/GraphicProject.js
@@ -4,7 +4,7 @@ import Link from 'next/link';
 import { useRouter } from 'next/router';
 import { updateUrl } from 'lib/browser';
 import { displayDOSLogo } from 'lib/sourceLogoUtils';
-import { getCount, getFileExt, getPreviewNotificationStyles } from 'lib/utils';
+import { getCount, getPreviewNotificationStyles } from 'lib/utils';
 import { useAuth } from 'context/authContext';
 import {
   normalizeGraphicProjectByAPI,
@@ -215,14 +215,14 @@ const GraphicProject = ( {
       lang={ selectedUnitLanguage.language_code }
       textDirection={ selectedUnitLanguage.text_direction }
     >
-      { isAdminPreview && (
+      {isAdminPreview && (
         <Notification
           el="p"
           show
           customStyles={ getPreviewNotificationStyles() }
           msg="This is a preview of your graphics project on Content Commons."
         />
-      ) }
+      )}
       <div className="modal_options">
         <div className="modal_options_left">
           <ModalLangDropdown
@@ -232,20 +232,13 @@ const GraphicProject = ( {
           />
         </div>
 
-        { visibility === 'INTERNAL'
-          && <InternalUseDisplay style={ { marginLeft: 'auto' } } /> }
+        {visibility === 'INTERNAL' && <InternalUseDisplay style={ { marginLeft: 'auto' } } />}
 
         <div className="trigger-container">
           <Popover
             id={ `${id}_graphic-share` }
             className="graphic-project__popover graphic-project__popover--share"
-            trigger={ (
-              <img
-                src={ shareIcon }
-                style={ { width: '20px', height: '20px' } }
-                alt="share icon"
-              />
-            ) }
+            trigger={ <img src={ shareIcon } style={ { width: '20px', height: '20px' } } alt="share icon" /> }
             expandFromRight
             toolTip="Share graphic"
           >
@@ -260,8 +253,7 @@ const GraphicProject = ( {
                 isPreview={ isAdminPreview }
                 { ...( isAdminPreview
                   ? { link: 'The direct link to the project will appear here.' }
-                  : null
-                ) }
+                  : null ) }
               />
             </div>
           </Popover>
@@ -269,25 +261,23 @@ const GraphicProject = ( {
           <Popover
             id={ `${id}_graphic-download` }
             className="graphic-project__popover graphic-project__popover--download"
-            trigger={ <img src={ downloadIcon } style={ { width: '20px', height: '20px' } } alt="download icon" /> }
+            trigger={ (
+              <img
+                src={ downloadIcon }
+                style={ { width: '20px', height: '20px' } }
+                alt="download icon"
+              />
+            ) }
             expandFromRight
             toolTip="Download graphic"
           >
-            <TabLayout
-              headline="Download this graphic."
-              tabs={ authFilterTabs() }
-            />
+            <TabLayout headline="Download this graphic." tabs={ authFilterTabs() } />
           </Popover>
         </div>
       </div>
 
-      { selectedUnit?.url
-        && (
-          <ModalImage
-            thumbnail={ selectedUnitURL }
-            thumbnailMeta={ { alt: getAlt() } }
-          />
-        ) }
+      {selectedUnit?.url
+        && <ModalImage thumbnail={ selectedUnitURL } thumbnailMeta={ { alt: getAlt() } } />}
 
       <ModalContentMeta
         type={ `${projectType.toLowerCase().replace( '_', ' ' )} graphic` }
@@ -296,26 +286,22 @@ const GraphicProject = ( {
 
       <ModalDescription description={ desc } />
 
-      { user && user.id !== 'public' && descInternal && (
+      {user && user.id !== 'public' && descInternal && (
         <section className="graphic-project__content internal-desc">
-          <h2 className="graphic-project__content__title">
-            Internal Description:
-          </h2>
-          <p>{ descInternal }</p>
+          <h2 className="graphic-project__content__title">Internal Description:</h2>
+          <p>{descInternal}</p>
         </section>
-      ) }
+      )}
 
       <section className="graphic-project__content alt">
-        <h2 className="graphic-project__content__title">
-          Alt (Alternative) Text:
-        </h2>
-        <p>{ getAlt() }</p>
+        <h2 className="graphic-project__content__title">Alt (Alternative) Text:</h2>
+        <p>{getAlt()}</p>
       </section>
 
       <ModalPostMeta
         type={ projectType }
         logo={ displayDOSLogo( owner ) }
-        source={ owner === 'GPA Editorial & Design' ? owner : '' }
+        source={ owner === 'GPA Design & Editorial' ? owner : '' }
         datePublished={ published }
         textDirection={ selectedUnitLanguage.text_direction }
       />

--- a/components/GraphicProject/GraphicProject.test.js
+++ b/components/GraphicProject/GraphicProject.test.js
@@ -14,32 +14,29 @@ import GraphicProject from './GraphicProject';
 
 jest.mock( 'next/config', () => () => ( { publicRuntimeConfig: {} } ) );
 jest.mock( 'lib/browser', () => ( { updateUrl: jest.fn() } ) );
-jest.mock(
-  'context/authContext',
-  () => ( {
-    useAuth: jest.fn( () => ( {
-      user: {
-        id: 'ck2m042xo0rnp0720nb4gxjix',
-        firstName: 'Joe',
-        lastName: 'Schmoe',
-        email: 'schmoej@america.gov',
-        jobTitle: '',
-        country: 'United States',
-        city: 'Washington, DC',
-        howHeard: '',
-        permissions: ['EDITOR'],
-        team: {
-          id: 'ck2lzfx6u0hkj0720f8n8mtda',
-          name: 'GPA Editorial & Design',
-          contentTypes: ['GRAPHIC'],
-          __typename: 'Team',
-        },
-        __typename: 'User',
-        esToken: 'eyasdljfakljsdfklj',
+jest.mock( 'context/authContext', () => ( {
+  useAuth: jest.fn( () => ( {
+    user: {
+      id: 'ck2m042xo0rnp0720nb4gxjix',
+      firstName: 'Joe',
+      lastName: 'Schmoe',
+      email: 'schmoej@america.gov',
+      jobTitle: '',
+      country: 'United States',
+      city: 'Washington, DC',
+      howHeard: '',
+      permissions: ['EDITOR'],
+      team: {
+        id: 'ck2lzfx6u0hkj0720f8n8mtda',
+        name: 'GPA Design & Editorial',
+        contentTypes: ['GRAPHIC'],
+        __typename: 'Team',
       },
-    } ) ),
-  } ),
-);
+      __typename: 'User',
+      esToken: 'eyasdljfakljsdfklj',
+    },
+  } ) ),
+} ) );
 
 jest.mock(
   'next/router',

--- a/components/GraphicProject/graphicElasticMock.js
+++ b/components/GraphicProject/graphicElasticMock.js
@@ -9,11 +9,12 @@ export const graphicElasticMock = [
       published: '2020-03-22T15:15:00.074Z',
       modified: '2020-04-02T15:15:00.074Z',
       visibility: 'PUBLIC',
-      owner: 'GPA Editorial & Design',
+      owner: 'GPA Design & Editorial',
       // alt: 'Some alt text here...',
       descPublic: {
         visibility: 'PUBLIC',
-        content: 'Secretary Pompeo outlined 12 requirements for Iran\'s regime to act like a normal state. With the November 4th sanctions deadline, here are reminders for the regime, starting with #12: Declare prior military dimensions of your nuclear program & abandon such work.',
+        content:
+                 "Secretary Pompeo outlined 12 requirements for Iran's regime to act like a normal state. With the November 4th sanctions deadline, here are reminders for the regime, starting with #12: Declare prior military dimensions of your nuclear program & abandon such work.",
       },
       descInternal: {
         visibility: 'INTERNAL',
@@ -25,7 +26,8 @@ export const graphicElasticMock = [
           id: 'eniebfwkjfenwknfwqjn',
           title: 'Mon titre graphique',
           visibility: 'PUBLIC',
-          url: 'https://cdp-video-tst.s3.amazonaws.com/2020/04/commons.america.gov_ck8h90w6x030l0765onryiqdt/CAPTIONS_Made_in_America_FRENCH_Twitter_Output.png',
+          url:
+                   'https://cdp-video-tst.s3.amazonaws.com/2020/04/commons.america.gov_ck8h90w6x030l0765onryiqdt/CAPTIONS_Made_in_America_FRENCH_Twitter_Output.png',
           signedUrl: 'https://mock-signed.png',
           language: {
             language_code: 'fr',
@@ -46,7 +48,8 @@ export const graphicElasticMock = [
           id: 'vewjnewjnewnwqfjn',
           title: 'Mon titre graphique FACEBOOK',
           visibility: 'PUBLIC',
-          url: 'https://cdp-video-tst.s3.amazonaws.com/2020/04/commons.america.gov_ck8h90w6x030l0765onryiqdt/CAPTIONS_Made_in_America_FRENCH_Facebook_Output.png',
+          url:
+                   'https://cdp-video-tst.s3.amazonaws.com/2020/04/commons.america.gov_ck8h90w6x030l0765onryiqdt/CAPTIONS_Made_in_America_FRENCH_Facebook_Output.png',
           signedUrl: 'https://mock-signed.png',
           language: {
             language_code: 'fr',
@@ -67,7 +70,8 @@ export const graphicElasticMock = [
           id: 'dqwkq4dm9qwlknlkwfn',
           title: 'My graphic title',
           visibility: 'PUBLIC',
-          url: 'https://cdp-video-tst.s3.amazonaws.com/2020/04/commons.america.gov_ck8h90w6x030l0765onryiqdt/CAPTIONS_Made_in_America_English_Output.png',
+          url:
+                   'https://cdp-video-tst.s3.amazonaws.com/2020/04/commons.america.gov_ck8h90w6x030l0765onryiqdt/CAPTIONS_Made_in_America_English_Output.png',
           signedUrl: 'https://mock-signed.png',
           language: {
             language_code: 'en',
@@ -90,7 +94,8 @@ export const graphicElasticMock = [
           id: 'fniuf2iuh3uh123iuh23uh',
           visibility: 'INTERNAL',
           editable: true,
-          url: 'https://cdp-video-tst.s3.amazonaws.com/2020/04/commons.america.gov_ck8h90w6x030l0765onryiqdt/CAPTIONS_Made_in_America_English_Output.psd',
+          url:
+                   'https://cdp-video-tst.s3.amazonaws.com/2020/04/commons.america.gov_ck8h90w6x030l0765onryiqdt/CAPTIONS_Made_in_America_English_Output.psd',
           language: {
             language_code: 'en',
             text_direction: 'ltr',
@@ -103,7 +108,8 @@ export const graphicElasticMock = [
           id: 'fnwndf2j3nlkf3n23uh',
           visibility: 'INTERNAL',
           editable: true,
-          url: 'https://cdp-video-tst.s3.amazonaws.com/2020/04/commons.america.gov_ck8h90w6x030l0765onryiqdt/CAPTIONS_Made_in_America_English_Output.ai',
+          url:
+                   'https://cdp-video-tst.s3.amazonaws.com/2020/04/commons.america.gov_ck8h90w6x030l0765onryiqdt/CAPTIONS_Made_in_America_English_Output.ai',
           language: {
             language_code: 'en',
             text_direction: 'ltr',
@@ -116,7 +122,8 @@ export const graphicElasticMock = [
           id: '32kbf32kjbk2f3jbf3j2',
           visibility: 'INTERNAL',
           editable: true,
-          url: 'https://cdp-video-tst.s3.amazonaws.com/2020/04/commons.america.gov_ck8h90w6x030l0765onryiqdt/CAPTIONS_Made_in_America_English_Output.png',
+          url:
+                   'https://cdp-video-tst.s3.amazonaws.com/2020/04/commons.america.gov_ck8h90w6x030l0765onryiqdt/CAPTIONS_Made_in_America_English_Output.png',
           language: {
             language_code: 'en',
             text_direction: 'ltr',
@@ -129,7 +136,8 @@ export const graphicElasticMock = [
           id: 'wnljnewln299jnjkwnewef',
           visibility: 'INTERNAL',
           editable: true,
-          url: 'https://cdp-video-tst.s3.amazonaws.com/2020/04/commons.america.gov_ck8h90w6x030l0765onryiqdt/CAPTIONS_Made_in_America_French_Output.psd',
+          url:
+                   'https://cdp-video-tst.s3.amazonaws.com/2020/04/commons.america.gov_ck8h90w6x030l0765onryiqdt/CAPTIONS_Made_in_America_French_Output.psd',
           language: {
             language_code: 'fr',
             text_direction: 'ltr',
@@ -142,7 +150,8 @@ export const graphicElasticMock = [
           id: 'qewbr438h4398h43bu3feiu',
           visibility: 'INTERNAL',
           editable: true,
-          url: 'https://cdp-video-tst.s3.amazonaws.com/2020/04/commons.america.gov_ck8h90w6x030l0765onryiqdt/CAPTIONS_Made_in_America_French_Output.ai',
+          url:
+                   'https://cdp-video-tst.s3.amazonaws.com/2020/04/commons.america.gov_ck8h90w6x030l0765onryiqdt/CAPTIONS_Made_in_America_French_Output.ai',
           language: {
             language_code: 'fr',
             text_direction: 'ltr',
@@ -155,7 +164,8 @@ export const graphicElasticMock = [
           id: 'beqwibfu4389h34hh34h43uf',
           visibility: 'INTERNAL',
           editable: false,
-          url: 'https://cdp-video-tst.s3.amazonaws.com/2020/04/commons.america.gov_ck8h90w6x030l0765onryiqdt/CAPTIONS_Made_in_America_French_Output.doc',
+          url:
+                   'https://cdp-video-tst.s3.amazonaws.com/2020/04/commons.america.gov_ck8h90w6x030l0765onryiqdt/CAPTIONS_Made_in_America_French_Output.doc',
           language: {
             language_code: 'fr',
             text_direction: 'ltr',
@@ -168,7 +178,8 @@ export const graphicElasticMock = [
           id: 'fnu2h348hf4842h8',
           visibility: 'INTERNAL',
           editable: false,
-          url: 'https://cdp-video-tst.s3.amazonaws.com/2020/04/commons.america.gov_ck8h90w6x030l0765onryiqdt/CAPTIONS_Made_in_America_French_Output.pdf',
+          url:
+                   'https://cdp-video-tst.s3.amazonaws.com/2020/04/commons.america.gov_ck8h90w6x030l0765onryiqdt/CAPTIONS_Made_in_America_French_Output.pdf',
           language: {
             language_code: 'fr',
             text_direction: 'ltr',
@@ -181,7 +192,8 @@ export const graphicElasticMock = [
           id: 'f23u4h824f2ewkjnfkjwfnkjn',
           visibility: 'INTERNAL',
           editable: false,
-          url: 'https://cdp-video-tst.s3.amazonaws.com/2020/04/commons.america.gov_ck8h90w6x030l0765onryiqdt/CAPTIONS_Made_in_America_English_Output.doc',
+          url:
+                   'https://cdp-video-tst.s3.amazonaws.com/2020/04/commons.america.gov_ck8h90w6x030l0765onryiqdt/CAPTIONS_Made_in_America_English_Output.doc',
           language: {
             language_code: 'en',
             text_direction: 'ltr',
@@ -194,7 +206,8 @@ export const graphicElasticMock = [
           id: '2323uh32uhr328223hfuhb',
           visibility: 'INTERNAL',
           editable: false,
-          url: 'https://cdp-video-tst.s3.amazonaws.com/2020/04/commons.america.gov_ck8h90w6x030l0765onryiqdt/CAPTIONS_Made_in_America_English_Output.pdf',
+          url:
+                   'https://cdp-video-tst.s3.amazonaws.com/2020/04/commons.america.gov_ck8h90w6x030l0765onryiqdt/CAPTIONS_Made_in_America_English_Output.pdf',
           language: {
             language_code: 'en',
             text_direction: 'ltr',

--- a/components/GraphicProject/graphicGraphqlMock.js
+++ b/components/GraphicProject/graphicGraphqlMock.js
@@ -32,7 +32,7 @@ export const graphicGraphqlMock = {
     permissions: ['ADMIN'],
     team: {
       id: 'ck8em6gwa004p0765q6mjvh5f',
-      name: 'GPA Editorial & Design',
+      name: 'GPA Design & Editorial',
       organization: 'Department of State',
       members: null,
       contentTypes: ['GRAPHIC'],
@@ -41,7 +41,7 @@ export const graphicGraphqlMock = {
   },
   team: {
     id: 'ck8em6gwa004p0765q6mjvh5f',
-    name: 'GPA Editorial & Design',
+    name: 'GPA Design & Editorial',
     organization: 'Department of State',
     members: null,
     contentTypes: ['GRAPHIC'],

--- a/components/Results/ResultItem/ResultItem.js
+++ b/components/Results/ResultItem/ResultItem.js
@@ -39,7 +39,7 @@ const ResultItem = ( { item } ) => {
     const dosOwners = [
       'GPA Video',
       'GPA Media Strategy',
-      'GPA Editorial & Design',
+      'GPA Design & Editorial',
       'U.S. Missions',
     ];
 

--- a/components/admin/Previews/GraphicPreview/mocks.js
+++ b/components/admin/Previews/GraphicPreview/mocks.js
@@ -12,7 +12,7 @@ export const mockData = {
   projectType: 'SOCIAL_MEDIA',
   status: 'PUBLISHED',
   supportFiles: [],
-  team: 'GPA Editorial & Design',
+  team: 'GPA Design & Editorial',
   thumbnail: {
     signedUrl: 'https://amgov-publisher-dev.s3.amazonaws.com/social&Signature=MHVgP6',
     alt: null,
@@ -37,7 +37,7 @@ export const mockGraphicItem = {
   status: 'PUBLISHED',
   supportFiles: [],
   team: {
-    name: 'GPA Editorial & Design',
+    name: 'GPA Design & Editorial',
   },
   thumbnail: {
     signedUrl: 'https://amgov-publisher-dev.s3.amazonaws.com/social&Signature=MHVgP6',

--- a/components/admin/ProjectDetailsForm/GraphicProjectDetailsFormContainer/GraphicProjectDetailsFormContainer.js
+++ b/components/admin/ProjectDetailsForm/GraphicProjectDetailsFormContainer/GraphicProjectDetailsFormContainer.js
@@ -122,10 +122,7 @@ const GraphicProjectDetailsFormContainer = props => {
         required: false,
         variables: {
           where: {
-            name_in: [
-              'GPA Editorial & Design',
-              'ShareAmerica',
-            ],
+            name_in: ['GPA Design & Editorial', 'ShareAmerica'],
           },
         },
       },

--- a/components/admin/ProjectDetailsForm/GraphicProjectDetailsFormContainer/GraphicProjectDetailsFormContainer.test.js
+++ b/components/admin/ProjectDetailsForm/GraphicProjectDetailsFormContainer/GraphicProjectDetailsFormContainer.test.js
@@ -49,10 +49,7 @@ const config = {
     required: false,
     variables: {
       where: {
-        name_in: [
-          'GPA Editorial & Design',
-          'ShareAmerica',
-        ],
+        name_in: ['GPA Design & Editorial', 'ShareAmerica'],
       },
     },
   },

--- a/components/admin/ProjectDetailsForm/GraphicProjectDetailsFormContainer/mocks.js
+++ b/components/admin/ProjectDetailsForm/GraphicProjectDetailsFormContainer/mocks.js
@@ -26,7 +26,8 @@ export const data = {
         filesize: 297343,
         visibility: 'PUBLIC',
         url: '2020/04/commons.america.gov_ck9laaua62c2o0720577s3jto/4_3_Serious_TW.jpg',
-        signedUrl: 'https://amgov-publisher-dev.s3.amazonaws.com/2020/04/commons.america.gov_ck9laaua62c2o0720577s3jto/4_3_Serious_TW.jpg?AWSAccessKeyId=accesskey&Expires=1589468486&Signature=BSnPgB%2FYTX0xmcf%2BFuf30euIczo%3D',
+        signedUrl:
+                 'https://amgov-publisher-dev.s3.amazonaws.com/2020/04/commons.america.gov_ck9laaua62c2o0720577s3jto/4_3_Serious_TW.jpg?AWSAccessKeyId=accesskey&Expires=1589468486&Signature=BSnPgB%2FYTX0xmcf%2BFuf30euIczo%3D',
         style: {
           id: 'ck9h3koe426aa0720y421wmk3',
           name: 'Clean',
@@ -65,7 +66,8 @@ export const data = {
         filesize: 433851,
         visibility: 'PUBLIC',
         url: '2020/04/commons.america.gov_ck9laaua62c2o0720577s3jto/4_3_Serious_FB.jpg',
-        signedUrl: 'https://amgov-publisher-dev.s3.amazonaws.com/2020/04/commons.america.gov_ck9laaua62c2o0720577s3jto/4_3_Serious_FB.jpg?AWSAccessKeyId=accesskey&Expires=1589468486&Signature=thesignature',
+        signedUrl:
+                 'https://amgov-publisher-dev.s3.amazonaws.com/2020/04/commons.america.gov_ck9laaua62c2o0720577s3jto/4_3_Serious_FB.jpg?AWSAccessKeyId=accesskey&Expires=1589468486&Signature=thesignature',
         style: {
           id: 'ck9h3kyb326ak0720wkbk01q6',
           name: 'Info/Stat',
@@ -105,7 +107,7 @@ export const data = {
     },
     team: {
       id: 'ck2qgfbku0ubh0720iwhkvuyn',
-      name: 'GPA Editorial & Design',
+      name: 'GPA Design & Editorial',
       organization: 'Department of State',
     },
     status: 'DRAFT',
@@ -154,7 +156,8 @@ export const data = {
         createdAt: '2020-04-28T11:28:43.173Z',
         updatedAt: '2020-05-06T12:04:17.325Z',
         url: null,
-        filename: 's-secure-rights_asikaid_ksidn_kaslkdfiwnz_iqmshqusm_kwspamdisa_sucms_english.psd',
+        filename:
+                 's-secure-rights_asikaid_ksidn_kaslkdfiwnz_iqmshqusm_kwspamdisa_sucms_english.psd',
         filetype: 'image/vnd.adobe.photoshop',
         filesize: 509000,
         visibility: 'PUBLIC',

--- a/components/admin/ProjectDetailsForm/ProjectDetailsForm.test.js
+++ b/components/admin/ProjectDetailsForm/ProjectDetailsForm.test.js
@@ -88,7 +88,7 @@ const props = {
       variables: {
         where: {
           name_in: [
-            'GPA Editorial & Design',
+            'GPA Design & Editorial',
             'ShareAmerica',
           ],
         },

--- a/components/admin/ProjectDetailsForm/__snapshots__/ProjectDetailsForm.test.js.snap
+++ b/components/admin/ProjectDetailsForm/__snapshots__/ProjectDetailsForm.test.js.snap
@@ -40,7 +40,7 @@ exports[`<ProjectDetailsForm />, for graphic projects renders without crashing 1
         "variables": Object {
           "where": Object {
             "name_in": Array [
-              "GPA Editorial & Design",
+              "GPA Design & Editorial",
               "ShareAmerica",
             ],
           },
@@ -230,7 +230,7 @@ exports[`<ProjectDetailsForm />, for graphic projects renders without crashing 1
                           Object {
                             "where": Object {
                               "name_in": Array [
-                                "GPA Editorial & Design",
+                                "GPA Design & Editorial",
                                 "ShareAmerica",
                               ],
                             },

--- a/components/admin/Upload/Upload.test.js
+++ b/components/admin/Upload/Upload.test.js
@@ -21,7 +21,7 @@ jest.mock( 'context/authContext', () => ( {
       permissions: ['EDITOR'],
       team: {
         id: 'ck2lzfx6u0hkj0720f8n8mtda',
-        name: 'GPA Editorial & Design',
+        name: 'GPA Design & Editorial',
         contentTypes: ['GRAPHIC'],
         __typename: 'Team',
       },

--- a/components/admin/dropdowns/TeamDropdown/TeamDropdown.test.js
+++ b/components/admin/dropdowns/TeamDropdown/TeamDropdown.test.js
@@ -119,7 +119,7 @@ describe( '<TeamDropdown />, when receiving query variables', () => {
     variables: {
       where: {
         name_in: [
-          'GPA Editorial & Design',
+          'GPA Design & Editorial',
           'ShareAmerica',
         ],
       },

--- a/components/admin/dropdowns/TeamDropdown/mocks.js
+++ b/components/admin/dropdowns/TeamDropdown/mocks.js
@@ -52,7 +52,7 @@ export const mocks = [
           },
           {
             id: 'ck2lzfx6u0hkj0720f8n8mtda',
-            name: 'GPA Editorial & Design',
+            name: 'GPA Design & Editorial',
             organization: 'Department of State',
             contentTypes: ['GRAPHIC'],
           },
@@ -95,10 +95,7 @@ export const mocks = [
       query: TEAMS_QUERY,
       variables: {
         where: {
-          name_in: [
-            'GPA Editorial & Design',
-            'ShareAmerica',
-          ],
+          name_in: ['GPA Design & Editorial', 'ShareAmerica'],
         },
       },
     },
@@ -113,7 +110,7 @@ export const mocks = [
           },
           {
             id: 'ck2lzfx6u0hkj0720f8n8mtda',
-            name: 'GPA Editorial & Design',
+            name: 'GPA Design & Editorial',
             organization: 'Department of State',
             contentTypes: ['GRAPHIC'],
           },

--- a/context/mocks.js
+++ b/context/mocks.js
@@ -9,26 +9,29 @@ export const graphicMock = {
       title: 'Test title language',
       copyright: '',
       alt: 'Alternative text',
-      descPublic: 'It is a long established fact that a reader will be distracted by the readable content of a page when looking at its layout.',
-      descInternal: 'It is a long established fact that a reader will be distracted by the readable content of a page when looking at its layout.',
-      assetPath: 'https://cdp-video-tst.s3.amazonaws.com/2020/01/commons.america.gov_ck5iguwcv01j40729bz48sijs/coffee.jpg',
+      descPublic:
+               'It is a long established fact that a reader will be distracted by the readable content of a page when looking at its layout.',
+      descInternal:
+               'It is a long established fact that a reader will be distracted by the readable content of a page when looking at its layout.',
+      assetPath:
+               'https://cdp-video-tst.s3.amazonaws.com/2020/01/commons.america.gov_ck5iguwcv01j40729bz48sijs/coffee.jpg',
       author: {
         id: 'ndfkjbewkj',
         firstName: 'Jane',
         lastName: 'Doe',
-        email: 'doej@america.gov'
+        email: 'doej@america.gov',
       },
       team: {
         id: 'wjbjb',
-        name: 'GPA Editorial & Design',
-        contentTypes: ['GRAPHIC']
+        name: 'GPA Design & Editorial',
+        contentTypes: ['GRAPHIC'],
       },
       status: 'PUBLISHED',
       visibility: 'PUBLIC',
       images: [],
       categories: [],
       tags: [],
-      __typename: 'GraphicProject'
+      __typename: 'GraphicProject',
     },
     {
       id: '5678',
@@ -39,26 +42,29 @@ export const graphicMock = {
       title: 'Test title social media',
       copyright: '',
       alt: 'Alternative text',
-      descPublic: 'It is a long established fact that a reader will be distracted by the readable content of a page when looking at its layout.',
-      descInternal: 'It is a long established fact that a reader will be distracted by the readable content of a page when looking at its layout.',
-      assetPath: 'https://cdp-video-tst.s3.amazonaws.com/2020/01/commons.america.gov_ck5iguwcv01j40729bz48sijs/coffee.jpg',
+      descPublic:
+               'It is a long established fact that a reader will be distracted by the readable content of a page when looking at its layout.',
+      descInternal:
+               'It is a long established fact that a reader will be distracted by the readable content of a page when looking at its layout.',
+      assetPath:
+               'https://cdp-video-tst.s3.amazonaws.com/2020/01/commons.america.gov_ck5iguwcv01j40729bz48sijs/coffee.jpg',
       author: {
         id: 'dejkndejn',
         firstName: 'John',
         lastName: 'Doe',
-        email: 'doej2@america.gov'
+        email: 'doej2@america.gov',
       },
       team: {
         id: 'wjbjb',
-        name: 'GPA Editorial & Design',
-        contentTypes: ['GRAPHIC']
+        name: 'GPA Design & Editorial',
+        contentTypes: ['GRAPHIC'],
       },
       status: 'DRAFT',
       visibility: 'PUBLIC',
       images: [],
       categories: [],
       tags: [],
-      __typename: 'GraphicProject'
-    }
-  ]
+      __typename: 'GraphicProject',
+    },
+  ],
 };

--- a/lib/sourceLogoUtils.js
+++ b/lib/sourceLogoUtils.js
@@ -4,7 +4,7 @@ import logoShareAmerica from 'static/images/logo_shareamerica.svg';
 const dosOwners = [
   'GPA Video',
   'GPA Media Strategy',
-  'GPA Editorial & Design',
+  'GPA Design & Editorial',
   'U.S. Missions',
 ];
 


### PR DESCRIPTION
- Changes team name to GPA Design & Editorial
- Updates applicable tests

To complete task, the following scripts need to be run:

**On the server:**
```mutation UPDATE_TEAM {
  updateTeam(data: {
    name: "GPA Design & Editorial"
  }, where: {
    id: "[ID]"
  }) {
    id
    name
  }
}
```

**On the API via Kibana:**
```POST graphics/_update_by_query
{
  "script": {
    "source": "ctx._source.owner='GPA Design & Editorial'",
    "lang": "painless"
  },
  "query": {
    "match": {
      "owner.keyword": "GPA Editorial & Design"
    }
  }
}
```