### PR TITLE
CDP-2205: Display DOS seal for regional media hubs logo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,11 +16,13 @@ _This sections lists changes committed since most recent release_
 
 **Added:**
 - A reminder to the Home page to prompt the user to login to see internal content
+- 'Regional Media Hubs' to graphic details form source dropdown and dashboard graphic queries
 
 **Changed:**
 - Package 'Browse All' link sorts packages by created date
 - Lists of Documents within a Package are displayed in the order of releases, guidances, transcripts
 - Delete button is disabled for published graphic projects
+- Display DoS logo and 'Regional Media Hubs' as the source in the graphics card and preview modal
 
 
 # [5.0.0](https://github.com/IIP-Design/content-commons-client/compare/v4.2.0...5.0.0)(2020-07-10)

--- a/components/GraphicProject/GraphicProject.js
+++ b/components/GraphicProject/GraphicProject.js
@@ -301,7 +301,7 @@ const GraphicProject = ( {
       <ModalPostMeta
         type={ projectType }
         logo={ displayDOSLogo( owner ) }
-        source={ owner === 'GPA Design & Editorial' ? owner : '' }
+        source={ owner !== 'ShareAmerica' ? owner : '' }
         datePublished={ published }
         textDirection={ selectedUnitLanguage.text_direction }
       />

--- a/components/admin/ProjectDetailsForm/GraphicProjectDetailsFormContainer/GraphicProjectDetailsFormContainer.js
+++ b/components/admin/ProjectDetailsForm/GraphicProjectDetailsFormContainer/GraphicProjectDetailsFormContainer.js
@@ -122,7 +122,11 @@ const GraphicProjectDetailsFormContainer = props => {
         required: false,
         variables: {
           where: {
-            name_in: ['GPA Design & Editorial', 'ShareAmerica'],
+            name_in: [
+              'GPA Design & Editorial',
+              'Regional Media Hubs',
+              'ShareAmerica',
+            ],
           },
         },
       },

--- a/components/admin/ProjectDetailsForm/GraphicProjectDetailsFormContainer/GraphicProjectDetailsFormContainer.test.js
+++ b/components/admin/ProjectDetailsForm/GraphicProjectDetailsFormContainer/GraphicProjectDetailsFormContainer.test.js
@@ -49,7 +49,11 @@ const config = {
     required: false,
     variables: {
       where: {
-        name_in: ['GPA Design & Editorial', 'ShareAmerica'],
+        name_in: [
+          'GPA Design & Editorial',
+          'Regional Media Hubs',
+          'ShareAmerica',
+        ],
       },
     },
   },

--- a/lib/graphql/queries/graphic.js
+++ b/lib/graphql/queries/graphic.js
@@ -257,7 +257,7 @@ export const TEAM_GRAPHIC_PROJECTS_QUERY = gql`
       orderBy: $orderBy
       where: {
         AND: [
-          { team: { name_in: [$team, "ShareAmerica"] } }
+          { team: { name_in: [$team, "Regional Media Hubs", "ShareAmerica"] } }
           {
             OR: [
               { title_contains: $searchTerm }
@@ -293,7 +293,7 @@ export const TEAM_GRAPHIC_PROJECTS_COUNT_QUERY = gql`
     graphicProjects(
       where: {
         AND: [
-          { team: { name_in: [$team, "ShareAmerica"] } }
+          { team: { name_in: [$team, "Regional Media Hubs", "ShareAmerica"] } }
           {
             OR: [
               { title_contains: $searchTerm }

--- a/lib/sourceLogoUtils.js
+++ b/lib/sourceLogoUtils.js
@@ -5,6 +5,7 @@ const dosOwners = [
   'GPA Video',
   'GPA Media Strategy',
   'GPA Design & Editorial',
+  'Regional Media Hubs',
   'U.S. Missions',
 ];
 


### PR DESCRIPTION
* Includes CDP-2201: As a publisher on the Design & Editorial team, I want to be able to select Regional Media Hubs as a Source
* Adds "Regional Media Hubs" to the graphic details form source dropdown and to the dashboard graphic queries
* Displays the DoS logo and "Regional Media Hubs" as the source in the graphics card and preview modal