### PR TITLE
CDP-2213 - Make team a where clause

### DIFF
--- a/components/ScrollableTableWithMenu/ScrollableTableWithMenu.js
+++ b/components/ScrollableTableWithMenu/ScrollableTableWithMenu.js
@@ -44,8 +44,16 @@ const ScrollableTableWithMenu = ( { columnMenu, persistentTableHeaders, projectT
   const contentQuery = state.queries.content;
   const countQuery = state.queries.count;
 
+  // Get teams to include in query for a specific content type
+  // This is rather odd and the connection between teams and content
+  // types should be more fully thought out and absracted
+  const teams
+    = team.name === 'GPA Design & Editorial'
+      ? `${team.name}|Regional Media Hubs|ShareAmerica`
+      : team.name;
+
   // Set GraphQL query variables
-  const variables = { team: team.name, searchTerm };
+  const variables = { team: { name_in: teams.split( '|' ) }, searchTerm };
   const bodyPaginationVars = { first: itemsPerPage, orderBy, skip };
   const paginationVars = { first: itemsPerPage, skip };
 

--- a/lib/graphql/queries/graphic.js
+++ b/lib/graphql/queries/graphic.js
@@ -245,7 +245,7 @@ export const GRAPHIC_PROJECT_IMAGE_FILES_QUERY = gql`
 
 export const TEAM_GRAPHIC_PROJECTS_QUERY = gql`
   query TeamGraphicProjectsQuery(
-    $team: String!
+    $team: TeamWhereInput!
     $searchTerm: String
     $first: Int
     $skip: Int
@@ -257,7 +257,7 @@ export const TEAM_GRAPHIC_PROJECTS_QUERY = gql`
       orderBy: $orderBy
       where: {
         AND: [
-          { team: { name_in: [$team, "Regional Media Hubs", "ShareAmerica"] } }
+          { team: $team }
           {
             OR: [
               { title_contains: $searchTerm }
@@ -289,11 +289,11 @@ export const TEAM_GRAPHIC_PROJECTS_QUERY = gql`
 `;
 
 export const TEAM_GRAPHIC_PROJECTS_COUNT_QUERY = gql`
-  query GraphicProjectsCountByTeam($team: String!, $searchTerm: String) {
+  query GraphicProjectsCountByTeam($team: TeamWhereInput!, $searchTerm: String) {
     graphicProjects(
       where: {
         AND: [
-          { team: { name_in: [$team, "Regional Media Hubs", "ShareAmerica"] } }
+          { team: $team }
           {
             OR: [
               { title_contains: $searchTerm }

--- a/lib/graphql/queries/package.js
+++ b/lib/graphql/queries/package.js
@@ -174,7 +174,7 @@ export const PACKAGE_FILES_QUERY = gql`
 
 export const TEAM_PACKAGES_QUERY = gql`
   query TeamPackagesQuery(
-    $team: String!,
+    $team: TeamWhereInput!,
     $searchTerm: String,
     $first: Int,
     $skip: Int,
@@ -186,7 +186,7 @@ export const TEAM_PACKAGES_QUERY = gql`
       orderBy: $orderBy,
       where: {
         AND: [
-          { team: { name: $team } },
+          { team: $team  },
           {
             OR: [
               { title_contains: $searchTerm },
@@ -227,11 +227,11 @@ export const PACKAGES_META_QUERY = gql`
 `;
 
 export const TEAM_PACKAGES_COUNT_QUERY = gql`
-  query PackagesCountByTeam( $team: String!, $searchTerm: String ) {
+  query PackagesCountByTeam( $team: TeamWhereInput!, $searchTerm: String ) {
     packages(
       where: {
         AND: [
-          { team: { name: $team } },
+          { team: $team },
           {
             OR: [
               { title_contains: $searchTerm },

--- a/lib/graphql/queries/video.js
+++ b/lib/graphql/queries/video.js
@@ -340,7 +340,7 @@ export const VIDEO_PROJECT_QUERY = gql`
 
 export const TEAM_VIDEO_PROJECTS_QUERY = gql`
   query VideoProjectsByTeam(
-    $team: String!,
+    $team: TeamWhereInput!,
     $searchTerm: String,
     $first: Int,
     $skip: Int,
@@ -352,7 +352,7 @@ export const TEAM_VIDEO_PROJECTS_QUERY = gql`
       orderBy: $orderBy,
       where: {
         AND: [
-          { team: { name: $team } },
+          { team:  $team },
           {
             OR: [
               { projectTitle_contains: $searchTerm },
@@ -414,11 +414,11 @@ export const TEAM_VIDEO_PROJECTS_QUERY = gql`
 `;
 
 export const TEAM_VIDEO_PROJECTS_COUNT_QUERY = gql`
-  query VideoProjectsCountByTeam( $team: String!, $searchTerm: String ) {
+  query VideoProjectsCountByTeam( $team: TeamWhereInput!, $searchTerm: String ) {
     videoProjects(
       where: {
         AND: [
-          { team: { name: $team } },
+          { team: $team },
           {
             OR: [
               { projectTitle_contains: $searchTerm },


### PR DESCRIPTION
Made the `team` parameter in the Dashboard Team queries a `TeamWhereInput` type to configure what content from different teams a specific team can see.  For example, the GPA Design & Editorial team can see its own content plus that of ShareAmerica and Regional Hubs while the U.S. Missions team can see only the content it creates.

Updated the Graphic, Video and Package queries.

