### PR TITLE
CDP-2243: Fixes missing alt text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,12 @@ _This sections lists changes committed since most recent release_
 - Default link color and hover styling for improved accessibility
 - Focus outline color to meet accessibility contrast requirement
 - Add accessible names to `SearchInput` form elements
+- Missing image alt attribute values
+- Accessible label for the "Browse All" links in each home page featured `section` so that additional context can be conveyed to screen reader software
+- Missing accessible label for each featured home page `section`
+- Featured section heading levels so there's only one `h1` on the home page
+- Missing landmark roles for the `header`, `main`, and `footer` wider compatibility with screen readers' rotor/element list
+
   
 # [5.4.6](https://github.com/IIP-Design/content-commons-client/compare/v5.4.5...5.4.6)(2021-03-24)
 **Fixed:**

--- a/components/Featured/Packages/Packages.js
+++ b/components/Featured/Packages/Packages.js
@@ -82,19 +82,14 @@ const Packages = ( { pin: idsToPin, user } ) => {
 
   if ( !items.length ) return null;
 
-  const accessibleLabel = 'latest-packages-title';
-
   return (
     <section
       className="latestPackages_section"
-      aria-labelledby={ accessibleLabel }
+      aria-label="Latest Guidance Packages"
     >
       <div className="latestPackages_container">
         <div className="latestPackages_header">
-          <h2
-            id={ accessibleLabel }
-            className="latestPackages_header_title"
-          >
+          <h2 className="latestPackages_header_title">
             Latest Guidance Packages
           </h2>
           <Link
@@ -107,7 +102,7 @@ const Packages = ( { pin: idsToPin, user } ) => {
               },
             } }
           >
-            <a className="latestPackages_header_link">Browse All</a>
+            <a className="latestPackages_header_link" aria-label="Browse all guidance packages">Browse All</a>
           </Link>
         </div>
         <Grid className="latestPackages_grid">

--- a/components/Featured/Packages/Packages.js
+++ b/components/Featured/Packages/Packages.js
@@ -82,11 +82,21 @@ const Packages = ( { pin: idsToPin, user } ) => {
 
   if ( !items.length ) return null;
 
+  const accessibleLabel = 'latest-packages-title';
+
   return (
-    <section className="latestPackages_section">
+    <section
+      className="latestPackages_section"
+      aria-labelledby={ accessibleLabel }
+    >
       <div className="latestPackages_container">
         <div className="latestPackages_header">
-          <h2 className="latestPackages_header_title">Latest Guidance Packages</h2>
+          <h2
+            id={ accessibleLabel }
+            className="latestPackages_header_title"
+          >
+            Latest Guidance Packages
+          </h2>
           <Link
             href={ {
               pathname: '/results',

--- a/components/Featured/Packages/Packages.js
+++ b/components/Featured/Packages/Packages.js
@@ -86,7 +86,7 @@ const Packages = ( { pin: idsToPin, user } ) => {
     <section className="latestPackages_section">
       <div className="latestPackages_container">
         <div className="latestPackages_header">
-          <h1 className="latestPackages_header_title">Latest Guidance Packages</h1>
+          <h2 className="latestPackages_header_title">Latest Guidance Packages</h2>
           <Link
             href={ {
               pathname: '/results',

--- a/components/Featured/Priorities/Priorities.js
+++ b/components/Featured/Priorities/Priorities.js
@@ -120,16 +120,14 @@ const Priorities = ( { categories, label, term, user, locale, tags } ) => {
 
   if ( items.length < 3 ) return null;
 
-  const accessibleLabel = `${term.join( '-' ).replaceAll( ' ', '-' )}-priorities-title`;
-
   return (
     <section
       className="priorities"
-      aria-labelledby={ accessibleLabel }
+      aria-label={ `Department Priority: ${label}` }
     >
       <div className="prioritiescontainer">
         <div className="prioritiestitle">
-          <h2 id={ accessibleLabel } className="ui large header">
+          <h2 className="ui large header">
             { `Department Priority: ${label}` }
           </h2>
           <Link
@@ -143,7 +141,7 @@ const Priorities = ( { categories, label, term, user, locale, tags } ) => {
               },
             } }
           >
-            <a className="browseAll">Browse All</a>
+            <a className="browseAll" aria-label={ `Browse all ${label} content` }>Browse All</a>
           </Link>
         </div>
         <Grid columns="equal" stackable stretched>

--- a/components/Featured/Priorities/Priorities.js
+++ b/components/Featured/Priorities/Priorities.js
@@ -120,11 +120,16 @@ const Priorities = ( { categories, label, term, user, locale, tags } ) => {
 
   if ( items.length < 3 ) return null;
 
+  const accessibleLabel = `${term.join( '-' ).replaceAll( ' ', '-' )}-priorities-title`;
+
   return (
-    <section className="priorities">
+    <section
+      className="priorities"
+      aria-labelledby={ accessibleLabel }
+    >
       <div className="prioritiescontainer">
         <div className="prioritiestitle">
-          <h2 className="ui large header">
+          <h2 id={ accessibleLabel } className="ui large header">
             { `Department Priority: ${label}` }
           </h2>
           <Link

--- a/components/Featured/Priorities/Priorities.js
+++ b/components/Featured/Priorities/Priorities.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import Link from 'next/link';
 import moment from 'moment';
 import { v4 } from 'uuid';
-import { Grid, Header, Item, Modal } from 'semantic-ui-react';
+import { Grid, Item, Modal } from 'semantic-ui-react';
 
 import SignedUrlImage from 'components/SignedUrlImage/SignedUrlImage';
 import { getModalContent } from 'components/modals/utils';
@@ -124,9 +124,9 @@ const Priorities = ( { categories, label, term, user, locale, tags } ) => {
     <section className="priorities">
       <div className="prioritiescontainer">
         <div className="prioritiestitle">
-          <Header as="h1" size="large">
+          <h2 className="ui large header">
             { `Department Priority: ${label}` }
-          </Header>
+          </h2>
           <Link
             href={ {
               pathname: '/results',

--- a/components/Featured/Priorities/Priorities.scss
+++ b/components/Featured/Priorities/Priorities.scss
@@ -28,7 +28,7 @@
       flex-direction: column-reverse;
     }
 
-    h1.ui.header {
+    .ui.header {
       position: relative;
       left: -1rem;
       padding: 0.5em 1em;

--- a/components/Featured/Recents/Recents.js
+++ b/components/Featured/Recents/Recents.js
@@ -80,16 +80,14 @@ const Recents = ( { postType, locale, user } ) => {
 
   if ( items.length < 3 ) return null;
 
-  const accessibleLabel = `latest-${postType}s-title`;
-
   return (
     <section
       className="ui container recents"
-      aria-labelledby={ accessibleLabel }
+      aria-label={ `Latest ${postTypeLabel}` }
     >
       <div className="recentswrapper">
         <div className="recentstitle">
-          <h2 id={ accessibleLabel } className="ui large header">
+          <h2 className="ui large header">
             { postTypeLabel && `Latest ${postTypeLabel}` }
           </h2>
           <Link
@@ -102,7 +100,7 @@ const Recents = ( { postType, locale, user } ) => {
               },
             } }
           >
-            <a className="browseAll">Browse All</a>
+            <a className="browseAll" aria-label={ `Browse all ${postTypeLabel}` }>Browse All</a>
           </Link>
         </div>
         <Grid columns="equal" stackable stretched>

--- a/components/Featured/Recents/Recents.js
+++ b/components/Featured/Recents/Recents.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import Link from 'next/link';
 import moment from 'moment';
 import { v4 } from 'uuid';
-import { Grid, Header, Item, Modal } from 'semantic-ui-react';
+import { Grid, Item, Modal } from 'semantic-ui-react';
 
 import { getModalContent } from 'components/modals/utils';
 import { getCategories } from '../utils';
@@ -84,9 +84,9 @@ const Recents = ( { postType, locale, user } ) => {
     <section className="ui container recents">
       <div className="recentswrapper">
         <div className="recentstitle">
-          <Header as="h1" size="large">
+          <h2 className="ui large header">
             { postTypeLabel && `Latest ${postTypeLabel}` }
-          </Header>
+          </h2>
           <Link
             href={ {
               pathname: '/results',

--- a/components/Featured/Recents/Recents.js
+++ b/components/Featured/Recents/Recents.js
@@ -80,11 +80,16 @@ const Recents = ( { postType, locale, user } ) => {
 
   if ( items.length < 3 ) return null;
 
+  const accessibleLabel = `latest-${postType}s-title`;
+
   return (
-    <section className="ui container recents">
+    <section
+      className="ui container recents"
+      aria-labelledby={ accessibleLabel }
+    >
       <div className="recentswrapper">
         <div className="recentstitle">
-          <h2 className="ui large header">
+          <h2 id={ accessibleLabel } className="ui large header">
             { postTypeLabel && `Latest ${postTypeLabel}` }
           </h2>
           <Link

--- a/components/Featured/Recents/Recents.scss
+++ b/components/Featured/Recents/Recents.scss
@@ -29,7 +29,7 @@
       flex-direction: column-reverse;
     }
 
-    > h1.ui.large.header {
+    > .ui.large.header {
       @media screen and (max-width: 900px) {        
         margin-bottom: 8px;
         font-size: 20px;

--- a/components/Footer/Footer.js
+++ b/components/Footer/Footer.js
@@ -33,7 +33,7 @@ const Footer = () => {
   ];
 
   return (
-    <footer className="ui">
+    <footer role="contentinfo" className="ui">
       <div className="footer-feedback">
         <p>
           { 'Help us improve ' }

--- a/components/Header/Header.js
+++ b/components/Header/Header.js
@@ -34,7 +34,7 @@ const HeaderGlobal = ( { router: { pathname } } ) => {
   return (
     <div className={ barClass }>
       <div className="ui container">
-        <header>
+        <header role="banner">
           <Header as="h1">
             <div>
               <Image className="seal" src={ DosSeal } centered alt="Department of State Seal" />

--- a/components/Page.js
+++ b/components/Page.js
@@ -26,7 +26,7 @@ const Page = ( { children, router } ) => {
     <div style={ { position: 'relative', minHeight: '100vh' } }>
       <Meta title={ title } />
       <Header />
-      <main id="content" className={ bodyCls }>
+      <main id="content" role="main" className={ bodyCls }>
         { children }
       </main>
       <Footer />

--- a/components/Results/ResultItem/ResultItem.js
+++ b/components/Results/ResultItem/ResultItem.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import moment from 'moment';
-import { Card, Image, Modal } from 'semantic-ui-react';
+import { Card, Modal } from 'semantic-ui-react';
 import InternalUseDisplay from 'components/InternalUseDisplay/InternalUseDisplay';
 
 import PackageCard from 'components/Package/PackageCard/PackageCard';
@@ -113,8 +113,8 @@ const ResultItem = ( { item } ) => {
         closeIcon
         trigger={ (
           <div className="card_imgWrapper">
-            <Image data-action={ action } src={ signedUrl } width="100%" height="100%" />
-            <Image data-action={ action } src={ item.icon } className="card_postIcon" />
+            <img data-action={ action } src={ signedUrl } width="100%" height="100%" alt={ item?.title || '' } />
+            <img data-action={ action } src={ item.icon } className="card_postIcon" alt={ item?.type ? `${item.type} icon` : '' } />
           </div>
         ) }
       >

--- a/components/Results/ResultItem/ResultItem.scss
+++ b/components/Results/ResultItem/ResultItem.scss
@@ -74,6 +74,7 @@
     -ms-overflow-y: hidden;
 
     > img {
+      display: block;
       height: auto !important;
     }
   }

--- a/components/admin/Dashboard/Dashboard.js
+++ b/components/admin/Dashboard/Dashboard.js
@@ -79,7 +79,7 @@ const Dashboard = () => {
     <section className="dashboard">
       <Grid stackable>
         <Grid.Column width={ 3 }>
-          <Image src={ userIcon } avatar className="dashboard__avatar-img" />
+          <Image src={ userIcon } avatar className="dashboard__avatar-img" alt="user icon" />
           <span className="dashboard__avatar-label">Dashboard</span>
         </Grid.Column>
         <Grid.Column width={ 13 }>

--- a/components/admin/Dashboard/TeamProjects/TeamProjectPrimaryCol/TeamProjectPrimaryCol.js
+++ b/components/admin/Dashboard/TeamProjects/TeamProjectPrimaryCol/TeamProjectPrimaryCol.js
@@ -101,7 +101,10 @@ const TeamProjectPrimaryCol = ( { d, header } ) => {
 
     if ( item?.thumbnail?.signedUrl ) {
       url = item.thumbnail.signedUrl;
-      alt = item.thumbnail.alt;
+
+      if ( item.thumbnail?.alt ) {
+        alt = item.thumbnail.alt;
+      }
     } else if ( type?.toLowerCase() === 'package' ) {
       url = packageThumbnail;
       alt = 'Package';

--- a/components/admin/ProjectUnits/ProjectUnitItem/ProjectUnitItem.js
+++ b/components/admin/ProjectUnits/ProjectUnitItem/ProjectUnitItem.js
@@ -67,7 +67,7 @@ const ProjectUnitItem = props => {
 
       if ( thumbnails && thumbnails[0] && thumbnails[0].image ) {
         return (
-          <Image src={ thumbnails[0].image.signedUrl } fluid />
+          <Image src={ thumbnails[0].image.signedUrl } fluid alt={ unit?.title || '' } />
         );
       }
     }


### PR DESCRIPTION
This PR includes CDP-2243, CDP-2244, CDP-2248, and CDP-2249.

### CDP-2243
- Adds missing `alt` text values. Most of the violations were for the video cards on the search results page, but there were a few others as well. Ideally, `alt` text should describe the image, but there's not really a way to do that programmatically without some form of AI, but even AI can be suspect since it can reflect algorithm biases. So I set the missing values to the title, which eliminates the `src` url from being announced. The only other alternative is to treat the thumbnails as decorative and give the `alt` attribute empty string values.

### CDP-2244
- Adds an `aria-label` to the "Browse All" links on the home page. Because there are multiple "Browse All" links, screen reader users would find it confusing to see so many links with the same announced text. Labelling the links provides additional context that will be announced by screen readers and exposes the labels in the rotor/element list. For example, instead of hearing "Browse All" announced for the COVID priorities link, users will now hear "Browse all COVID-19 and Global Health content".

### CDP-2248
- Adjusts the featured section headings so that they are `h2` instead of `h1`. This results in a more accurate document outline for screen readers software since there is already and `h1` for the page title.

### CDP-2249
- Adds landmark roles to the `header`, `main`, and `footer` elements. Adding the landmark roles helps ensure that these regions are exposed to a screen reader's rotor/element list. Typically, this would not be necessary, but in some browser and screen reader combinations these regions aren't always exposed, e.g., Chrome and VoiceOver (at least on my computer).