### PR TITLE
fix: update dependency arrays in the posts component useEffect

### DIFF
--- a/components/Post/Post.js
+++ b/components/Post/Post.js
@@ -56,7 +56,7 @@ const Post = ( { item, router } ) => {
           } );
       }
     }
-  }, [selectedLanguage] );
+  }, [selectedLanguage, selectedItem] );
 
   useEffect( () => {
     const { pathname } = router;
@@ -69,7 +69,7 @@ const Post = ( { item, router } ) => {
         updateUrl( `/article?id=${id}&site=${site}` );
       }
     }
-  }, [selectedItem, router] );
+  }, [selectedItem] );
 
   if ( selectedItem ) {
     const embedItem


### PR DESCRIPTION
Fix the dependencies array in the post component. The really problematic one was the second one since the if router was included as a dependency and also updated by the useEffect hook. So each time the hook ran it updated the router, thereby initiating another running of the hook.