### PR TITLE
CDP-2167: Videos are incorrectly labeled on "Videos in Project" screen

### DIFF
--- a/components/admin/ProjectEdit/EditVideoModal/ModalForms/FileDataForm/FileDataForm.js
+++ b/components/admin/ProjectEdit/EditVideoModal/ModalForms/FileDataForm/FileDataForm.js
@@ -377,6 +377,16 @@ const FileDataForm = ( {
               disabled={ values.use === cleanUseId && values.videoBurnedInStatus === 'CLEAN' }
             />
 
+            <UseDropdown
+              id="video-use"
+              label="Video Type"
+              name="use"
+              onChange={ handleDropdownSave }
+              required
+              type="video"
+              value={ values.use }
+            />
+
             <VideoBurnedInStatusDropdown
               id="video-subtitles"
               label="On-Screen Text"
@@ -386,16 +396,6 @@ const FileDataForm = ( {
               type="video"
               value={ values.videoBurnedInStatus }
               disabled={ values.use === cleanUseId }
-            />
-
-            <UseDropdown
-              id="video-use"
-              label="Video Type"
-              name="use"
-              onChange={ handleDropdownSave }
-              required
-              type="video"
-              value={ values.use }
             />
 
             <QualityDropdown

--- a/components/admin/ProjectEdit/EditVideoModal/ModalSections/FileSidebar/FileSidebar.js
+++ b/components/admin/ProjectEdit/EditVideoModal/ModalSections/FileSidebar/FileSidebar.js
@@ -53,10 +53,11 @@ const FileSidebar = () => {
         return (
           <div className="edit-video-sidebar">
             <Carousel legend={ false } selectedItem={ selectedFile } vertical>
-              { files && (
-                files.map( file => {
+              { files
+                && files.map( file => {
                   const fileUse = file.use && file.use.name ? file.use.name : '';
-                  const captionStatus = file.videoBurnedInStatus ? `| ${file.videoBurnedInStatus}` : '';
+                  const captionStatus = file.videoBurnedInStatus === 'SUBTITLED' ? 'On-Screen Text' : 'No On-Screen Text';
+
                   return (
                     <div
                       className="edit-video-sidebar-item"
@@ -72,12 +73,11 @@ const FileSidebar = () => {
                         className={ selectedFile === file.id ? 'edit-video-sidebar-image selected' : 'edit-video-sidebar-image' }
                         src={ image }
                       />
-                      <p>{ `${titleCase( file.quality )} ${titleCase( captionStatus )}` }</p>
+                      <p>{ `${titleCase( file.quality )} | ${captionStatus}` }</p>
                       <p>{ titleCase( fileUse ) }</p>
                     </div>
                   );
-                } )
-              ) }
+                } ) }
             </Carousel>
           </div>
         );


### PR DESCRIPTION
* Updates labeling for videos in `FileSidebar` to reflect changes in `VideoBurnedInStatusDropdown` text
* Switched the presentation order of `UseDropdown` and `VideoBurnedInStatusDropdown` to match mocks