### PR TITLE
CDP-2217: Add skip to content link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ _This sections lists changes committed since most recent release_
 - `DownloadThumbnailsAndOtherFiles` component
 - Internal option to visibility dropdown on video details project form
 - 'INTERNAL USE ONLY' display on video result card and project if project is internal
+- Skip to content link for improved accessibility
 
 **Changed:**
 - Remove English from the language dropdown in the video preview modal and commons page when the English unit consists of *only* 'Clean' use videos
@@ -22,6 +23,7 @@ _This sections lists changes committed since most recent release_
 - Include thumbnails in the 'Other' tab in the video download popup
 - Download instructions text to match mockup changes
 - Remove Transcripts tab in the video download popup on Commons
+- Default link color and hover styling for improved accessibility
 
 **Fixed:**
 - Bug where a video unit's thumbnail was not being assigned to `unit.thumbnail` on the results page; This was preventing a video unit's thumbnails from being listed in its download popup.

--- a/components/Page.js
+++ b/components/Page.js
@@ -26,7 +26,7 @@ const Page = ( { children, router } ) => {
     <div style={ { position: 'relative', minHeight: '100vh' } }>
       <Meta title={ title } />
       <Header />
-      <main className={ bodyCls }>
+      <main id="content" className={ bodyCls }>
         { children }
       </main>
       <Footer />

--- a/components/PageTypes/ContentPage/ContentPage.js
+++ b/components/PageTypes/ContentPage/ContentPage.js
@@ -4,9 +4,9 @@ import PropTypes from 'prop-types';
 import PageMeta from 'components/Meta/PageMeta';
 
 const style = {
-  page: {
-    marginTop: '90px',
-  },
+  // page: {
+  //   marginTop: '90px',
+  // },
   paragraph: {
     fontSize: '2em',
     fontWeight: '700',
@@ -16,7 +16,7 @@ const style = {
 const ContentPage = ( { children, item, url } ) => {
   if ( !item ) {
     return (
-      <section className="max_width_1200" style={ style.page }>
+      <section className="max_width_1200">
         <p style={ style.paragraph }>Content Unavailable</p>
       </section>
     );
@@ -25,7 +25,7 @@ const ContentPage = ( { children, item, url } ) => {
   return (
     <Fragment>
       <PageMeta item={ item } url={ url } />
-      <section className="max_width_1200" style={ style.page }>
+      <section className="max_width_1200">
         { children }
       </section>
     </Fragment>

--- a/components/admin/ProjectEdit/GraphicEdit/GraphicEdit.js
+++ b/components/admin/ProjectEdit/GraphicEdit/GraphicEdit.js
@@ -701,7 +701,7 @@ const GraphicEdit = ( { id } ) => {
       {/* Form data saved notification */}
       <Notification
         el="p"
-        customStyles={ centeredStyles }
+        customStyles={ { ...centeredStyles, top: '8em' } }
         show={ showNotification }
         msg={ notificationMessage }
       />

--- a/components/admin/ProjectEdit/GraphicEdit/GraphicEdit.test.js
+++ b/components/admin/ProjectEdit/GraphicEdit/GraphicEdit.test.js
@@ -189,7 +189,7 @@ describe( '<GraphicEdit />, when there is an existing DRAFT graphic project', ()
       el: 'p',
       customStyles: {
         position: 'absolute',
-        top: '1em',
+        top: '8em',
         left: '50%',
         transform: 'translateX(-50%)',
       },
@@ -394,7 +394,7 @@ describe( '<GraphicEdit />, when there is an existing PUBLISHED graphic project'
       el: 'p',
       customStyles: {
         position: 'absolute',
-        top: '1em',
+        top: '8em',
         left: '50%',
         transform: 'translateX(-50%)',
       },
@@ -565,7 +565,7 @@ describe( '<GraphicEdit />, when there is no props.id and local files have been 
       el: 'p',
       customStyles: {
         position: 'absolute',
-        top: '1em',
+        top: '8em',
         left: '50%',
         transform: 'translateX(-50%)',
       },

--- a/components/admin/ProjectEdit/VideoEdit/VideoEdit.js
+++ b/components/admin/ProjectEdit/VideoEdit/VideoEdit.js
@@ -284,7 +284,7 @@ const VideoEdit = props => {
       {/* Form data saved notification */}
       <Notification
         el="p"
-        customStyles={ centeredStyles }
+        customStyles={ { ...centeredStyles, top: '8em' } }
         show={ showNotification }
         msg={ notificationMessage }
       />

--- a/components/download/DownloadItem/DownloadItemContent.scss
+++ b/components/download/DownloadItem/DownloadItemContent.scss
@@ -19,6 +19,7 @@
   }
 
   &:hover {
+    text-decoration: none !important;
 
     .item-hover,
     &:after {

--- a/components/menus/menu.scss
+++ b/components/menus/menu.scss
@@ -83,6 +83,7 @@
 
     &:hover {
       color: $light-blue;
+      text-decoration: none !important;
     }
 
     &--margin {

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -30,6 +30,7 @@ class MyDocument extends Document {
               title="Google Analytics"
             />
           </noscript>
+          <a className="skip-to-content" href="#content">Skip to main content</a>
           <Main />
           <NextScript />
         </body>

--- a/styles/styles.scss
+++ b/styles/styles.scss
@@ -25,6 +25,10 @@ body {
 
 html {
   font-size: $font-size;
+
+  @media screen and (prefers-reduced-motion: no-preference) {
+    scroll-behavior: smooth;
+  }
 }
 
 body {
@@ -81,11 +85,39 @@ a {
   }
 }
 
+.skip-to-content {
+  position: absolute;
+  top: 0;
+  z-index: 500; // place above the header
+  padding-left: 0.25rem;
+  padding-right: 0.25rem;
+  color: $light-blue;
+  font-size: 0.89rem;
+  font-weight: 700;
+  line-height: 1.5;
+  background-color: #fff;
+  transform: translateY(-100%);
+  transition: transform 0.1s linear;
+}
+
+.skip-to-content:focus {
+  transform: translateY(0%);
+}
+
 main {
   padding-bottom: 560px; // height of footer plus extra padding
   @media screen and (max-width: 767px) {
     padding-bottom: 652px
   }
+
+  // &#content:target {
+  //   margin-top: 0;
+  //   padding-top: 6.7rem;
+  //   @media only screen and (min-width: 768px) {
+  //     margin-top: 0;
+  //     padding-top: 5rem;
+  //   }
+  // }
 }
 
 .ui.container {
@@ -102,11 +134,12 @@ main {
     margin-right: auto !important;
   }
 
-  /* Non home pages need margin to clear the fixed header */
+  /* Non home pages need padding to clear the fixed header */
   &.inside {
-    margin-top: 6.7rem;
+    position: relative;
+    padding-top: 6.7rem;
     @media only screen and (min-width: 768px) {
-      margin-top: 5rem;
+      padding-top: 5rem;
     }
   }
 

--- a/styles/styles.scss
+++ b/styles/styles.scss
@@ -73,6 +73,14 @@ h6.ui.header {
   font-size: 1rem; // 18px;
 }
 
+a {
+  color: $light-blue;
+
+  &:not(.title):hover {
+    text-decoration: underline;
+  }
+}
+
 main {
   padding-bottom: 560px; // height of footer plus extra padding
   @media screen and (max-width: 767px) {


### PR DESCRIPTION
### CDP-2217
* Adjusts the default link colors to meet the 4.5:1 contrast requirement and displays an underline on hover for links in the main content. The underline is necessary if we're going to display links (non-hovered) with color only (i.e., no underline). See https://www.w3.org/WAI/WCAG21/Techniques/general/G183.

### CDP-2215
* Adds `id="content"` to the `<main>` element.
* Adds smooth scrolling for users who have no preference for `prefers-reduced-motion`.
* Uses `padding` instead of `margin` for the content container since clicking the skip to content link results in the top of the page being hidden by the fixed navigation.
* Sets `position` to `relative` on the content container and adjusts the `top` value for the `GraphicEdit` and `VideoEdit` notification. This is to account for the use of `padding` instead of `margin` in the previous bullet.
