### PR TITLE
CDP-2314: Allow results pages to be refreshed/directly navigated to

### DIFF
--- a/components/FilterMenu/FilterMenu.js
+++ b/components/FilterMenu/FilterMenu.js
@@ -9,9 +9,7 @@ import FilterMenuCountries from './FilterMenuCountries';
 
 import './FilterMenu.scss';
 
-const FilterMenu = props => {
-  const { filter, global } = props;
-
+const FilterMenu = ( { filter, global } ) => {
   const showMenuItem = item => {
     if ( item === 'document' ) {
       return global?.postTypes?.list.some( type => type.key === item ) || false;

--- a/components/FilterMenu/FilterSelections.js
+++ b/components/FilterMenu/FilterSelections.js
@@ -77,21 +77,19 @@ const getAllSelections = ( filter, global ) => {
   return selectedFilters;
 };
 
-const FilterSelections = props => {
-  const {
-    router,
-    filter,
-    global,
-    term,
-    language,
-    clearFilters,
-  } = props;
-
+const FilterSelections = ( {
+  router,
+  filter,
+  global,
+  term,
+  language,
+  clearFilters,
+} ) => {
   const [selections, setSelections] = useState( [] );
 
   useEffect( () => {
     setSelections( [...getAllSelections( filter, global )] );
-  }, [filter] );
+  }, [filter, global] );
 
   /**
    * Reload results page with updated query params

--- a/lib/redux/reducers/filter.js
+++ b/lib/redux/reducers/filter.js
@@ -14,8 +14,8 @@ const INITIAL_STATE = {
   countries: [],
   sources: [],
   postTypes: [],
-  dateFrom: new Date(),
-  dateTo: new Date(),
+  dateFrom: new Date().toString(),
+  dateTo: new Date().toString(),
   date: 'recent',
 };
 
@@ -80,19 +80,19 @@ const filter = ( state = INITIAL_STATE, action ) => {
     case FILTER_DATE_CHANGE:
       return {
         ...state,
-        date: action.payload ? action.payload : 'recent',
+        date: action.payload ? action.payload.toString() : 'recent',
       };
 
     case FILTER_FROM_DATE_CHANGE:
       return {
         ...state,
-        dateFrom: action.payload,
+        dateFrom: action.payload.toString(),
       };
 
     case FILTER_TO_DATE_CHANGE:
       return {
         ...state,
-        dateTo: action.payload,
+        dateTo: action.payload.toString(),
       };
 
     default:

--- a/lib/redux/store.js
+++ b/lib/redux/store.js
@@ -1,7 +1,7 @@
 import { createStore, applyMiddleware, combineReducers } from 'redux';
 import thunk from 'redux-thunk';
 import { composeWithDevTools } from 'redux-devtools-extension/logOnlyInProduction';
-import { createWrapper } from 'next-redux-wrapper';
+import { HYDRATE, createWrapper } from 'next-redux-wrapper';
 
 import uploadResolver from './reducers/upload';
 import filterReducer from './reducers/filter';
@@ -16,6 +16,17 @@ const reducers = combineReducers( {
   projectUpdate: projectUpdateReducer,
   global: globalReducer,
 } );
+
+const reducer = ( state, action ) => {
+  if ( action.type === HYDRATE ) {
+    return {
+      ...state,
+      ...action.payload,
+    };
+  }
+
+  return reducers( state, action );
+};
 
 /*
 Add redux dev tools: https://github.com/zalmoxisus/redux-devtools-extension
@@ -35,7 +46,7 @@ const composeEnhancers = composeWithDevTools( {} );
 * @param {string} options.storeKey This key will be used to preserve store in global namespace for safe HMR
 */
 // const makeStore = ( initialState, options ) => createStore( reducers, initialState, composeEnhancers( applyMiddleware( thunk ) ) );
-const makeStore = context => createStore( reducers, composeEnhancers( applyMiddleware( thunk ) ) );
+const makeStore = context => createStore( reducer, composeEnhancers( applyMiddleware( thunk ) ) );
 
 const storeWrapper = createWrapper( makeStore );
 

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -69,7 +69,10 @@ Commons.getInitialProps = async appContext => {
 
 Commons.propTypes = {
   apollo: propTypes.object,
-  Component: propTypes.func,
+  Component: propTypes.oneOfType( [
+    propTypes.func,
+    propTypes.object,
+  ] ),
   pageProps: propTypes.object,
   router: propTypes.object,
 };


### PR DESCRIPTION
Refactor the results page to use `getServerSideProps` rather than get `initialProps`.

As part of this update I added a `HYDRATE` action reducer to handle changes initiated by `next-redux-wrapper`. Also save dates as strings rather than objects so that they can be serialized when getting `getServerSideProps`.

Also addresses CDP-2316.