### PR TITLE
CDP-2155: Adjust Language & On-Screen Text values on initial edit video modal load

### DIFF
--- a/components/admin/ProjectEdit/EditVideoModal/ModalForms/FileDataForm/FileDataForm.js
+++ b/components/admin/ProjectEdit/EditVideoModal/ModalForms/FileDataForm/FileDataForm.js
@@ -373,8 +373,8 @@ const FileDataForm = ( {
               label="Language"
               onChange={ ( e, { value } ) => handleLanguageChange( value ) }
               required
-              value={ values.language }
-              disabled={ values.use === cleanUseId && values.videoBurnedInStatus === 'CLEAN' }
+              value={ values.use === cleanUseId ? englishId : values.language }
+              disabled={ values.use === cleanUseId }
             />
 
             <UseDropdown
@@ -394,7 +394,7 @@ const FileDataForm = ( {
               onChange={ handleDropdownSave }
               required
               type="video"
-              value={ values.videoBurnedInStatus }
+              value={ values.use === cleanUseId ? 'CLEAN' : values.videoBurnedInStatus }
               disabled={ values.use === cleanUseId }
             />
 

--- a/components/admin/ProjectEdit/EditVideoModal/ModalForms/FileDataForm/FileDataForm.test.js
+++ b/components/admin/ProjectEdit/EditVideoModal/ModalForms/FileDataForm/FileDataForm.test.js
@@ -291,7 +291,6 @@ describe( '<FileDataForm />, when the video use is not Clean', () => {
     expect( languageDropdown.prop( 'label' ) ).toEqual( 'Language' );
     expect( languageDropdown.prop( 'required' ) ).toEqual( true );
     expect( languageDropdown.prop( 'value' ) ).toEqual( languageId );
-    // disabled since file (i.e., mocks[1]) has Clean video use
     expect( languageDropdown.prop( 'disabled' ) ).toEqual( false );
   } );
 
@@ -308,7 +307,6 @@ describe( '<FileDataForm />, when the video use is not Clean', () => {
       .toEqual( 'video' );
     expect( burnedInStatusDropdown.prop( 'required' ) )
       .toEqual( true );
-    // disabled since file (i.e., mocks[1]) has Clean video use
     expect( burnedInStatusDropdown.prop( 'disabled' ) )
       .toEqual( false );
     expect( burnedInStatusDropdown.prop( 'onChange' ).name )

--- a/components/admin/ProjectEdit/EditVideoModal/ModalForms/FileDataForm/mocks.js
+++ b/components/admin/ProjectEdit/EditVideoModal/ModalForms/FileDataForm/mocks.js
@@ -320,7 +320,7 @@ const mocks = [
     request: {
       query: LANGUAGE_BY_NAME_QUERY,
       variables: {
-        where: { displayName: 'English' },
+        displayName: 'English',
       },
     },
     result: {


### PR DESCRIPTION
* Sets the Language & On-Screen Text dropdown values for Clean videos in edit modal