### PR TITLE
CDP-2237: Fix the 500 error displayed for users who are not logged in when you share/copy the link on modal.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ _This sections lists changes committed since most recent release_
 
 # [5.2.0](https://github.com/IIP-Design/content-commons-client/compare/v5.1.1...5.2.0)(2020-09-14)
 
+**Changed:**
+- Check for a logged in user before calling `getItemRequest` on graphic and video project pages
+
 **Added:**
 - 'For Translation' tab with 'Clean' use videos to the video download popup on commons and publisher
 - 'Other' tab to the video download popup on commons

--- a/pages/graphic.js
+++ b/pages/graphic.js
@@ -22,10 +22,14 @@ GraphicPage.getInitialProps = async ctx => {
     : '';
 
   if ( query && query.site && query.id ) {
-    const response = await getItemRequest( query.site, query.id, true, user );
+    const response = user?.id && user.id !== 'public'
+      ? await getItemRequest( query.site, query.id, true, user )
+      : null;
 
-    if ( response.internal ) {
+    if ( !response || response?.internal ) {
       redirectTo( `/login?return=${ctx.asPath}`, ctx );
+
+      return {};
     }
 
     const item = getDataFromHits( response );

--- a/pages/video.js
+++ b/pages/video.js
@@ -5,6 +5,7 @@ import ContentPage from 'components/PageTypes/ContentPage/ContentPage';
 import Video from 'components/Video/Video';
 import { fetchUser } from 'context/authContext';
 import { getItemRequest } from 'lib/elastic/api';
+import { redirectTo } from 'lib/browser';
 import { normalizeItem, getDataFromHits } from 'lib/elastic/parser';
 
 const VideoPage = ( { item, url } ) => (
@@ -22,7 +23,16 @@ VideoPage.getInitialProps = async ctx => {
     : '';
 
   if ( query && query.site && query.id ) {
-    const response = await getItemRequest( query.site, query.id, false, user ) || {};
+    const response = user?.id && user.id !== 'public'
+      ? await getItemRequest( query.site, query.id, false, user )
+      : null;
+
+    if ( !response || response?.internal ) {
+      redirectTo( `/login?return=${ctx.asPath}`, ctx );
+
+      return {};
+    }
+
     const item = getDataFromHits( response );
 
     if ( item && item[0] ) {


### PR DESCRIPTION
* Fixes the 500 error displayed for users who are not logged in when you share/copy the link on modal by checking for a logged in user before calling `getItemRequest` on the graphic and video pages. 