### PR TITLE
Video publish changes fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,9 +22,14 @@ _This sections lists changes committed since most recent release_
 - Include thumbnails in the 'Other' tab in the video download popup
 - Download instructions text to match mockup changes
 - Remove Transcripts tab in the video download popup on Commons
+- Disable the Publish Changes button on the video review screen if there are *only* 'Clean' use videos and the project has already been published
+- Adjust publish message on the video review screen to instruct the user to upload at least one non-clean video before publishing changes
 
 **Fixed:**
 - Bug where a video unit's thumbnail was not being assigned to `unit.thumbnail` on the results page; This was preventing a video unit's thumbnails from being listed in its download popup.
+- Bug where deleting a video file from a published video's details page would not display the Publish Changes button. Fixed by calling the `updateVideoProject` mutation and passing the `projectTile` as the updated data when a video file is removed.
+- Bug where changing a video file's language would not display the Publish Changes button. Fixed by calling the `updateVideoProject` mutation and passing the `projectTile` as the updated data when a video file's language is changed.
+- Bug where changing a video file's type would not display the Publish Changes button. Fixed by calling the `updateVideoProject` mutation and passing the `projectTile` as the updated data when a video file's dropdown value is changed.
 
 
 # [5.1.1](https://github.com/IIP-Design/content-commons-client/compare/v5.1.0...5.1.1)(2020-07-29)

--- a/components/admin/ProjectEdit/EditVideoModal/ModalForms/FileDataForm/FileDataForm.js
+++ b/components/admin/ProjectEdit/EditVideoModal/ModalForms/FileDataForm/FileDataForm.js
@@ -24,6 +24,7 @@ import { formatBytes, formatDate, secondsToHMS } from 'lib/utils';
 
 // eslint-disable-next-line import/no-cycle
 import { VIDEO_UNIT_QUERY } from 'components/admin/ProjectEdit/EditVideoModal/ModalSections/FileSection/FileSection';
+import { UPDATE_VIDEO_PROJECT_MUTATION } from 'lib/graphql/queries/video';
 import {
   VIDEO_PROJECT_QUERY, VIDEO_FILE_QUERY, VIDEO_FILE_LANG_MUTATION, VIDEO_UNIT_CONNECT_FILE_MUTATION,
   VIDEO_UNIT_DISCONNECT_FILE_MUTATION, VIDEO_FILE_SUBTITLES_MUTATION, VIDEO_FILE_USE_MUTATION,
@@ -44,6 +45,7 @@ const FileDataForm = ( {
   streamCreateVideoFileMutation,
   streamDeleteVideoFileMutation,
   streamUpdateVideoFileMutation,
+  updateVideoProjectMutation,
   useVideoFileMutation,
   values,
   videoBurnedInStatusVideoFileMutation,
@@ -273,6 +275,21 @@ const FileDataForm = ( {
             data: { unit: cachedData.unit },
           } );
 
+          const cachedProjectData = cache.readQuery( {
+            query: VIDEO_PROJECT_QUERY,
+            variables: { id: selectedProject },
+          } );
+
+          // update project to trigger display of Publish Changes button
+          updateVideoProjectMutation( {
+            variables: {
+              data: {
+                projectTitle: cachedProjectData.project.projectTitle,
+              },
+              where: { id: selectedProject },
+            },
+          } );
+
           console.log( `Deleted video: ${selectedFile}` );
 
           const newSelectedFile = cachedData.unit.files && cachedData.unit.files[0] && cachedData.unit.files[0].id
@@ -428,6 +445,7 @@ FileDataForm.propTypes = {
   streamCreateVideoFileMutation: propTypes.func,
   streamDeleteVideoFileMutation: propTypes.func,
   streamUpdateVideoFileMutation: propTypes.func,
+  updateVideoProjectMutation: propTypes.func,
   useVideoFileMutation: propTypes.func,
   values: propTypes.object,
   videoBurnedInStatusVideoFileMutation: propTypes.func,
@@ -447,6 +465,7 @@ export default compose(
       variables: { displayName: 'English' },
     } ),
   } ),
+  graphql( UPDATE_VIDEO_PROJECT_MUTATION, { name: 'updateVideoProjectMutation' } ),
   graphql( VIDEO_FILE_DELETE_MUTATION, { name: 'deleteVideoFileMutation' } ),
   graphql( VIDEO_FILE_DELETE_STREAM_MUTATION, { name: 'streamDeleteVideoFileMutation' } ),
   graphql( VIDEO_FILE_UPDATE_STREAM_MUTATION, { name: 'streamUpdateVideoFileMutation' } ),

--- a/components/admin/ProjectEdit/EditVideoModal/ModalForms/FileDataForm/FileDataForm.js
+++ b/components/admin/ProjectEdit/EditVideoModal/ModalForms/FileDataForm/FileDataForm.js
@@ -77,6 +77,15 @@ const FileDataForm = ( {
     startTimeout();
   };
 
+  const updateVideoProject = projectTitle => (
+    updateVideoProjectMutation( {
+      variables: {
+        data: { projectTitle },
+        where: { id: selectedProject },
+      },
+    } )
+  );
+
   const changeLanguage = ( value, id ) => {
     // Get array of units and the language they are in
     const unitsByLang = units.map( unit => ( { unitId: unit.id, langId: unit.language.id } ) );
@@ -109,6 +118,14 @@ const FileDataForm = ( {
                 query: VIDEO_UNIT_QUERY,
                 data: { unit: cachedData.unit },
               } );
+
+              const cachedProjectData = cache.readQuery( {
+                query: VIDEO_PROJECT_QUERY,
+                variables: { id: selectedProject },
+              } );
+
+              // update project to trigger display of Publish Changes button
+              updateVideoProject( cachedProjectData.project.projectTitle );
             } catch ( error ) {
               console.log( error );
             }
@@ -281,14 +298,7 @@ const FileDataForm = ( {
           } );
 
           // update project to trigger display of Publish Changes button
-          updateVideoProjectMutation( {
-            variables: {
-              data: {
-                projectTitle: cachedProjectData.project.projectTitle,
-              },
-              where: { id: selectedProject },
-            },
-          } );
+          updateVideoProject( cachedProjectData.project.projectTitle );
 
           console.log( `Deleted video: ${selectedFile}` );
 

--- a/components/admin/ProjectEdit/EditVideoModal/ModalForms/FileDataForm/FileDataForm.js
+++ b/components/admin/ProjectEdit/EditVideoModal/ModalForms/FileDataForm/FileDataForm.js
@@ -208,6 +208,14 @@ const FileDataForm = ( {
             query: VIDEO_FILE_QUERY,
             data: { file: cachedData.file },
           } );
+
+          const cachedProjectData = cache.readQuery( {
+            query: VIDEO_PROJECT_QUERY,
+            variables: { id: selectedProject },
+          } );
+
+          // update project to trigger display of Publish Changes button
+          updateVideoProject( cachedProjectData.project.projectTitle );
         } catch ( error ) {
           console.log( error );
         }

--- a/components/admin/ProjectEdit/EditVideoModal/ModalForms/FileDataForm/FileDataFormQueries.js
+++ b/components/admin/ProjectEdit/EditVideoModal/ModalForms/FileDataForm/FileDataFormQueries.js
@@ -4,6 +4,7 @@ export const VIDEO_PROJECT_QUERY = gql`
   query VIDEO_PROJECT_QUERY( $id: ID! ) {
     project: videoProject( id: $id ) {
       id
+      projectTitle
       units {
         id
         language {

--- a/components/admin/ProjectEdit/EditVideoModal/ModalForms/FileDataForm/mocks.js
+++ b/components/admin/ProjectEdit/EditVideoModal/ModalForms/FileDataForm/mocks.js
@@ -32,6 +32,7 @@ const mocks = [
       data: {
         project: {
           id: 'ckcoositc0biv0720dwlj4l0g',
+          projectTitle: 'the project title',
           units: [
             {
               id: 'ckcoospdp0bjc07207x6j8xhw',

--- a/components/admin/ProjectReview/VideoReview/VideoReview.js
+++ b/components/admin/ProjectReview/VideoReview/VideoReview.js
@@ -162,7 +162,13 @@ const VideoReview = props => {
   };
 
   const getPublishMessage = () => {
+    const requireNonCleanMsg = 'Please upload at least one non-Clean video to publish';
+
     if ( data?.project?.status === 'PUBLISHED' ) {
+      if ( isDirty && disablePublishBtn ) {
+        return `${requireNonCleanMsg} your changes.`;
+      }
+
       if ( isDirty ) {
         return 'It looks like you made changes to your project. Do you want to publish changes?';
       }
@@ -171,7 +177,7 @@ const VideoReview = props => {
     }
 
     if ( disablePublishBtn ) {
-      return 'Please upload at least one non-Clean video to publish.';
+      return `${requireNonCleanMsg}.`;
     }
 
     return 'Your project looks great! Are you ready to Publish?';

--- a/components/admin/ProjectReview/VideoReview/VideoReview.js
+++ b/components/admin/ProjectReview/VideoReview/VideoReview.js
@@ -234,7 +234,7 @@ const VideoReview = props => {
         ) : (
           <Fragment>
             { isDirty && (
-              <Button className={ setButtonState( 'edit' ) } onClick={ handlePublish }>
+              <Button className={ setButtonState( 'edit' ) } onClick={ handlePublish } disabled={ disablePublishBtn }>
                 Publish Changes
               </Button>
             ) }
@@ -280,7 +280,7 @@ const VideoReview = props => {
 
         { /* Project is published but changes have been made that have not been published */ }
         { isPublished && isDirty && (
-          <Button className="project_button project_button--edit" onClick={ handlePublish }>
+          <Button className="project_button project_button--edit" onClick={ handlePublish } disabled={ disablePublishBtn }>
             Publish Changes
           </Button>
         ) }


### PR DESCRIPTION
* Fixes a bug where deleting a video file from a published video's details page would not display the Publish Changes button. Fixed by calling the `updateVideoProject` mutation and passing the `projectTile` as the updated data when a video file is removed.
* Fixes a bug where changing a video file's language would not display the Publish Changes button. Fixed by calling the `updateVideoProject` mutation and passing the `projectTile` as the updated data when a video file's language is changed.
* Fixes a bug where changing a video file's type would not display the Publish Changes button. Fixed by calling the `updateVideoProject` mutation and passing the `projectTile` as the updated data when a video file's dropdown value is changed.
* Disables the Publish Changes button on the video review page when there are *only* 'Clean' use videos and the project has already been published.
* Adjusts the publish message on the video review page to instruct the user to upload at least one non-clean use video before publish changes to an already published project.
* Updates mock test data.