### PR TITLE
CDP-2146: Do not display English in video preview download modal if all of the English unit's videos are Clean

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 _This sections lists changes committed since most recent release_
 
+**Added:**
+- 'For Translation' tab with 'Clean' use videos to the video download popup on commons and publisher
+- 'Other' tab to the video download popup on commons
+- `DownloadThumbnailsAndOtherFiles` component
+
 **Changed:**
+- Remove English from the language dropdown in the video preview modal and commons page when the English unit consists of *only* 'Clean' use videos
 - 'GPA Editorial & Design' team name to 'GPA Design & Editorial'
+- Include thumbnails in the 'Other' tab in the video download popup
+- Download instructions text to match mockup changes
+
+**Fixed:**
+- Bug where a video unit's thumbnail was not being assigned to `unit.thumbnail` on the results page; This was preventing a video unit's thumbnails from being listed in its download popup.
 
 # [5.1.0](https://github.com/IIP-Design/content-commons-client/compare/v5.0.0...5.1.0)(2020-07-15)
 

--- a/components/TabLayout/TabLayout.scss
+++ b/components/TabLayout/TabLayout.scss
@@ -1,7 +1,7 @@
 @import "styles/colors.scss";
 
 .tab-layout {  
-  width: 540px;
+  width: 600px;
   min-height: 360px;
   padding: 20px;
   background-color: #fff;

--- a/components/TabLayout/TabLayout.scss
+++ b/components/TabLayout/TabLayout.scss
@@ -1,7 +1,7 @@
 @import "styles/colors.scss";
 
 .tab-layout {  
-  width: 600px;
+  width: 660px;
   min-height: 360px;
   padding: 20px;
   background-color: #fff;

--- a/components/Video/Download/DownloadThumbnailsAndOtherFiles.js
+++ b/components/Video/Download/DownloadThumbnailsAndOtherFiles.js
@@ -1,0 +1,68 @@
+import React, { useEffect, useState } from 'react';
+import PropTypes from 'prop-types';
+
+import { getCount, getFileDownloadUrl, getFileNameFromUrl } from 'lib/utils';
+
+import DownloadItemContent from 'components/download/DownloadItem/DownloadItemContent';
+
+const DownloadThumbnailsAndOtherFiles = ( { item } ) => {
+  const [otherFiles, setOtherFiles] = useState( [] );
+
+  useEffect( () => {
+    let thumbnails = [];
+
+    if ( item?.units ) {
+      thumbnails = item.units.reduce( ( acc, unit ) => {
+        if ( unit?.thumbnail && unit?.language ) {
+          acc.push( {
+            thumbnail: unit.thumbnail,
+            language: unit.language,
+          } );
+        }
+
+        return acc;
+      }, [] );
+    }
+
+    const supportFiles = item?.supportFiles
+      ? item.supportFiles.filter( file => file.supportFileType !== 'srt' && file.supportFileType !== 'vtt' )
+      : [];
+
+    const allFiles = [...thumbnails, ...supportFiles];
+
+    setOtherFiles( allFiles );
+  }, [item] );
+
+  const renderFormItem = file => {
+    const lang = file?.language?.display_name || ''; // eslint-disable-line camelcase
+    const src = file?.thumbnail || file?.srcUrl || '';
+    const filename = getFileNameFromUrl( src ) || `${lang}-other-file`;
+    const fileType = file.supportFileType ? `${file.supportFileType} file` : 'Thumbnail';
+
+    return (
+      <DownloadItemContent
+        key={ `${lang}-${src}` }
+        srcUrl={ getFileDownloadUrl( src, filename ) }
+        hoverText={ `Download ${lang} ${fileType}` }
+      >
+        <div className="item-content">
+          <p className="item-content__title">
+            <strong>
+              { `Download ${lang} ${fileType}` }
+            </strong>
+          </p>
+        </div>
+      </DownloadItemContent>
+    );
+  };
+
+  return getCount( otherFiles )
+    ? otherFiles.map( renderFormItem )
+    : <p className="download-item__noContent">There are no other files available for download at this time.</p>;
+};
+
+DownloadThumbnailsAndOtherFiles.propTypes = {
+  item: PropTypes.object,
+};
+
+export default DownloadThumbnailsAndOtherFiles;

--- a/components/Video/Download/DownloadVideo.js
+++ b/components/Video/Download/DownloadVideo.js
@@ -50,11 +50,10 @@ const DownloadVideo = ( { burnedInCaptions, selectedLanguageUnit, isAdminPreview
         <div className="item-content">
           <p className="item-content__title">
             <strong>
-              Download
-              { ` "${title}"` }
-              { ` for ${videoQuality}`}
+              { `Download "${title}" for ${videoQuality}` }
             </strong>
           </p>
+          <p className="item-content__meta">{ `${video.use} | ${video.videoBurnedInStatus === 'CLEAN' ? 'No subtitles' : 'Subtitles'}` }</p>
           <p className="item-content__meta">{ `File size: ${size.weight}` }</p>
           <p className="item-content__meta">{ `Dimensions: ${size.label}` }</p>
         </div>
@@ -63,9 +62,13 @@ const DownloadVideo = ( { burnedInCaptions, selectedLanguageUnit, isAdminPreview
   };
 
   const renderFormItems = ( unit, captions ) => {
-    // fetch all source videos with NO burned in captions and then sort by file size
-    const videos = unit.source.filter( video => video.burnedInCaptions === 'true' === captions );
-    const videosWithSizeProp = unit.source.filter( video => video.size && video.size.filesize );
+    // fetch all source videos by Clean vs. non-Clean and then sort by file size
+    const videos = unit.source.filter( video => {
+      const isClean = video.use === 'Clean';
+
+      return captions ? !isClean : isClean;
+    } );
+    const videosWithSizeProp = videos.filter( video => video.filesize );
 
     // only sort the videos if each video has a filesize prop for comparison
     if ( videosWithSizeProp.length === videos.length ) {

--- a/components/Video/Download/DownloadVideo.js
+++ b/components/Video/Download/DownloadVideo.js
@@ -53,7 +53,7 @@ const DownloadVideo = ( { burnedInCaptions, selectedLanguageUnit, isAdminPreview
               { `Download "${title}" for ${videoQuality}` }
             </strong>
           </p>
-          <p className="item-content__meta">{ `${video.use} | ${video.videoBurnedInStatus === 'CLEAN' ? 'No subtitles' : 'Subtitles'}` }</p>
+          <p className="item-content__meta">{ `${video.use} | ${video.use === 'Clean' ? 'No subtitles' : 'Subtitles'}` }</p>
           <p className="item-content__meta">{ `File size: ${size.weight}` }</p>
           <p className="item-content__meta">{ `Dimensions: ${size.label}` }</p>
         </div>

--- a/components/Video/Download/__tests__/DownloadThumbnailsAndOtherFiles.test.js
+++ b/components/Video/Download/__tests__/DownloadThumbnailsAndOtherFiles.test.js
@@ -1,0 +1,62 @@
+import { mount } from 'enzyme';
+import DownloadThumbnailsAndOtherFiles from '../DownloadThumbnailsAndOtherFiles';
+import { mockItem } from '../../mocks';
+import { getFileDownloadUrl, getFileNameFromUrl } from 'lib/utils';
+
+jest.mock(
+  'next/config',
+  () => () => ( {
+    publicRuntimeConfig: {
+      REACT_APP_PUBLIC_API: 'https://amgov-publisher-dev.s3.amazonaws.com',
+    },
+  } ),
+);
+jest.mock( 'lib/hooks/useSignedUrl', () => jest.fn( () => ( { signedUrl: 'https://example.jpg' } ) ) );
+
+describe( '<DownloadThumbnailsAndOtherFiles />', () => {
+  const props = {
+    item: mockItem,
+  };
+  let Component;
+  let wrapper;
+
+  beforeEach( () => {
+    Component = <DownloadThumbnailsAndOtherFiles { ...props } />;
+    wrapper = mount( Component );
+  } );
+
+  it( 'renders without crashing', () => {
+    expect( wrapper.exists() ).toEqual( true );
+  } );
+
+  it( 'passes the correct data to the DownloadItems', () => {
+    const downloadItems = wrapper.find( 'DownloadItemContent' );
+    const { item } = props;
+    const thumbnails = item.units.reduce( ( acc, unit ) => {
+      acc.push( {
+        thumbnail: unit.thumbnail,
+        language: unit.language,
+      } );
+
+      return acc;
+    }, [] );
+    const supportFiles = item.supportFiles.filter( file => file.supportFileType !== 'srt' && file.supportFileType !== 'vtt' );
+    const allOtherFiles = [...thumbnails, ...supportFiles];
+
+    expect( downloadItems.length ).toEqual( allOtherFiles.length );
+    downloadItems.forEach( ( downloadItem, i ) => {
+      const file = allOtherFiles[i];
+      const title = downloadItem.find( '.item-content__title' );
+      const hover = downloadItem.find( '.item-hover' );
+      const src = file.thumbnail || file.srcUrl;
+      const fileName = getFileNameFromUrl( src );
+      const fileType = file.supportFileType ? `${file.supportFileType} file` : 'Thumbnail';
+      const helperText = `Download ${file.language.display_name} ${fileType}`;
+      const srcUrl = getFileDownloadUrl( src, fileName );
+
+      expect( title.text() ).toEqual( helperText );
+      expect( hover.text() ).toEqual( helperText );
+      expect( downloadItem.prop( 'srcUrl' ) ).toEqual( srcUrl );
+    } );
+  } );
+} );

--- a/components/Video/Video.js
+++ b/components/Video/Video.js
@@ -22,6 +22,7 @@ import TabLayout from 'components/TabLayout/TabLayout';
 import DownloadVideo from './Download/DownloadVideo';
 import DownloadCaption from './Download/DownloadCaption';
 import DownloadTranscript from './Download/DownloadTranscript';
+import DownloadThumbnailsAndOtherFiles from './Download/DownloadThumbnailsAndOtherFiles';
 import DownloadHelp from './Download/DownloadHelp';
 import Share from '../Share/Share';
 import EmbedVideo from '../Embed';
@@ -182,6 +183,7 @@ const Video = ( { item, router, isAdminPreview = false } ) => {
           instructions={ (
             <p>
               By downloading these editable files, you agree to the
+              { ' ' }
               <Link href="/about"><a>Terms of Use</a></Link>
               .
             </p>
@@ -201,6 +203,23 @@ const Video = ( { item, router, isAdminPreview = false } ) => {
           instructions="Download Transcripts"
         >
           <DownloadTranscript item={ item } />
+        </DownloadItem>
+      ),
+    },
+    {
+      title: 'Other',
+      content: (
+        <DownloadItem
+          instructions={ (
+            <p>
+              By downloading these files, you agree to the
+              { ' ' }
+              <Link href="/about"><a>Terms of Use</a></Link>
+              .
+            </p>
+          ) }
+        >
+          <DownloadThumbnailsAndOtherFiles item={ item } />
         </DownloadItem>
       ),
     },

--- a/components/Video/Video.js
+++ b/components/Video/Video.js
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { Embed, Checkbox } from 'semantic-ui-react';
+import Link from 'next/link';
 import { withRouter } from 'next/router';
 
 import { updateUrl } from 'lib/browser';
@@ -227,8 +228,8 @@ const Video = ( { item, router, isAdminPreview = false } ) => {
                     title: 'Video File',
                     content: (
                       <DownloadItem
-                        instructions={ `Download the video and SRT files in ${unit.language.display_name}.
-                        This download option is best for uploading this video to web pages.` }
+                        instructions={ `Download the video and caption files in ${unit.language.display_name}.
+                        This download option is best for uploading this video to web pages and social media.` }
                       >
                         <DownloadVideo
                           selectedLanguageUnit={ unit }
@@ -242,7 +243,7 @@ const Video = ( { item, router, isAdminPreview = false } ) => {
                     title: 'Caption File',
                     content: (
                       <DownloadItem
-                        instructions="Download caption file(s) for this video."
+                        instructions={ <p>By downloading these editable files you agree to the <Link href="/about"><a>Terms of Use</a></Link>.</p> }
                       >
                         <DownloadCaption
                           selectedLanguageUnit={ unit }

--- a/components/Video/Video.js
+++ b/components/Video/Video.js
@@ -86,6 +86,8 @@ const Video = ( { item, router, isAdminPreview = false } ) => {
     willFetchVideoPlayer();
   }, [unit, captions] );
 
+  const getUnitWithCleanVideos = _units => _units.find( u => u.source.some( file => file?.use === 'Clean' ) );
+
   /**
    * Get the video data associated with currently selected language
    */
@@ -127,6 +129,8 @@ const Video = ( { item, router, isAdminPreview = false } ) => {
   const embedItem = shareLink
     ? `<iframe src="${shareLink}" width="640" height="360" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>`
     : '';
+
+  const unitWithCleanVideos = getUnitWithCleanVideos( item.units );
 
   if ( unit && selectedLanguage ) {
     const toggleCaptions = [...new Set( unit.source.map( u => u.burnedInCaptions ) )];
@@ -246,7 +250,7 @@ const Video = ( { item, router, isAdminPreview = false } ) => {
                         instructions="Download a clean version (no-text version) of the video, for adding translated subtitles."
                       >
                         <DownloadVideo
-                          selectedLanguageUnit={ unit }
+                          selectedLanguageUnit={ unitWithCleanVideos || unit }
                           burnedInCaptions={ false }
                           isAdminPreview={ isAdminPreview }
                         />
@@ -257,7 +261,13 @@ const Video = ( { item, router, isAdminPreview = false } ) => {
                     title: 'Caption Files',
                     content: (
                       <DownloadItem
-                        instructions={ <p>By downloading these editable files you agree to the <Link href="/about"><a>Terms of Use</a></Link>.</p> }
+                        instructions={ (
+                          <p>
+                            By downloading these editable files, you agree to the
+                            <Link href="/about"><a>Terms of Use</a></Link>
+                            .
+                          </p>
+                        ) }
                       >
                         <DownloadCaption
                           selectedLanguageUnit={ unit }

--- a/components/Video/Video.js
+++ b/components/Video/Video.js
@@ -225,7 +225,7 @@ const Video = ( { item, router, isAdminPreview = false } ) => {
                 headline="Download this video."
                 tabs={ [
                   {
-                    title: 'Video File',
+                    title: 'Video Files',
                     content: (
                       <DownloadItem
                         instructions={ `Download the video and caption files in ${unit.language.display_name}.
@@ -233,14 +233,28 @@ const Video = ( { item, router, isAdminPreview = false } ) => {
                       >
                         <DownloadVideo
                           selectedLanguageUnit={ unit }
-                          burnedInCaptions={ captions }
+                          burnedInCaptions
                           isAdminPreview={ isAdminPreview }
                         />
                       </DownloadItem>
                     ),
                   },
                   {
-                    title: 'Caption File',
+                    title: 'For Translation',
+                    content: (
+                      <DownloadItem
+                        instructions="Download a clean version (no-text version) of the video, for adding translated subtitles."
+                      >
+                        <DownloadVideo
+                          selectedLanguageUnit={ unit }
+                          burnedInCaptions={ false }
+                          isAdminPreview={ isAdminPreview }
+                        />
+                      </DownloadItem>
+                    ),
+                  },
+                  {
+                    title: 'Caption Files',
                     content: (
                       <DownloadItem
                         instructions={ <p>By downloading these editable files you agree to the <Link href="/about"><a>Terms of Use</a></Link>.</p> }

--- a/components/Video/Video.test.js
+++ b/components/Video/Video.test.js
@@ -157,7 +157,7 @@ describe( '<Video />, for a user not logged in', () => {
     const tabLayout = mount( popover.prop( 'children' ) );
     const { tabs } = tabLayout.props();
     const tabTitles = [
-      'Video Files', 'Caption Files', 'Transcript', 'Help',
+      'Video Files', 'Caption Files', 'Transcript', 'Other', 'Help',
     ];
 
     expect( tabs.length ).toEqual( tabTitles.length );

--- a/components/Video/Video.test.js
+++ b/components/Video/Video.test.js
@@ -1,4 +1,5 @@
 import { mount } from 'enzyme';
+import { useAuth } from 'context/authContext';
 import Video from './Video';
 import { mockItem } from './mocks';
 
@@ -24,6 +25,9 @@ jest.mock( 'next/router', () => ( {
     return component;
   },
 } ) );
+jest.mock( 'context/authContext', () => ( {
+  useAuth: jest.fn(),
+} ) );
 
 jest.mock( 'components/modals/ModalItem', () => 'modal-item' );
 jest.mock( 'components/modals/ModalLangDropdown/ModalLangDropdown', () => 'modal-lang-dropdown' );
@@ -47,6 +51,30 @@ const mockRouter = { pathname: '/video' };
 afterAll( () => { jest.restoreAllMocks(); } );
 
 describe( '<Video />', () => {
+  beforeEach( () => {
+    useAuth.mockImplementation( () => ( {
+      user: {
+        id: 'ck2m042xo0rnp0720nb4gxjix',
+        firstName: 'Joe',
+        lastName: 'Schmoe',
+        email: 'schmoej@america.gov',
+        jobTitle: '',
+        country: 'United States',
+        city: 'Washington, DC',
+        howHeard: '',
+        permissions: ['EDITOR'],
+        team: {
+          id: 'ck2lzfx6u0hkj0720f8n8mtda',
+          name: 'GPA Design & Editorial',
+          contentTypes: ['GRAPHIC'],
+          __typename: 'Team',
+        },
+        __typename: 'User',
+        esToken: 'eyasdljfakljsdfklj',
+      },
+    } ) );
+  } );
+
   it( 'renders without crashing', () => {
     const wrapper = mount( <Video item={ mockItem } router={ mockRouter } /> );
 
@@ -87,4 +115,54 @@ describe( '<Video />', () => {
 
   //   expect( modalItem.contains( 'Content Unavailable' ) ).toEqual( true );
   // } );
+} );
+
+describe( '<Video />, for a user not logged in', () => {
+  const props = {
+    item: mockItem,
+    router: mockRouter,
+    isAdminPreview: false,
+  };
+  let Component;
+  let wrapper;
+
+  beforeEach( () => {
+    Component = <Video { ...props } />;
+    wrapper = mount( Component );
+
+    useAuth.mockImplementation( () => ( {
+      user: {
+        id: 'public',
+        firstName: '',
+        lastName: '',
+        email: '',
+        jobTitle: null,
+        country: null,
+        city: null,
+        howHeard: null,
+        permissions: [],
+        team: null,
+        __typename: 'User',
+      },
+    } ) );
+  } );
+
+  it( 'renders without crashing', () => {
+    expect( wrapper.exists() ).toEqual( true );
+  } );
+
+  it( 'renders the correct download tabs', () => {
+    const { id } = props.item;
+    const popover = wrapper.find( `[id="${id}_video-download"]` );
+    const tabLayout = mount( popover.prop( 'children' ) );
+    const { tabs } = tabLayout.props();
+    const tabTitles = [
+      'Video Files', 'Caption Files', 'Transcript', 'Help',
+    ];
+
+    expect( tabs.length ).toEqual( tabTitles.length );
+    tabs.forEach( ( tab, i ) => {
+      expect( tab.title ).toEqual( tabTitles[i] );
+    } );
+  } );
 } );

--- a/components/admin/Previews/ProjectPreview/ProjectPreviewContent/ProjectPreviewContent.js
+++ b/components/admin/Previews/ProjectPreview/ProjectPreviewContent/ProjectPreviewContent.js
@@ -14,7 +14,6 @@ import ApolloError from 'components/errors/ApolloError';
 
 import DownloadVideo from 'components/admin/download/DownloadVideo/DownloadVideo';
 import DownloadCaption from 'components/admin/download/DownloadCaption/DownloadCaption';
-import DownloadThumbnail from 'components/admin/download/DownloadThumbnail/DownloadThumbnail';
 import DownloadOtherFiles from 'components/admin/download/DownloadOtherFiles/DownloadOtherFiles';
 import DownloadHelp from 'components/Video/Download/DownloadHelp';
 
@@ -420,19 +419,6 @@ class ProjectPreviewContent extends React.PureComponent {
                         instructions={ this.getDownloadItemInstructions( { editable: true } ) }
                       >
                         <DownloadCaption
-                          id={ id }
-                          isPreview
-                        />
-                      </DownloadItem>
-                    ),
-                  },
-                  {
-                    title: 'Thumbnail',
-                    content: (
-                      <DownloadItem
-                        instructions="Download Transcripts"
-                      >
-                        <DownloadThumbnail
                           id={ id }
                           isPreview
                         />

--- a/components/admin/Previews/ProjectPreview/ProjectPreviewContent/ProjectPreviewContent.js
+++ b/components/admin/Previews/ProjectPreview/ProjectPreviewContent/ProjectPreviewContent.js
@@ -128,6 +128,8 @@ class ProjectPreviewContent extends React.PureComponent {
     return files.length > 0 && hasSomeNonCleanVideos;
   } );
 
+  getUnitWithCleanVideos = units => units.find( unit => unit.files.some( file => file?.use?.name === 'Clean' ) );
+
   getEnglishIndex = units => units.findIndex( unit => unit.language.displayName === 'English' );
 
   getFilesCount = ( units, i ) => {
@@ -200,7 +202,11 @@ class ProjectPreviewContent extends React.PureComponent {
   ], [] );
 
   getDownloadItemInstructions = ( { editable } ) => (
-    <p>By downloading these{editable ? ' editable' : ''} files you agree to the <Link href="/about"><a>Terms of Use</a></Link>.</p>
+    <p>
+      { `By downloading these ${editable ? 'editable' : ''}files, you agree to the` }
+      <Link href="/about"><a>Terms of Use</a></Link>
+      .
+    </p>
   );
 
   toggleArrow = () => {
@@ -230,6 +236,7 @@ class ProjectPreviewContent extends React.PureComponent {
     } = project;
     const { dropDownIsOpen, selectedLanguage } = this.state;
 
+    const unitWithCleanVideos = this.getUnitWithCleanVideos( units );
     const projectUnits = this.getProjectUnits( units );
     const selectedUnit = projectUnits[String( selectedLanguage )];
 
@@ -405,7 +412,7 @@ class ProjectPreviewContent extends React.PureComponent {
                         instructions="Download a clean version (no-text version) of the video, for adding translated subtitles."
                       >
                         <DownloadVideo
-                          selectedLanguageUnit={ selectedUnit }
+                          selectedLanguageUnit={ unitWithCleanVideos || selectedUnit }
                           burnedInCaptions={ false }
                           isPreview
                         />

--- a/components/admin/Previews/ProjectPreview/ProjectPreviewContent/ProjectPreviewContent.js
+++ b/components/admin/Previews/ProjectPreview/ProjectPreviewContent/ProjectPreviewContent.js
@@ -255,10 +255,7 @@ class ProjectPreviewContent extends React.PureComponent {
       );
     }
 
-    const {
-      createdAt, updatedAt, stream, videoBurnedInStatus,
-    } = files[0];
-
+    const { createdAt, updatedAt, stream } = files[0];
     const youTubeUrl = getStreamData( stream, 'youtube', 'url' );
     const vimeoUrl = getStreamData( stream, 'vimeo', 'url' );
 
@@ -388,7 +385,7 @@ class ProjectPreviewContent extends React.PureComponent {
                 headline="Download this video."
                 tabs={ [
                   {
-                    title: 'Video File',
+                    title: 'Video Files',
                     content: (
                       <DownloadItem
                         instructions={ `Download the video and caption files in ${selectedLanguage}.
@@ -396,14 +393,28 @@ class ProjectPreviewContent extends React.PureComponent {
                       >
                         <DownloadVideo
                           selectedLanguageUnit={ selectedUnit }
-                          burnedInCaptions={ videoBurnedInStatus === 'CAPTIONED' }
+                          burnedInCaptions
                           isPreview
                         />
                       </DownloadItem>
                     ),
                   },
                   {
-                    title: 'Caption File',
+                    title: 'For Translation',
+                    content: (
+                      <DownloadItem
+                        instructions="Download a clean version (no-text version) of the video, for adding translated subtitles."
+                      >
+                        <DownloadVideo
+                          selectedLanguageUnit={ selectedUnit }
+                          burnedInCaptions={ false }
+                          isPreview
+                        />
+                      </DownloadItem>
+                    ),
+                  },
+                  {
+                    title: 'Caption Files',
                     content: (
                       <DownloadItem
                         instructions={ this.getDownloadItemInstructions( { editable: true } ) }

--- a/components/admin/Previews/ProjectPreview/ProjectPreviewContent/ProjectPreviewContent.js
+++ b/components/admin/Previews/ProjectPreview/ProjectPreviewContent/ProjectPreviewContent.js
@@ -6,6 +6,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import gql from 'graphql-tag';
+import Link from 'next/link';
 import { graphql } from 'react-apollo';
 import { Dropdown, Embed } from 'semantic-ui-react';
 
@@ -199,6 +200,10 @@ class ProjectPreviewContent extends React.PureComponent {
     { name: this.getTag( curr, unit ) },
   ], [] );
 
+  getDownloadItemInstructions = ( { editable } ) => (
+    <p>By downloading these{editable ? ' editable' : ''} files you agree to the <Link href="/about"><a>Terms of Use</a></Link>.</p>
+  );
+
   toggleArrow = () => {
     this.setState( prevState => ( {
       dropDownIsOpen: !prevState.dropDownIsOpen,
@@ -387,7 +392,7 @@ class ProjectPreviewContent extends React.PureComponent {
                     content: (
                       <DownloadItem
                         instructions={ `Download the video and caption files in ${selectedLanguage}.
-                        This download option is best for uploading this video to web pages.` }
+                        This download option is best for uploading this video to web pages and social media.` }
                       >
                         <DownloadVideo
                           selectedLanguageUnit={ selectedUnit }
@@ -401,7 +406,7 @@ class ProjectPreviewContent extends React.PureComponent {
                     title: 'Caption File',
                     content: (
                       <DownloadItem
-                        instructions="Download caption file(s) for this video."
+                        instructions={ this.getDownloadItemInstructions( { editable: true } ) }
                       >
                         <DownloadCaption
                           id={ id }
@@ -427,7 +432,7 @@ class ProjectPreviewContent extends React.PureComponent {
                     title: 'Other',
                     content: (
                       <DownloadItem
-                        instructions="Download Other File(s)"
+                        instructions={ this.getDownloadItemInstructions( { editable: false } ) }
                       >
                         <DownloadOtherFiles
                           id={ id }

--- a/components/admin/Previews/ProjectPreview/ProjectPreviewContent/ProjectPreviewContent.js
+++ b/components/admin/Previews/ProjectPreview/ProjectPreviewContent/ProjectPreviewContent.js
@@ -241,9 +241,13 @@ class ProjectPreviewContent extends React.PureComponent {
     const selectedUnit = projectUnits[String( selectedLanguage )];
 
     if ( !selectedUnit || !Object.keys( selectedUnit ).length ) {
+      const hasOnlyCleanVideos = !!unitWithCleanVideos && unitWithCleanVideos?.files.every( file => file?.use?.name === 'Clean' );
+
       return (
         <p style={ { fontSize: '1rem' } }>
-          This project does not have any units to preview.
+          { hasOnlyCleanVideos
+            ? 'This project consists of Clean videos only. Please upload at least one non-Clean video to preview or publish.'
+            : 'This project does not have any units to preview.' }
         </p>
       );
     }

--- a/components/admin/Previews/ProjectPreview/ProjectPreviewContent/ProjectPreviewContent.js
+++ b/components/admin/Previews/ProjectPreview/ProjectPreviewContent/ProjectPreviewContent.js
@@ -203,7 +203,7 @@ class ProjectPreviewContent extends React.PureComponent {
 
   getDownloadItemInstructions = ( { editable } ) => (
     <p>
-      { `By downloading these ${editable ? 'editable' : ''}files, you agree to the` }
+      { `By downloading these${editable ? ' editable' : ''} files, you agree to the ` }
       <Link href="/about"><a>Terms of Use</a></Link>
       .
     </p>

--- a/components/admin/download/DownloadOtherFiles/DownloadOtherFiles.test.js
+++ b/components/admin/download/DownloadOtherFiles/DownloadOtherFiles.test.js
@@ -151,11 +151,12 @@ describe( '<DownloadOtherFiles />', () => {
 
     const downloadOther = wrapper.find( 'DownloadOtherFiles' );
     const items = downloadOther.find( 'Item' );
-    const { files } = noFilesMocks[0].result.data.project;
+    const { files, thumbnails } = noFilesMocks[0].result.data.project;
+    const allFiles = [...thumbnails, ...files];
     const msg = 'There are no other files available for download at this time';
 
     expect( downloadOther.exists() ).toEqual( true );
-    expect( items.length ).toEqual( files.length );
+    expect( items.length ).toEqual( allFiles.length );
     expect( downloadOther.contains( msg ) ).toEqual( true );
   } );
 
@@ -166,12 +167,13 @@ describe( '<DownloadOtherFiles />', () => {
     wrapper.update();
 
     const items = wrapper.find( 'DownloadItemContent' );
-    const { files } = mocks[0].result.data.project;
+    const { files, thumbnails } = mocks[0].result.data.project;
+    const allFiles = [...thumbnails, ...files];
     const s3Bucket = 'https://s3-url.com';
 
-    expect( items.length ).toEqual( files.length );
+    expect( items.length ).toEqual( allFiles.length );
     items.forEach( ( item, i ) => {
-      const { url: assetPath } = files[i];
+      const { url: assetPath } = allFiles[i];
 
       expect( item.prop( 'srcUrl' ) ).toEqual( `${s3Bucket}/${assetPath}` );
       expect( item.find( '.download-item' ).prop( 'href' ) ).toEqual( 'https://example.jpg' );
@@ -192,9 +194,10 @@ describe( '<DownloadOtherFiles />', () => {
 
     const downloadOtherFiles = wrapper.find( 'DownloadOtherFiles' );
     const previews = downloadOtherFiles.find( '.preview-text' );
-    const { files } = mocks[0].result.data.project;
+    const { files, thumbnails } = mocks[0].result.data.project;
+    const allFiles = [...thumbnails, ...files];
 
-    expect( previews.length ).toEqual( files.length );
+    expect( previews.length ).toEqual( allFiles.length );
     previews.forEach( preview => {
       expect( preview.exists() )
         .toEqual( downloadOtherFiles.prop( 'isPreview' ) );

--- a/components/admin/download/DownloadOtherFiles/__snapshots__/DownloadOtherFiles.test.js.snap
+++ b/components/admin/download/DownloadOtherFiles/__snapshots__/DownloadOtherFiles.test.js.snap
@@ -33,6 +33,28 @@ exports[`<DownloadOtherFiles /> renders final state without crashing 1`] = `
           },
         ],
         "id": "123",
+        "thumbnails": Array [
+          Object {
+            "filename": "thumbnail-1.jpg",
+            "filetype": "image/jpeg",
+            "id": "th765",
+            "language": Object {
+              "displayName": "English",
+              "id": "en23",
+            },
+            "url": "2019/06/123/thumbnail-1.jpg",
+          },
+          Object {
+            "filename": "thumbnail-2.jpg",
+            "filetype": "image/jpeg",
+            "id": "th865",
+            "language": Object {
+              "displayName": "English",
+              "id": "en23",
+            },
+            "url": "2019/06/123/thumbnail-2.jpg",
+          },
+        ],
       },
       "refetch": [Function],
       "startPolling": [Function],
@@ -49,7 +71,85 @@ exports[`<DownloadOtherFiles /> renders final state without crashing 1`] = `
   isPreview={false}
 >
   <DownloadItemContent
-    hoverText="Download English application/pdf file"
+    hoverText="Download English Thumbnail"
+    isAdminPreview={false}
+    key="fs_th765"
+    srcUrl="https://s3-url.com/2019/06/123/thumbnail-1.jpg"
+  >
+    <a
+      className="download-item"
+      download={true}
+      href="https://example.jpg"
+      key="https://example.jpg"
+      rel="noopener noreferrer"
+    >
+      <div
+        className="item-icon"
+      >
+        <img
+          alt="Download English Thumbnail"
+          src="downloadIconSVG"
+        />
+      </div>
+      <div
+        className="item-content"
+      >
+        <p
+          className="item-content__title"
+        >
+          <strong>
+            Download English Thumbnail
+          </strong>
+        </p>
+      </div>
+      <span
+        className="item-hover"
+      >
+        Download English Thumbnail
+      </span>
+    </a>
+  </DownloadItemContent>
+  <DownloadItemContent
+    hoverText="Download English Thumbnail"
+    isAdminPreview={false}
+    key="fs_th865"
+    srcUrl="https://s3-url.com/2019/06/123/thumbnail-2.jpg"
+  >
+    <a
+      className="download-item"
+      download={true}
+      href="https://example.jpg"
+      key="https://example.jpg"
+      rel="noopener noreferrer"
+    >
+      <div
+        className="item-icon"
+      >
+        <img
+          alt="Download English Thumbnail"
+          src="downloadIconSVG"
+        />
+      </div>
+      <div
+        className="item-content"
+      >
+        <p
+          className="item-content__title"
+        >
+          <strong>
+            Download English Thumbnail
+          </strong>
+        </p>
+      </div>
+      <span
+        className="item-hover"
+      >
+        Download English Thumbnail
+      </span>
+    </a>
+  </DownloadItemContent>
+  <DownloadItemContent
+    hoverText="Download \\"file-1.pdf\\" (Pdf)"
     isAdminPreview={false}
     key="fs_pdf89"
     srcUrl="https://s3-url.com/2019/06/123/file-1.pdf"
@@ -65,7 +165,7 @@ exports[`<DownloadOtherFiles /> renders final state without crashing 1`] = `
         className="item-icon"
       >
         <img
-          alt="Download English application/pdf file"
+          alt="Download \\"file-1.pdf\\" (Pdf)"
           src="downloadIconSVG"
         />
       </div>
@@ -76,19 +176,19 @@ exports[`<DownloadOtherFiles /> renders final state without crashing 1`] = `
           className="item-content__title"
         >
           <strong>
-            Download English application/pdf file
+            Download "file-1.pdf" (Pdf)
           </strong>
         </p>
       </div>
       <span
         className="item-hover"
       >
-        Download English application/pdf file
+        Download "file-1.pdf" (Pdf)
       </span>
     </a>
   </DownloadItemContent>
   <DownloadItemContent
-    hoverText="Download English audio/x-mpeg-3 file"
+    hoverText="Download \\"audio-1.mp3\\" (Mp3)"
     isAdminPreview={false}
     key="fs_au56"
     srcUrl="https://s3-url.com/2019/06/123/audio-1.mp3"
@@ -104,7 +204,7 @@ exports[`<DownloadOtherFiles /> renders final state without crashing 1`] = `
         className="item-icon"
       >
         <img
-          alt="Download English audio/x-mpeg-3 file"
+          alt="Download \\"audio-1.mp3\\" (Mp3)"
           src="downloadIconSVG"
         />
       </div>
@@ -115,14 +215,14 @@ exports[`<DownloadOtherFiles /> renders final state without crashing 1`] = `
           className="item-content__title"
         >
           <strong>
-            Download English audio/x-mpeg-3 file
+            Download "audio-1.mp3" (Mp3)
           </strong>
         </p>
       </div>
       <span
         className="item-hover"
       >
-        Download English audio/x-mpeg-3 file
+        Download "audio-1.mp3" (Mp3)
       </span>
     </a>
   </DownloadItemContent>

--- a/components/admin/download/DownloadOtherFiles/mocks.js
+++ b/components/admin/download/DownloadOtherFiles/mocks.js
@@ -3,14 +3,14 @@ import { VIDEO_PROJECT_PREVIEW_OTHER_FILES_QUERY } from './DownloadOtherFiles';
 export const props = {
   id: '123',
   instructions: 'Download Other File(s)',
-  isPreview: false
+  isPreview: false,
 };
 
 export const mocks = [
   {
     request: {
       query: VIDEO_PROJECT_PREVIEW_OTHER_FILES_QUERY,
-      variables: { id: props.id }
+      variables: { id: props.id },
     },
     result: {
       data: {
@@ -24,8 +24,8 @@ export const mocks = [
               url: `2019/06/${props.id}/file-1.pdf`,
               language: {
                 id: 'en23',
-                displayName: 'English'
-              }
+                displayName: 'English',
+              },
             },
             {
               id: 'au56',
@@ -34,37 +34,59 @@ export const mocks = [
               url: `2019/06/${props.id}/audio-1.mp3`,
               language: {
                 id: 'en23',
-                displayName: 'English'
-              }
-            }
-          ]
-        }
-      }
-    }
-  }
+                displayName: 'English',
+              },
+            },
+          ],
+          thumbnails: [
+            {
+              id: 'th765',
+              filename: 'thumbnail-1.jpg',
+              filetype: 'image/jpeg',
+              url: `2019/06/${props.id}/thumbnail-1.jpg`,
+              language: {
+                id: 'en23',
+                displayName: 'English',
+              },
+            },
+            {
+              id: 'th865',
+              filename: 'thumbnail-2.jpg',
+              filetype: 'image/jpeg',
+              url: `2019/06/${props.id}/thumbnail-2.jpg`,
+              language: {
+                id: 'en23',
+                displayName: 'English',
+              },
+            },
+          ],
+        },
+      },
+    },
+  },
 ];
 
 export const errorMocks = [
   {
     ...mocks[0],
     result: {
-      errors: [{ message: 'There was an error.' }]
-    }
-  }
+      errors: [{ message: 'There was an error.' }],
+    },
+  },
 ];
 
 export const nullProjectMocks = [
   {
     ...mocks[0],
-    result: { data: { project: null } }
-  }
+    result: { data: { project: null } },
+  },
 ];
 
 export const emptyProjectMocks = [
   {
     ...mocks[0],
-    result: { data: { project: {} } }
-  }
+    result: { data: { project: {} } },
+  },
 ];
 
 export const noFilesMocks = [
@@ -74,9 +96,10 @@ export const noFilesMocks = [
       data: {
         project: {
           ...mocks[0].result.data.project,
-          files: []
-        }
-      }
-    }
-  }
+          files: [],
+          thumbnails: [],
+        },
+      },
+    },
+  },
 ];

--- a/components/admin/download/DownloadVideo/DownloadVideo.js
+++ b/components/admin/download/DownloadVideo/DownloadVideo.js
@@ -41,11 +41,10 @@ const DownloadVideo = props => {
         <div className="item-content">
           <p className="item-content__title">
             <strong>
-              Download
-              { ` "${title}"` }
-              { ` for ${videoQuality}`}
+              { `Download "${title}" for ${videoQuality}` }
             </strong>
           </p>
+          <p className="item-content__meta">{ `${video.use.name} | ${video.videoBurnedInStatus === 'CLEAN' ? 'No subtitles' : 'Subtitles'}` }</p>
           <p className="item-content__meta">{ `File size: ${size.weight}` }</p>
           <p className="item-content__meta">{ `Dimensions: ${size.label}` }</p>
         </div>
@@ -54,9 +53,13 @@ const DownloadVideo = props => {
   };
 
   const renderFormItems = unit => {
-    // fetch all source videos with NO burned in captions and then sort by file size
-    const videos = unit.files.filter( video => video.videoBurnedInStatus === 'true' === burnedInCaptions );
-    const videosWithSizeProp = unit.files.filter( video => video.filesize );
+    // fetch all source videos by Clean vs. non-Clean and then sort by file size
+    const videos = unit.files.filter( video => {
+      const isClean = video.use.name === 'Clean';
+
+      return burnedInCaptions ? !isClean : isClean;
+    } );
+    const videosWithSizeProp = videos.filter( video => video.filesize );
 
     // only sort the videos if each video has a filesize prop for comparison
     if ( videosWithSizeProp.length === videos.length ) {

--- a/components/admin/download/DownloadVideo/__snapshots__/DownloadVideo.test.js.snap
+++ b/components/admin/download/DownloadVideo/__snapshots__/DownloadVideo.test.js.snap
@@ -1,10 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`<DownloadVideo /> renders without crashing 1`] = `
+exports[`<DownloadVideo />, if used for Clean videos in the "For Translations" tab renders without crashing 1`] = `
 <DownloadVideo
   burnedInCaptions={false}
   instructions="Download the video file in English"
-  isPreview={false}
+  isPreview={true}
   selectedLanguageUnit={
     Object {
       "__typename": "VideoUnit",
@@ -55,7 +55,7 @@ exports[`<DownloadVideo /> renders without crashing 1`] = `
             "id": "us31",
             "name": "Full Video",
           },
-          "videoBurnedInStatus": "CLEAN",
+          "videoBurnedInStatus": "SUBTITLED",
         },
         Object {
           "__typename": "VideoFile",
@@ -99,8 +99,8 @@ exports[`<DownloadVideo /> renders without crashing 1`] = `
           "url": "2019/06/123/video-file-2.mp4",
           "use": Object {
             "__typename": "VideoUse",
-            "id": "us31",
-            "name": "Full Video",
+            "id": "us32",
+            "name": "Clean",
           },
           "videoBurnedInStatus": "CLEAN",
         },
@@ -162,63 +162,12 @@ exports[`<DownloadVideo /> renders without crashing 1`] = `
   <div>
     <DownloadItemContent
       hoverText="Download for web"
-      isAdminPreview={false}
-      key="fs_un91-f19"
-      srcUrl="https://s3-url.com/2019/06/123/video-file-1.mp4"
-    >
-      <a
-        className="download-item"
-        download={true}
-        href="https://example.jpg"
-        key="https://example.jpg"
-        rel="noopener noreferrer"
-      >
-        <div
-          className="item-icon"
-        >
-          <img
-            alt="Download for web"
-            src="downloadIconSVG"
-          />
-        </div>
-        <div
-          className="item-content"
-        >
-          <p
-            className="item-content__title"
-          >
-            <strong>
-              Download
-               "test project title"
-               for web
-            </strong>
-          </p>
-          <p
-            className="item-content__meta"
-          >
-            File size: 631.9 MB
-          </p>
-          <p
-            className="item-content__meta"
-          >
-            Dimensions: 1920 x 1080
-          </p>
-        </div>
-        <span
-          className="item-hover"
-        >
-          Download for web
-        </span>
-      </a>
-    </DownloadItemContent>
-    <DownloadItemContent
-      hoverText="Download for web"
-      isAdminPreview={false}
+      isAdminPreview={true}
       key="fs_un91-f20"
       srcUrl="https://s3-url.com/2019/06/123/video-file-2.mp4"
     >
       <a
-        className="download-item"
+        className="download-item download-item--preview"
         download={true}
         href="https://example.jpg"
         key="https://example.jpg"
@@ -239,10 +188,13 @@ exports[`<DownloadVideo /> renders without crashing 1`] = `
             className="item-content__title"
           >
             <strong>
-              Download
-               "test project title"
-               for web
+              Download "test project title" for web
             </strong>
+          </p>
+          <p
+            className="item-content__meta"
+          >
+            Clean | No subtitles
           </p>
           <p
             className="item-content__meta"
@@ -259,6 +211,11 @@ exports[`<DownloadVideo /> renders without crashing 1`] = `
           className="item-hover"
         >
           Download for web
+          <span
+            className="preview-text"
+          >
+            The link will be active after publishing.
+          </span>
         </span>
       </a>
     </DownloadItemContent>

--- a/components/download/DownloadItem/DownloadItem.js
+++ b/components/download/DownloadItem/DownloadItem.js
@@ -11,12 +11,12 @@ const DownloadItem = ( { instructions, children } ) => (
 DownloadItem.propTypes = {
   children: PropTypes.oneOfType( [
     PropTypes.array,
-    PropTypes.object
+    PropTypes.object,
   ] ),
   instructions: PropTypes.oneOfType( [
     PropTypes.string,
-    PropTypes.object
-  ] )
+    PropTypes.object,
+  ] ),
 };
 
 export default DownloadItem;

--- a/components/download/DownloadItem/DownloadItemContent.scss
+++ b/components/download/DownloadItem/DownloadItemContent.scss
@@ -49,6 +49,7 @@
   }
 
   &__instructions {
+    max-width: 60ch;
     margin-bottom: 1em;    
     font-style: italic;
     font-size: 0.75rem;

--- a/lib/elastic/__tests__/parser.test.js
+++ b/lib/elastic/__tests__/parser.test.js
@@ -130,7 +130,7 @@ describe( 'normalizeItem', () => {
           expect( item[key] ).toEqual( supportFiles || [] );
           break;
         case 'units':
-          expect( item[key] ).toEqual( [video._source.unit[1]] );
+          expect( item[key] ).toEqual( video._source.unit );
           break;
         case 'thumbnail':
           expect( item[key] ).toEqual( thumbnail.medium.url );
@@ -153,7 +153,6 @@ describe( 'normalizeItem', () => {
     const {
       title, desc, categories, tags, supportFiles,
     } = unit[1];
-
     // keys for video type
     const keys = [
       'title',
@@ -178,20 +177,20 @@ describe( 'normalizeItem', () => {
         case 'description':
           expect( item[key] ).toEqual( desc );
           break;
-        case 'duration':
-          expect( item[key] ).toEqual( video._source.duration );
-          break;
         case 'categories':
           expect( item[key] ).toEqual( categories || [] );
           break;
         case 'tags':
           expect( item[key] ).toEqual( tags || [] );
           break;
+        case 'duration':
+          expect( item[key] ).toEqual( video._source.duration );
+          break;
         case 'supportFiles':
           expect( item[key] ).toEqual( supportFiles || [] );
           break;
         case 'units':
-          expect( item[key] ).toEqual( [video._source.unit[1]] );
+          expect( item[key] ).toEqual( video._source.unit );
           break;
         case 'thumbnail':
           expect( item[key] ).toEqual( thumbnail.medium.url );

--- a/lib/elastic/__tests__/parser.test.js
+++ b/lib/elastic/__tests__/parser.test.js
@@ -88,9 +88,10 @@ describe( 'normalizeItem', () => {
     const language = 'fr-fr';
     const item = normalizeItem( video, language );
     const languages = video._source.unit.map( u => u.language.locale );
+    const { thumbnail, unit } = video._source;
     const {
-      title, desc, categories, tags, supportFiles, source,
-    } = video._source.unit[3];
+      title, desc, categories, tags, supportFiles,
+    } = unit[1];
     // keys for video type
     const keys = [
       'title',
@@ -116,9 +117,6 @@ describe( 'normalizeItem', () => {
         case 'description':
           expect( item[key] ).toEqual( desc );
           break;
-        // case 'thumbnail':
-        //   expect( item[key] ).toEqual( source[0].stream.thumbnail );
-        //   break;
         case 'categories':
           expect( item[key] ).toEqual( categories || [] );
           break;
@@ -132,10 +130,13 @@ describe( 'normalizeItem', () => {
           expect( item[key] ).toEqual( supportFiles || [] );
           break;
         case 'units':
-          expect( item[key] ).toEqual( video._source.unit );
+          expect( item[key] ).toEqual( [video._source.unit[1]] );
+          break;
+        case 'thumbnail':
+          expect( item[key] ).toEqual( thumbnail.medium.url );
           break;
         case 'selectedLanguageUnit':
-          expect( item[key] ).toEqual( video._source.unit[3] );
+          expect( item[key] ).toEqual( video._source.unit[1] );
           break;
         default:
           break;
@@ -148,7 +149,11 @@ describe( 'normalizeItem', () => {
     const language = 'id-id';
     const item = normalizeItem( video, language );
     const languages = video._source.unit.map( u => u.language.locale );
-    const defaultThumb = 'thumbnailImage';
+    const { thumbnail, unit } = video._source;
+    const {
+      title, desc, categories, tags, supportFiles,
+    } = unit[1];
+
     // keys for video type
     const keys = [
       'title',
@@ -168,20 +173,31 @@ describe( 'normalizeItem', () => {
       expect( Object.keys( item ).includes( key ) ).toEqual( true );
       switch ( key ) {
         case 'title':
-          expect( item[key] ).toEqual( '[TITLE]' );
+          expect( item[key] ).toEqual( title );
           break;
         case 'description':
+          expect( item[key] ).toEqual( desc );
+          break;
         case 'duration':
-          expect( item[key] ).toEqual( '' );
+          expect( item[key] ).toEqual( video._source.duration );
           break;
         case 'categories':
+          expect( item[key] ).toEqual( categories || [] );
+          break;
         case 'tags':
-        case 'units':
+          expect( item[key] ).toEqual( tags || [] );
+          break;
         case 'supportFiles':
-          expect( item[key] ).toEqual( [] );
+          expect( item[key] ).toEqual( supportFiles || [] );
+          break;
+        case 'units':
+          expect( item[key] ).toEqual( [video._source.unit[1]] );
           break;
         case 'thumbnail':
-          expect( item[key] ).toEqual( defaultThumb );
+          expect( item[key] ).toEqual( thumbnail.medium.url );
+          break;
+        case 'selectedLanguageUnit':
+          expect( item[key] ).toEqual( video._source.unit[1] );
           break;
         default:
           break;

--- a/lib/elastic/mocks.js
+++ b/lib/elastic/mocks.js
@@ -177,94 +177,6 @@ export const video = {
       {
         transcript: {},
         srt: {
-          srcUrl: 'https://staticcdp.s3.amazonaws.com/2018/05/fd5914916f95b2c486ee72e4dfb3e938.srt',
-          md5: 'fd5914916f95b2c486ee72e4dfb3e938',
-        },
-        language: {
-          language_code: 'ar',
-          text_direction: 'rtl',
-          display_name: 'Arabic',
-          locale: 'ar',
-          native_name: 'العربية',
-        },
-        source: [
-          {
-            streamUrl: [
-              {
-                site: 'youtube',
-                url: 'https://youtu.be/W66BKd0XCsQ',
-              },
-            ],
-            duration: null,
-            filetype: '',
-            burnedInCaptions: 'true',
-            size: {
-              width: '1920',
-              bitrate: '15250925',
-              filesize: '173797630',
-              height: '1080',
-            },
-            stream: {
-              uid: '124ffcc8675a6d094b9e69c5aa85b233',
-              thumbnail: 'https://cloudflarestream.com/124ffcc8675a6d094b9e69c5aa85b233/thumbnails/thumb_5_0.png',
-              url: 'https://watch.cloudflarestream.com/124ffcc8675a6d094b9e69c5aa85b233',
-            },
-            video_quality: 'web',
-            downloadUrl: 'https://staticcdp.s3.amazonaws.com/2018/05/f6006f8f8ceab66955e55b518f652778.mp4',
-            md5: 'f6006f8f8ceab66955e55b518f652778',
-          },
-        ],
-        categories: [],
-        title: 'شراكات القهوة الأميركية',
-        desc: 'تحتاج شركات القهوة الكبيرة في الولايات المتحدة إلى حبوب البُن، ويحتاج صغار مزارعي البُن في جميع أنحاء العالم إلى سوق مستدام لمحصولهم. هذه المصالح المشتركة دفعت الوكالة الأميركية للتنمية الدولية إلى ربط شركات القهوة الأميركية مباشرة مع مزارعي البُن في جميع أنحاء العالم.\r\n',
-      },
-      {
-        transcript: {},
-        srt: {
-          srcUrl: 'https://staticcdp.s3.amazonaws.com/2018/05/bdfcd5999ec824b1b21ec60d926b2f8f.srt',
-          md5: 'bdfcd5999ec824b1b21ec60d926b2f8f',
-        },
-        language: {
-          language_code: 'zh-hans',
-          text_direction: 'ltr',
-          display_name: 'Chinese (Simplified)',
-          locale: 'zh-cn',
-          native_name: '简体中文',
-        },
-        source: [
-          {
-            streamUrl: [
-              {
-                site: 'youtube',
-                url: 'https://youtu.be/h2MFevzLlqQ',
-              },
-            ],
-            duration: null,
-            filetype: '',
-            burnedInCaptions: 'true',
-            size: {
-              width: '1920',
-              bitrate: '15270211',
-              filesize: '174017416',
-              height: '1080',
-            },
-            stream: {
-              uid: '0b14bbf4b7ea7987e3c161b60a2b7e97',
-              thumbnail: 'https://cloudflarestream.com/0b14bbf4b7ea7987e3c161b60a2b7e97/thumbnails/thumb_5_0.png',
-              url: 'https://watch.cloudflarestream.com/0b14bbf4b7ea7987e3c161b60a2b7e97',
-            },
-            video_quality: 'web',
-            downloadUrl: 'https://staticcdp.s3.amazonaws.com/2018/05/7b732b762b819d77b53920eecdb06f9c.mp4',
-            md5: '7b732b762b819d77b53920eecdb06f9c',
-          },
-        ],
-        categories: [],
-        title: '美国的咖啡伙伴关系',
-        desc: '美国大型咖啡公司需要咖啡豆。世界各地的小型农户需要为自己的产品寻找可持续的市场。共同的利益促使美国国际发展署协助美国咖啡公司与世界各地种植咖啡的农户取得直接联系。\r\n',
-      },
-      {
-        transcript: {},
-        srt: {
           srcUrl: 'https://staticcdp.s3.amazonaws.com/2018/05/7fa40a77c8b9eefec04e3b50bd6ebc46.srt',
           md5: '7fa40a77c8b9eefec04e3b50bd6ebc46',
         },
@@ -286,6 +198,7 @@ export const video = {
             duration: null,
             filetype: '',
             burnedInCaptions: 'false',
+            use: 'Clean',
             size: {
               width: '1920',
               bitrate: '15346707',
@@ -330,6 +243,7 @@ export const video = {
             duration: null,
             filetype: '',
             burnedInCaptions: 'true',
+            use: 'Full Video',
             size: {
               width: '1920',
               bitrate: '15259627',
@@ -349,134 +263,6 @@ export const video = {
         categories: [],
         title: 'Les partenariats dans la filière café aux États-Unis',
         desc: 'Les grandes entreprises caféières américaines ont besoin de grains de café, et les petits producteurs à travers le monde ont besoin d’un marché durable pour leurs produits. Ces intérêts communs ont incité l’Agence des États-Unis pour le développement international (USAID) à mettre les entreprises caféières américaines en contact direct avec les producteurs de café à travers le monde.',
-      },
-      {
-        transcript: {},
-        language: {
-          language_code: 'pt-br',
-          text_direction: 'ltr',
-          display_name: 'Portuguese (Brazil)',
-          locale: 'pt-br',
-          native_name: 'Português',
-        },
-        source: [
-          {
-            streamUrl: [
-              {
-                site: 'youtube',
-                url: 'https://youtu.be/YUy2PxWTRlw',
-              },
-            ],
-            duration: null,
-            filetype: '',
-            burnedInCaptions: 'true',
-            size: {
-              width: '1920',
-              bitrate: '15324441',
-              filesize: '174635418',
-              height: '1080',
-            },
-            stream: {
-              uid: '9a7f2efafa4aef4db9f5a481d33ac6f8',
-              thumbnail: 'https://cloudflarestream.com/9a7f2efafa4aef4db9f5a481d33ac6f8/thumbnails/thumb_5_0.png',
-              url: 'https://watch.cloudflarestream.com/9a7f2efafa4aef4db9f5a481d33ac6f8',
-            },
-            video_quality: 'web',
-            downloadUrl: 'https://staticcdp.s3.amazonaws.com/2018/05/25e7d0f6e6ba4faf879d06d2a58269f9.mp4',
-            md5: '25e7d0f6e6ba4faf879d06d2a58269f9',
-          },
-        ],
-        categories: [],
-        title: 'Café: parcerias nos EUA',
-        desc: 'As grandes empresas de café nos Estados Unidos precisam de grãos de café, e os pequenos cafeicultores do mundo precisam de um mercado sustentável para seus produtos. Esses interesses mútuos levaram a Agência dos Estados Unidos para o Desenvolvimento Internacional (Usaid) a conectar empresas de café dos EUA diretamente com cafeicultores ao redor do mundo.',
-      },
-      {
-        transcript: {},
-        srt: {
-          srcUrl: 'https://staticcdp.s3.amazonaws.com/2018/05/8bafa778cae480bacb45320e2e45d396.srt',
-          md5: '8bafa778cae480bacb45320e2e45d396',
-        },
-        language: {
-          language_code: 'ru',
-          text_direction: 'ltr',
-          display_name: 'Russian',
-          locale: 'ru-ru',
-          native_name: 'Русский',
-        },
-        source: [
-          {
-            streamUrl: [
-              {
-                site: 'youtube',
-                url: 'https://youtu.be/O4lFqqeeDdA',
-              },
-            ],
-            duration: null,
-            filetype: '',
-            burnedInCaptions: 'true',
-            size: {
-              width: '1920',
-              bitrate: '15362520',
-              filesize: '175069361',
-              height: '1080',
-            },
-            stream: {
-              uid: '613477c3dc16ae010059309c71f7a46a',
-              thumbnail: 'https://cloudflarestream.com/613477c3dc16ae010059309c71f7a46a/thumbnails/thumb_5_0.png',
-              url: 'https://watch.cloudflarestream.com/613477c3dc16ae010059309c71f7a46a',
-            },
-            video_quality: 'web',
-            downloadUrl: 'https://staticcdp.s3.amazonaws.com/2018/05/8cdc2fcda7ae9566abe28ef7cf9ccb9e.mp4',
-            md5: '8cdc2fcda7ae9566abe28ef7cf9ccb9e',
-          },
-        ],
-        categories: [],
-        title: 'Кофейные партнерства США',
-        desc: 'Крупным американским кофейным компаниям нужны кофе-бобы, а мелким кофейным фермерам по всему миру нужен устойчивый рынок для их продукта. Эти взаимные интересы побудили Агентство Соединенных Штатов по международному развитию (USAID) соединить кофейные компании США непосредственно с кофейными фермерами по всему миру.',
-      },
-      {
-        transcript: {},
-        srt: {
-          srcUrl: 'https://staticcdp.s3.amazonaws.com/2018/05/be0948bd9ed9e20a55df874d3c7d6f7b.srt',
-          md5: 'be0948bd9ed9e20a55df874d3c7d6f7b',
-        },
-        language: {
-          language_code: 'es',
-          text_direction: 'ltr',
-          display_name: 'Spanish',
-          locale: 'es-es',
-          native_name: 'Español',
-        },
-        source: [
-          {
-            streamUrl: [
-              {
-                site: 'youtube',
-                url: 'https://youtu.be/UUfrTmq8TKs',
-              },
-            ],
-            duration: null,
-            filetype: '',
-            burnedInCaptions: 'true',
-            size: {
-              width: '1920',
-              bitrate: '15370155',
-              filesize: '175156363',
-              height: '1080',
-            },
-            stream: {
-              uid: '21ea4b2bf79b7ae4ed47e62509bcc8db',
-              thumbnail: 'https://cloudflarestream.com/21ea4b2bf79b7ae4ed47e62509bcc8db/thumbnails/thumb_5_0.png',
-              url: 'https://watch.cloudflarestream.com/21ea4b2bf79b7ae4ed47e62509bcc8db',
-            },
-            video_quality: 'web',
-            downloadUrl: 'https://staticcdp.s3.amazonaws.com/2018/05/e639762a3b84e40d02f06b7bd12271ab.mp4',
-            md5: 'e639762a3b84e40d02f06b7bd12271ab',
-          },
-        ],
-        categories: [],
-        title: 'Asociaciones de EE. UU. con la industria cafetalera',
-        desc: 'Las grandes compañías cafeteras de Estados Unidos necesitan granos de café y los pequeños productores de café de todo el mundo necesitan un mercado sostenible para su producto. Estos intereses mutuos movilizaron a la Agencia de Estados Unidos para el Desarrollo Internacional (USAID) a poner en contacto directo a las empresas cafeteras de Estados Unidos con agroproductores de café de todo el mundo.',
       },
     ],
     thumbnail: {

--- a/lib/elastic/parser.js
+++ b/lib/elastic/parser.js
@@ -194,9 +194,17 @@ const populateVideoItem = ( source, language ) => {
   // const { key } = store.getState().language.currentLanguage;
   // const key = getLocaleKey( language );
   const units = source.unit.map( unit => {
-    if ( unit.thumbnail ) {
-      unit.thumbnail = getThumbnail( source, unit );
-    }
+    /**
+     * unit.thumbnail is null on the results page, which causes
+     * the thumbnail url to not be assigned. However, unit.thumbnail is
+     * an object, i.e., truthy, on the home and the project pages, which
+     * allows unit.thumbnail to be reassigned to the thumbnail url.
+     * So, there's no need for the unit.thumbnail condition check.
+     */
+    // if ( unit.thumbnail ) {
+    //   unit.thumbnail = getThumbnail( source, unit );
+    // }
+    unit.thumbnail = getThumbnail( source, unit );
 
     return unit;
   } );

--- a/lib/elastic/parser.js
+++ b/lib/elastic/parser.js
@@ -17,7 +17,7 @@ import logoGEC from 'static/images/logo_gec.svg';
 import logoVOA from 'static/images/logo_voa.png';
 import logoDOSSeal from 'static/images/dos_seal.svg';
 
-import { contentRegExp, maybeGetUrlToProdS3 } from 'lib/utils';
+import { contentRegExp, getCount, getUnitsWithNonCleanVideos, maybeGetUrlToProdS3 } from 'lib/utils';
 
 // import store from '../redux/store';
 
@@ -193,14 +193,23 @@ const getLocaleKey = () => 'en-us';
 const populateVideoItem = ( source, language ) => {
   // const { key } = store.getState().language.currentLanguage;
   // const key = getLocaleKey( language );
-  const units = source.unit.map( unit => {
+  const unitsWithNonCleanVideos = getUnitsWithNonCleanVideos( source.unit );
+
+  const units = unitsWithNonCleanVideos.map( unit => {
     if ( unit.thumbnail ) {
       unit.thumbnail = getThumbnail( source, unit );
     }
 
     return unit;
   } );
-  const languageUnit = units.find( unit => unit.language.locale.toLowerCase() === language.toLowerCase() );
+
+  const languageUnit = units.find( unit => {
+    if ( unit.language.locale.toLowerCase() === language.toLowerCase() ) {
+      return true;
+    }
+
+    return unit.language;
+  } );
 
   let thumbnail = null;
 

--- a/lib/elastic/parser.js
+++ b/lib/elastic/parser.js
@@ -17,7 +17,7 @@ import logoGEC from 'static/images/logo_gec.svg';
 import logoVOA from 'static/images/logo_voa.png';
 import logoDOSSeal from 'static/images/dos_seal.svg';
 
-import { contentRegExp, getCount, getUnitsWithNonCleanVideos, maybeGetUrlToProdS3 } from 'lib/utils';
+import { contentRegExp, getHasSomeNonCleanVideos, maybeGetUrlToProdS3 } from 'lib/utils';
 
 // import store from '../redux/store';
 
@@ -193,22 +193,18 @@ const getLocaleKey = () => 'en-us';
 const populateVideoItem = ( source, language ) => {
   // const { key } = store.getState().language.currentLanguage;
   // const key = getLocaleKey( language );
-  const unitsWithNonCleanVideos = getUnitsWithNonCleanVideos( source.unit );
-
-  const units = unitsWithNonCleanVideos.map( unit => {
+  const units = source.unit.map( unit => {
     if ( unit.thumbnail ) {
       unit.thumbnail = getThumbnail( source, unit );
     }
 
     return unit;
   } );
-
+  // const languageUnit = units.find( unit => unit.language.locale.toLowerCase() === language.toLowerCase() );
   const languageUnit = units.find( unit => {
-    if ( unit.language.locale.toLowerCase() === language.toLowerCase() ) {
-      return true;
-    }
+    const hasSomeNonClean = getHasSomeNonCleanVideos( unit );
 
-    return unit.language;
+    return hasSomeNonClean;
   } );
 
   let thumbnail = null;

--- a/lib/elastic/query.js
+++ b/lib/elastic/query.js
@@ -23,9 +23,13 @@ export const getAvailableLanguages = item => {
   if ( !item || !item.type ) return [];
   switch ( item.type ) {
     case 'video': {
-      const unitsWithNonCleanVideos = getUnitsWithNonCleanVideos( item.units );
+      const getUnitsWithOnlyCleanVideos = _units => _units.filter( u => u.source.every( file => file?.use === 'Clean' ) );
+      const unitsWithOnlyClean = getUnitsWithOnlyCleanVideos( item.units );
+      const unitsWithSomeNonClean = getUnitsWithNonCleanVideos( item.units );
+      const hasOnlyClean = getCount( unitsWithOnlyClean ) > 0;
+      const units = hasOnlyClean ? unitsWithSomeNonClean : item.units;
 
-      const langArr = unitsWithNonCleanVideos.reduce( ( langs, unit ) => {
+      const langArr = units.reduce( ( langs, unit ) => {
         if ( unit.source && unit.source.length ) {
           langs.push( {
             key: unit.language.locale,

--- a/lib/elastic/query.js
+++ b/lib/elastic/query.js
@@ -1,5 +1,5 @@
 import Bodybuilder from 'bodybuilder';
-import { maybeFixQuotes, escape, escapeRegExp } from '../utils';
+import { getCount, getUnitsWithNonCleanVideos, maybeFixQuotes, escape, escapeRegExp } from 'lib/utils';
 
 // TO DO: Create type objects where all type related tasks, vars are held
 // i.e. fields to search, parser, etc.
@@ -23,7 +23,9 @@ export const getAvailableLanguages = item => {
   if ( !item || !item.type ) return [];
   switch ( item.type ) {
     case 'video': {
-      const langArr = item.units.reduce( ( langs, unit ) => {
+      const unitsWithNonCleanVideos = getUnitsWithNonCleanVideos( item.units );
+
+      const langArr = unitsWithNonCleanVideos.reduce( ( langs, unit ) => {
         if ( unit.source && unit.source.length ) {
           langs.push( {
             key: unit.language.locale,

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -620,3 +620,28 @@ export const suppressActWarning = consoleError => {
     }
   } );
 };
+
+/**
+ * Determines whether a unit has at least one non-Clean use video
+ * @param {boolean}
+ */
+export const getHasSomeNonCleanVideos = unit => {
+  // unit.source for ES; unit.files for GraphQL
+  const array = unit.source || unit.files || [];
+
+  const hasSomeNonClean = getCount( array ) && array.some( file => {
+    // ES returns file.use; GraphQL returns file.use.name
+    const value = typeof file.use === 'string' ? file?.use : file?.use?.name;
+
+    return value !== 'Clean';
+  } );
+
+  return hasSomeNonClean;
+};
+
+/**
+ * Filters video units for those with at least one non-Clean use video
+ * @param {array} units
+ * @returns {array}
+ */
+export const getUnitsWithNonCleanVideos = units => units.filter( getHasSomeNonCleanVideos );


### PR DESCRIPTION
* Includes CDP-2145: Adds a new "For Translation" tab to the video preview download modal that lists "Clean" videos for download (tab is displayed for logged in users only)
* Removes English from the language dropdown in the video preview modal and commons page when the English unit consists of *only* "Clean" use videos
* Per mockup, adds an "Other" tab to the video preview download popup on commons and publisher; This tab includes thumbnails and other files (i.e., non-caption files)
* Per mockup, adjusts the download instructions text for each tab
* Fixes a bug where a video unit's thumbnail was not being assigned to `unit.thumbnail` on the results page; This was preventing a video unit's thumbnails from being listed in its download popup.
