### PR TITLE
CDP-2146: Remove Transcripts tab from video download popup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ _This sections lists changes committed since most recent release_
 - 'GPA Editorial & Design' team name to 'GPA Design & Editorial'
 - Include thumbnails in the 'Other' tab in the video download popup
 - Download instructions text to match mockup changes
+- Remove Transitions tab in the video download popup on Commons
 
 **Fixed:**
 - Bug where a video unit's thumbnail was not being assigned to `unit.thumbnail` on the results page; This was preventing a video unit's thumbnails from being listed in its download popup.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ _This sections lists changes committed since most recent release_
 - 'GPA Editorial & Design' team name to 'GPA Design & Editorial'
 - Include thumbnails in the 'Other' tab in the video download popup
 - Download instructions text to match mockup changes
-- Remove Translations tab in the video download popup on Commons
+- Remove Transcripts tab in the video download popup on Commons
 
 **Fixed:**
 - Bug where a video unit's thumbnail was not being assigned to `unit.thumbnail` on the results page; This was preventing a video unit's thumbnails from being listed in its download popup.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ _This sections lists changes committed since most recent release_
 - 'GPA Editorial & Design' team name to 'GPA Design & Editorial'
 - Include thumbnails in the 'Other' tab in the video download popup
 - Download instructions text to match mockup changes
-- Remove Transitions tab in the video download popup on Commons
+- Remove Translations tab in the video download popup on Commons
 
 **Fixed:**
 - Bug where a video unit's thumbnail was not being assigned to `unit.thumbnail` on the results page; This was preventing a video unit's thumbnails from being listed in its download popup.

--- a/components/Video/Video.js
+++ b/components/Video/Video.js
@@ -21,7 +21,6 @@ import TabLayout from 'components/TabLayout/TabLayout';
 
 import DownloadVideo from './Download/DownloadVideo';
 import DownloadCaption from './Download/DownloadCaption';
-import DownloadTranscript from './Download/DownloadTranscript';
 import DownloadThumbnailsAndOtherFiles from './Download/DownloadThumbnailsAndOtherFiles';
 import DownloadHelp from './Download/DownloadHelp';
 import Share from '../Share/Share';
@@ -195,16 +194,6 @@ const Video = ( { item, router, isAdminPreview = false } ) => {
             selectedLanguageUnit={ unit }
             item={ item }
           />
-        </DownloadItem>
-      ),
-    },
-    {
-      title: 'Transcript',
-      content: (
-        <DownloadItem
-          instructions="Download Transcripts"
-        >
-          <DownloadTranscript item={ item } />
         </DownloadItem>
       ),
     },

--- a/components/Video/Video.test.js
+++ b/components/Video/Video.test.js
@@ -157,7 +157,7 @@ describe( '<Video />, for a user not logged in', () => {
     const tabLayout = mount( popover.prop( 'children' ) );
     const { tabs } = tabLayout.props();
     const tabTitles = [
-      'Video Files', 'Caption Files', 'Transcript', 'Other', 'Help',
+      'Video Files', 'Caption Files', 'Other', 'Help',
     ];
 
     expect( tabs.length ).toEqual( tabTitles.length );


### PR DESCRIPTION
* Removes the Transcripts tab from the video download popup on Commons