### PR TITLE
fix: users were being directed to login page for public content

### DIFF
--- a/pages/graphic.js
+++ b/pages/graphic.js
@@ -22,9 +22,15 @@ GraphicPage.getInitialProps = async ctx => {
     : '';
 
   if ( query && query.site && query.id ) {
-    const response = user?.id && user.id !== 'public'
-      ? await getItemRequest( query.site, query.id, true, user )
-      : null;
+    // Do not need to check for the user here as the server will strip internal content
+    // if a token is not present on the user param. Letting the server handle it will mitigate
+    // use case that occurs when the user is null.
+    const response = await getItemRequest(
+      query.site,
+      query.id,
+      true,
+      user,
+    );
 
     if ( !response || response?.internal ) {
       redirectTo( `/login?return=${ctx.asPath}`, ctx );

--- a/pages/video.js
+++ b/pages/video.js
@@ -23,9 +23,15 @@ VideoPage.getInitialProps = async ctx => {
     : '';
 
   if ( query && query.site && query.id ) {
-    const response = user?.id && user.id !== 'public'
-      ? await getItemRequest( query.site, query.id, false, user )
-      : null;
+    // Do not need to check for the user here as the server will strip internal content
+    // if a token is not present on the user param. Letting the server handle it will mitigate
+    // use case that occurs when the user is null.
+    const response = await getItemRequest(
+      query.site,
+      query.id,
+      false,
+      user,
+    );
 
     if ( !response || response?.internal ) {
       redirectTo( `/login?return=${ctx.asPath}`, ctx );


### PR DESCRIPTION
The user was being redirected to login screen for public content. Remove the check for the user on the client and let the server determine is content should be returned based on a valid user token being present.