### PR TITLE
CDP-2327: Fix page title for search results page

### DIFF
--- a/components/SearchTerm/SearchTerm.js
+++ b/components/SearchTerm/SearchTerm.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { object } from 'prop-types';
 import { connect } from 'react-redux';
+import VisuallyHidden from 'components/VisuallyHidden/VisuallyHidden';
 import { numberWithCommas } from 'lib/utils';
 import './SearchTerm.scss';
 
@@ -9,14 +10,15 @@ const SearchTerm = ( { search } ) => {
 
   return (
     <section className="searchTerm">
-      <h1 className="ui header searchTermQuery">
+      <VisuallyHidden><h1>search results</h1></VisuallyHidden>
+      <div className="ui header searchTermQuery">
         { currentTerm && `${currentTerm}` }
         <div className="sub header searchTermTotal">
           { numberWithCommas( total ) }
           { ' ' }
           { total === 1 ? 'item' : 'items' }
         </div>
-      </h1>
+      </div>
     </section>
   );
 };

--- a/components/SearchTerm/SearchTerm.js
+++ b/components/SearchTerm/SearchTerm.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import { object } from 'prop-types';
 import { connect } from 'react-redux';
-import { Header } from 'semantic-ui-react';
 import { numberWithCommas } from 'lib/utils';
 import './SearchTerm.scss';
 
@@ -10,14 +9,14 @@ const SearchTerm = ( { search } ) => {
 
   return (
     <section className="searchTerm">
-      <Header as="h1" className="searchTermQuery">
+      <h1 className="ui header searchTermQuery">
         { currentTerm && `${currentTerm}` }
-        <Header.Subheader className="searchTermTotal">
+        <div className="sub header searchTermTotal">
           { numberWithCommas( total ) }
           { ' ' }
           { total === 1 ? 'item' : 'items' }
-        </Header.Subheader>
-      </Header>
+        </div>
+      </h1>
     </section>
   );
 };

--- a/components/SearchTerm/SearchTerm.js
+++ b/components/SearchTerm/SearchTerm.js
@@ -3,20 +3,18 @@ import { object } from 'prop-types';
 import { connect } from 'react-redux';
 import VisuallyHidden from 'components/VisuallyHidden/VisuallyHidden';
 import { numberWithCommas } from 'lib/utils';
-import './SearchTerm.scss';
+import styles from './SearchTerm.module.scss';
 
 const SearchTerm = ( { search } ) => {
   const { currentTerm, total } = search;
 
   return (
-    <section className="searchTerm">
+    <section className={ styles.searchTerm }>
       <VisuallyHidden><h1>search results</h1></VisuallyHidden>
-      <div className="ui header searchTermQuery">
+      <div className={ styles.searchTermQuery }>
         { currentTerm && `${currentTerm}` }
-        <div className="sub header searchTermTotal">
-          { numberWithCommas( total ) }
-          { ' ' }
-          { total === 1 ? 'item' : 'items' }
+        <div className={ styles.searchTermTotal }>
+          { `${numberWithCommas( total )} item${total === 1 ? '' : 's'}` }
         </div>
       </div>
     </section>

--- a/components/SearchTerm/SearchTerm.js
+++ b/components/SearchTerm/SearchTerm.js
@@ -12,8 +12,8 @@ const SearchTerm = ( { search } ) => {
     <section className={ styles.searchTerm }>
       <VisuallyHidden><h1>search results</h1></VisuallyHidden>
       <div className={ styles.searchTermQuery }>
-        { currentTerm && `${currentTerm}` }
-        <div className={ styles.searchTermTotal }>
+        <div role="status" aria-live="polite">{ currentTerm && `${currentTerm}` }</div>
+        <div className={ styles.searchTermTotal } role="status" aria-live="polite">
           { `${numberWithCommas( total )} item${total === 1 ? '' : 's'}` }
         </div>
       </div>

--- a/components/SearchTerm/SearchTerm.module.scss
+++ b/components/SearchTerm/SearchTerm.module.scss
@@ -17,6 +17,10 @@
     font-size: 1.6rem;
   }
   font-weight: 700;
+
+  [role="status"]:first-of-type {
+    line-height: 1;
+  }
 }
 
 .searchTermTotal {

--- a/components/SearchTerm/SearchTerm.module.scss
+++ b/components/SearchTerm/SearchTerm.module.scss
@@ -1,23 +1,27 @@
 @import 'styles/colors.scss';
 
 .searchTerm {
-  text-align: center;
   padding: 1em 0 1.6em 0;
   @media screen and (min-width: 1100px) {
-    padding: 0 0 1.6em 0;
+    padding-top: 0;
   }
+  text-align: center;
 }
-.ui.header.searchTermQuery {
-  color: $blue;
+
+.searchTermQuery {
   margin-top: 0;
   margin-bottom: 0;
+  color: $blue;
   font-size: 1.4rem;
   @media screen and (min-width: 768px) {
     font-size: 1.6rem;
   }
+  font-weight: 700;
 }
-.ui.header .sub.header.searchTermTotal {
-  color: $grey;
+
+.searchTermTotal {
   margin-bottom: 0;
+  color: $grey;
   font-size: 0.9rem;
+  font-weight: 400;
 }

--- a/components/SearchTerm/SearchTerm.scss
+++ b/components/SearchTerm/SearchTerm.scss
@@ -1,4 +1,4 @@
-@import "../../styles/colors.scss";
+@import 'styles/colors.scss';
 
 .searchTerm {
   text-align: center;
@@ -9,6 +9,7 @@
 }
 .ui.header.searchTermQuery {
   color: $blue;
+  margin-top: 0;
   margin-bottom: 0;
   font-size: 1.4rem;
   @media screen and (min-width: 768px) {

--- a/components/SearchTerm/SearchTerm.test.js
+++ b/components/SearchTerm/SearchTerm.test.js
@@ -1,0 +1,50 @@
+import { mount } from 'enzyme';
+import { Provider } from 'react-redux';
+import configureStore from 'redux-mock-store';
+import * as state from './mocks';
+import SearchTerm from './SearchTerm';
+
+const mockStore = configureStore( [] );
+
+describe( '<FilterSelections />', () => {
+  let store;
+  let Component;
+  let wrapper;
+  let searchTerm;
+  let props;
+
+  beforeEach( () => {
+    store = mockStore( state.mocks );
+
+    Component = (
+      <Provider store={ store }>
+        <SearchTerm />
+      </Provider>
+    );
+
+    wrapper = mount( Component );
+    searchTerm = wrapper.find( 'SearchTerm' );
+    props = searchTerm.props();
+  } );
+
+  it( 'renders without crashing', () => {
+    expect( searchTerm.exists() ).toEqual( true );
+  } );
+
+  it( 'renders a visually hidden h1', () => {
+    const hidden = searchTerm.find( 'VisuallyHidden' );
+    const h1 = hidden.find( 'h1' );
+
+    expect( h1.contains( 'search results' ) ).toEqual( true );
+  } );
+
+  it( 'renders live regions for the search term and hits', () => {
+    const liveRegions = searchTerm.find( '[role="status"][aria-live="polite"]' );
+    const { term, total } = props.search;
+    const content = [term, `${total} items`];
+
+    liveRegions.forEach( ( region, i ) => {
+      expect( region.contains( content[i] ) ).toEqual( true );
+    } );
+  } );
+} );

--- a/components/SearchTerm/mocks.js
+++ b/components/SearchTerm/mocks.js
@@ -1,0 +1,279 @@
+export const mocks = {
+  search: {
+    currentPage: 1,
+    endIndex: 1,
+    endPage: 1,
+    error: false,
+    isFetching: false,
+    pageSize: 12,
+    pages: [1],
+    response: {
+      took: 102,
+      timed_out: false,
+      _shards: {
+        total: 45,
+        successful: 45,
+        skipped: 0,
+        failed: 0,
+      },
+      hits: {
+        total: {
+          value: 2,
+          relation: 'eq',
+        },
+        max_score: 17.204853,
+        hits: [
+          {
+            _index: 'graphics_20200624',
+            _type: 'graphic',
+            _id: 'dDoFsngB3NQyV_fD5EZV',
+            _score: 17.204853,
+            _source: {
+              id: 'ckn90jtv10x880720yn3lk378',
+              site: 'commons.america.gov',
+              title: 'ddd',
+              type: 'graphic',
+              published: '2021-04-08T15:07:12.553Z',
+              modified: '2021-04-08T15:07:12.553Z',
+              copyright: 'COPYRIGHT',
+              visibility: 'PUBLIC',
+              owner: 'GPA Design & Editorial',
+              supportFiles: [],
+              images: [
+                {
+                  title: 'Mexico City 2.jpg',
+                  visibility: 'PUBLIC',
+                  filename: 'Mexico City 2.jpg',
+                  filetype: 'image/jpeg',
+                  filesize: 1030591,
+                  height: 0,
+                  width: 0,
+                  alt: '',
+                  url: 'https://staticcdpdev.s3.amazonaws.com/social_media/2021/04/commons.america.gov_ckn90jtv10x880720yn3lk378/Mexico_City_2.jpg',
+                  language: {
+                    language_code: 'en',
+                    locale: 'en-us',
+                    text_direction: 'ltr',
+                    display_name: 'English',
+                    native_name: 'English',
+                  },
+                  style: 'Quote',
+                  social: ['WhatsApp'],
+                },
+              ],
+              categories: [
+                {
+                  id: 'eqO6fXABg9RjisyQvmSr',
+                  name: 'health',
+                },
+              ],
+              tags: [],
+              descPublic: {
+                content: '',
+                visibility: 'PUBLIC',
+              },
+              descInternal: {
+                content: '',
+                visibility: 'INTERNAL',
+              },
+            },
+          },
+          {
+            _index: 'videos_20200225',
+            _type: 'video',
+            _id: '8l5LW3gBW8ACTXPZZzxO',
+            _score: 10.589139,
+            _source: {
+              post_id: 'ckeil4ftm02fi0720cxayp43z',
+              site: 'commons.america.gov',
+              type: 'video',
+              published: '2021-03-25T14:27:31.643Z',
+              modified: '2021-03-25T14:27:31.643Z',
+              visibility: 'INTERNAL',
+              supportFiles: [
+                {
+                  visibility: 'PUBLIC',
+                  srcUrl: 'https://staticcdpdev.s3.amazonaws.com/2020/08/commons.america.gov_ckeil4ftm02fi0720cxayp43z/Mexico_City_1.srt',
+                  supportFileType: 'srt',
+                  language: {
+                    language_code: 'en',
+                    text_direction: 'ltr',
+                    locale: 'en-us',
+                    display_name: 'English',
+                    native_name: 'English',
+                  },
+                },
+              ],
+              unit: [
+                {
+                  thumbnail: 'https://staticcdpdev.s3.amazonaws.com/2020/08/commons.america.gov_ckeil4ftm02fi0720cxayp43z/Mexico_City_2.jpg',
+                  transcript: {
+                    visibility: 'PUBLIC',
+                    srcUrl: '',
+                    text: '',
+                  },
+                  srt: {
+                    visibility: 'PUBLIC',
+                    srcUrl: '',
+                  },
+                  language: {
+                    language_code: 'en',
+                    text_direction: 'ltr',
+                    locale: 'en-us',
+                    display_name: 'English',
+                    native_name: 'English',
+                  },
+                  categories: [
+                    {
+                      name: 'geography',
+                      id: 'bqO6fXABg9RjisyQvWTf',
+                    },
+                    {
+                      name: 'global issues',
+                      id: 'c6O6fXABg9RjisyQvmQR',
+                    },
+                  ],
+                  source: [
+                    {
+                      streamUrl: [
+                        {
+                          uid: '453367676',
+                          site: 'vimeo',
+                          link: 'https://vimeo.com/453367676',
+                          url: 'https://player.vimeo.com/video/453367676',
+                        },
+                      ],
+                      duration: '14.889875',
+                      filetype: 'video/mp4',
+                      burnedInCaptions: 'false',
+                      visibility: 'PUBLIC',
+                      size: {
+                        width: 1920,
+                        bitrate: 8503602,
+                        filesize: 15829673,
+                        height: 1080,
+                      },
+                      stream: {
+                        uid: '453367676',
+                        site: 'vimeo',
+                        link: 'https://vimeo.com/453367676',
+                        url: 'https://player.vimeo.com/video/453367676',
+                      },
+                      use: 'Full Video',
+                      video_quality: 'BROADCAST',
+                      downloadUrl: 'https://staticcdpdev.s3.amazonaws.com/2020/08/commons.america.gov_ckeil4ftm02fi0720cxayp43z/Mexico_City_6.mp4',
+                    },
+                  ],
+                  title: 'just a test ddd',
+                  desc: 'test',
+                  tags: [
+                    {
+                      name: 'american culture',
+                      id: 'DqO6fXABg9RjisyQuGTk',
+                    },
+                    {
+                      name: 'agriculture',
+                      id: 'QKO6fXABg9RjisyQu2SS',
+                    },
+                  ],
+                },
+                {
+                  thumbnail: 'https://staticcdpdev.s3.amazonaws.com/2020/08/commons.america.gov_ckeil4ftm02fi0720cxayp43z/Mexico_City_2.jpg',
+                  transcript: {
+                    visibility: 'PUBLIC',
+                    srcUrl: '',
+                    text: '',
+                  },
+                  srt: {
+                    visibility: 'PUBLIC',
+                    srcUrl: '',
+                  },
+                  language: {
+                    language_code: 'ar',
+                    text_direction: 'rtl',
+                    locale: 'ar',
+                    display_name: 'Arabic',
+                    native_name: 'العربية',
+                  },
+                  categories: [
+                    {
+                      name: 'جغرافية',
+                      id: 'bqO6fXABg9RjisyQvWTf',
+                    },
+                    {
+                      name: 'قضايا عالمية',
+                      id: 'c6O6fXABg9RjisyQvmQR',
+                    },
+                  ],
+                  source: [
+                    {
+                      streamUrl: [
+                        {
+                          uid: '453410880',
+                          site: 'vimeo',
+                          link: 'https://vimeo.com/453410880',
+                          url: 'https://player.vimeo.com/video/453410880',
+                        },
+                      ],
+                      duration: '14.889875',
+                      filetype: 'video/mp4',
+                      burnedInCaptions: 'true',
+                      visibility: 'PUBLIC',
+                      size: {
+                        width: 1920,
+                        bitrate: 8503602,
+                        filesize: 15829673,
+                        height: 1080,
+                      },
+                      stream: {
+                        uid: '453410880',
+                        site: 'vimeo',
+                        link: 'https://vimeo.com/453410880',
+                        url: 'https://player.vimeo.com/video/453410880',
+                      },
+                      use: 'Web Chat',
+                      video_quality: 'WEB',
+                      downloadUrl: 'https://staticcdpdev.s3.amazonaws.com/2020/08/commons.america.gov_ckeil4ftm02fi0720cxayp43z/Mexico_City_1.mp4',
+                    },
+                  ],
+                  title: 'just a test',
+                  desc: '',
+                  tags: [],
+                },
+              ],
+              owner: 'GPA Video',
+              author: 'Edwin Mah',
+              thumbnail: {
+                name: 'Mexico City 2.jpg',
+                alt: '',
+                caption: '',
+                longdesc: '',
+                visibility: 'PUBLIC',
+                sizes: {
+                  small: null,
+                  medium: null,
+                  large: null,
+                  full: {
+                    url: 'https://staticcdpdev.s3.amazonaws.com/2020/08/commons.america.gov_ckeil4ftm02fi0720cxayp43z/Mexico_City_2.jpg',
+                    width: 1920,
+                    height: 1080,
+                    orientation: 'landscape',
+                  },
+                },
+              },
+              categories: [],
+            },
+          },
+        ],
+      },
+    },
+    sort: 'relevance',
+    term: 'ddd',
+    language: 'en-us',
+    currentTerm: 'ddd',
+    startIndex: 0,
+    startPage: 1,
+    total: 2,
+    totalPages: 1,
+  },
+};


### PR DESCRIPTION
This PR adds a page title to the search results page and creates live regions for the search term and hits. The live regions allow screen readers to make an announcement whenever the search term or number of hits changes.

This PR also uses CSS modules for the `SearchTerm` component and replaces the Semantic UI Header component, which resulted in a 17 KB (gzipped) savings.