### PR TITLE
fix: properly return the loadReviewComponent render function

### DIFF
--- a/components/admin/ProjectEdit/VideoEdit/VideoEdit.js
+++ b/components/admin/ProjectEdit/VideoEdit/VideoEdit.js
@@ -153,6 +153,7 @@ const VideoEdit = props => {
       {
         pathname: '/admin/project',
         query: {
+          action: 'review',
           content: 'video',
           id: projectId,
         },

--- a/components/admin/ProjectReview/VideoReview/VideoReview.js
+++ b/components/admin/ProjectReview/VideoReview/VideoReview.js
@@ -35,7 +35,7 @@ const VideoReview = props => {
   const {
     loading, error, data, startPolling, stopPolling,
   } = useQuery( VIDEO_PROJECT_QUERY, {
-    variables: { id: props.id },
+    variables: { id },
     // using network-only here to ensure that we have the latest to determine
     // if the project has unpublished changes
     // todo - verify update mutation is returning necessary data to avoid

--- a/pages/admin/project.js
+++ b/pages/admin/project.js
@@ -1,4 +1,4 @@
-import React, { Fragment } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import { redirectTo } from 'lib/browser';
 import { withRouter } from 'next/router';
@@ -34,43 +34,46 @@ const getProjectQuery = content => {
   }
 };
 
-const ProjectPage = props => {
+const ProjectPage = ( { query, router } ) => {
   // Handles client side route checking
-  const isValidPath = query => query && allowedContentTypes( query.content );
+  const isValidPath = q => q && allowedContentTypes( q.content );
 
   const loadEditComponent = () => {
-    switch ( props.query.content ) {
+    switch ( query.content ) {
       case 'video':
-        return <VideoEdit id={ props.query.id } />;
+        return <VideoEdit id={ query.id } />;
 
       case 'graphic':
-        return <GraphicEdit id={ props.query.id } />;
+        return <GraphicEdit id={ query.id } />;
 
       default:
         return null;
     }
-    // if ( props.query.content === 'video' ) {
-    //   return <VideoEdit id={ props.query.id } />;
-    // }
   };
 
   const loadReviewComponent = () => {
-    if ( props.query.content === 'video' ) {
-      return <VideoReview id={ props.query.id } />;
+    if ( query.content === 'video' ) {
+      return <VideoReview id={ query.id } />;
     }
+
+    return null;
   };
 
-  if ( !isValidPath( props.query ) ) {
-    props.router.push( '/admin/dashboard' );
+  if ( !isValidPath( query ) ) {
+    router.push( '/admin/dashboard' );
   }
 
-  const { action: actionQry } = props.query;
+  const { action: actionQry } = query;
 
   if ( actionQry === 'edit' ) {
     return loadEditComponent();
   }
 
-  loadReviewComponent();
+  if ( actionQry === 'review' ) {
+    return loadReviewComponent();
+  }
+
+  return null;
 };
 
 // Executes before page renders


### PR DESCRIPTION
Includes a little cleanup and refactoring, but the core of the fix is on line 73 of `pages/admin/project.js`. Namely, `loadReviewComponent();` should be `return loadReviewComponent();`.

Also, explicitly set the action to `review` on the review action button redirect.