### PR TITLE
CDP-2233 Video Display Issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 _This sections lists changes committed since most recent release_
 
+**Fixed:**
+- Query on Home page to return public video projects when user is not logged in.
+
 # [5.2.0](https://github.com/IIP-Design/content-commons-client/compare/v5.1.1...5.2.0)(2020-09-14)
 
 **Added:**

--- a/lib/elastic/api.js
+++ b/lib/elastic/api.js
@@ -114,6 +114,7 @@ export const postTypeAggRequest = user => {
     .then( response => response.data );
 };
 
+
 /**
  *
  * @param {*} currentType
@@ -121,32 +122,31 @@ export const postTypeAggRequest = user => {
  */
 export const typeRecentsRequest = ( currentType, currentLang, user ) => {
   let body = {};
+  const isPublic = !user || user?.id === 'public';
 
-  if ( currentType === 'graphic' ) {
-    if ( !user || user?.id === 'public' ) {
-      body = bodybuilder()
-        .size( 3 )
-        .query( 'match', 'type', currentType )
-        .query( 'match', 'visibility', 'PUBLIC' )
-        .sort( 'published', 'desc' )
-        .build();
-    } else {
-      body = bodybuilder()
-        .size( 3 )
-        .query( 'match', 'type', currentType )
-        .sort( 'published', 'desc' )
-        .build();
-    }
-  } else {
-    body = bodybuilder().size( 3 )
-      .query( 'match', 'type', currentType )
-      .query( 'query_string', 'query', `(language.locale: ${currentLang} OR unit.language.locale: ${currentLang})` )
-      .sort( 'published', 'desc' )
-      .build();
+  // Create base query
+  body = bodybuilder().size( 3 )
+    .query( 'match', 'type', currentType )
+    .sort( 'published', 'desc' );
+
+  // Add video specifc query to base
+  if ( currentType === 'video' ) {
+    body = body.query(
+      'query_string',
+      'query',
+      `(language.locale: ${currentLang} OR unit.language.locale: ${currentLang})`,
+    );
+  }
+
+  // Add PUBLIC visibility if video or graphic. Video and graphics also have INTERNAL projects
+  // Need to add PUBLIC to ensure you pull 3 PUBLIC projects as opposed to the latest 3 as this
+  // could result in < 3 returning as the internal projects will be stripped on the server
+  if ( ( currentType === 'video' || currentType === 'graphic' ) && isPublic ) {
+    body = body.query( 'match', 'visibility', 'PUBLIC' );
   }
 
   return axios.post(
-    SEARCH, { body }, {
+    SEARCH, { body: body.build() }, {
       headers: { Authorization: `Bearer ${user?.esToken}` },
     },
   ).then( response => response.data );


### PR DESCRIPTION
Video is not displaying on the home screen when there are internal projects. This is due to the query targeting any visibility and setting the size to 3. If there are internal projects within the 3 returned results, the server will strip them (if the user is not logged in) leaving < 3 sent to the client. The section will not display on the Home page if less than 3 results are returned. This is fixed by specifically targeting PUBLIC projects in the query.

Note: PR #257 was merged inadvertently to the develop branch