### PR TITLE
CDP-2234: Home page titles are not breaking correctly

### DIFF
--- a/components/Featured/Recents/Recents.scss
+++ b/components/Featured/Recents/Recents.scss
@@ -1,4 +1,5 @@
 @import "styles/colors.scss";
+@import "styles/mixins.scss";
 
 .recents {
   padding: 3em 0;
@@ -111,12 +112,11 @@
 
     &_title {
       width: 80%;
-      word-break: break-all; // Safari
-      overflow-wrap: anywhere;
       -webkit-hyphens: auto;
       -ms-hyphens: auto;
       -moz-hyphens: auto;
       hyphens: auto;
+      @include wrap-text;
     }
 
     &_icon {


### PR DESCRIPTION
* Adjusts styling for long titles in home page cards so that they break properly.