### PR TITLE
CDP-2236: Fix non-English language content from appearing by default on the home page

### DIFF
--- a/lib/elastic/api.js
+++ b/lib/elastic/api.js
@@ -129,8 +129,8 @@ export const typeRecentsRequest = ( currentType, currentLang, user ) => {
     .query( 'match', 'type', currentType )
     .sort( 'published', 'desc' );
 
-  // Add video specifc query to base
-  if ( currentType === 'video' ) {
+  // Add video & article specific query to base
+  if ( currentType === 'post' || currentType === 'video' ) {
     body = body.query(
       'query_string',
       'query',


### PR DESCRIPTION
* Adds the language query for the `post` content type in the recents Elasticsearch query. Previously, the language query was only added for the `video` content type.

**Note:** I didn't add the language query for graphics since we're selecting the Twitter graphic for display and since graphics didn't have the language query prior to PR #258