### PR TITLE
CDP-2381: Add resources section

### DIFF
--- a/components/ButtonAddFiles/ButtonAddFiles.js
+++ b/components/ButtonAddFiles/ButtonAddFiles.js
@@ -2,10 +2,7 @@ import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { Button } from 'semantic-ui-react';
 
-const ButtonAddFiles = props => {
-  const {
-    onChange, disabled, className, children, accept, multiple, fluid,
-  } = props;
+const ButtonAddFiles = ( { onChange, disabled, className, children, accept, multiple, fluid } ) => {
   const fileInput = React.createRef();
 
   // Trigger files dialogue on button click

--- a/components/admin/FileList/FileList.js
+++ b/components/admin/FileList/FileList.js
@@ -1,0 +1,40 @@
+import PropTypes from 'prop-types';
+
+import Filename from 'components/admin/Filename/Filename';
+import FileRemoveReplaceButtonGroup from 'components/admin/FileRemoveReplaceButtonGroup/FileRemoveReplaceButtonGroup';
+
+import styles from './FileList.module.scss';
+
+const FileList = ( { files, onRemove, projectId } ) => (
+  <ul className={ styles.list }>
+    { files.map( file => {
+      const { id, filename, input } = file;
+      const _filename = projectId ? filename : input?.name;
+
+      return (
+        <li key={ id } className={ `${styles.item} ${projectId ? 'available' : styles.unavailable}` }>
+          <span className={ styles.filename }>
+            <Filename
+              children={ _filename }
+              filenameLength={ 48 }
+              numCharsBeforeBreak={ 20 }
+              numCharsAfterBreak={ 28 }
+            />
+          </span>
+
+          <FileRemoveReplaceButtonGroup
+            onRemove={ () => onRemove( id ) }
+          />
+        </li>
+      );
+    } ) }
+  </ul>
+);
+
+FileList.propTypes = {
+  files: PropTypes.array,
+  onRemove: PropTypes.func,
+  projectId: PropTypes.string,
+};
+
+export default FileList;

--- a/components/admin/FileList/FileList.module.scss
+++ b/components/admin/FileList/FileList.module.scss
@@ -4,6 +4,7 @@
   list-style: none;
   padding-left: 0;
   font-size: 0.888888889rem;
+  max-width: 35%;
 
   > .item {
     display: flex;

--- a/components/admin/FileList/FileList.module.scss
+++ b/components/admin/FileList/FileList.module.scss
@@ -1,0 +1,33 @@
+@import 'styles/mixins.scss';
+
+.list {
+  list-style: none;
+  padding-left: 0;
+  font-size: 0.888888889rem;
+
+  > .item {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+
+    & [tooltip] {
+      margin: 0;
+      &:focus {
+        @include focus-styling;
+      }
+    }
+  }
+}
+
+.unavailable {
+  .filename {
+    span,
+    [tooltip] {
+      color: $medium-grey;
+    }
+  }
+
+  .FileRemoveReplaceButtonGroup__btn-group {
+    visibility: hidden;
+  }
+}

--- a/components/admin/PlaybookEdit/PlaybookEdit.js
+++ b/components/admin/PlaybookEdit/PlaybookEdit.js
@@ -214,7 +214,7 @@ const PlaybookEdit = ( { id: playbookId } ) => {
 
       <PlaybookTextEditor />
 
-      <PlaybookResources />
+      <PlaybookResources projectId={ playbookId } />
 
       <div className="actions">
         <ActionHeadline

--- a/components/admin/PlaybookEdit/PlaybookResources/PlaybookResources.js
+++ b/components/admin/PlaybookEdit/PlaybookResources/PlaybookResources.js
@@ -1,34 +1,69 @@
-import React from 'react';
-// import PropTypes from 'prop-types';
+import { Fragment, useState } from 'react';
+import PropTypes from 'prop-types';
 
 import ButtonAddFiles from 'components/ButtonAddFiles/ButtonAddFiles';
+import FileList from 'components/admin/FileList/FileList';
 
 import styles from './PlaybookResources.module.scss';
 
-const PlaybookResources = () => (
-  <section aria-label="Available Resources" className={ styles.container }>
-    <h2>Available Resources</h2>
-    <span>Upload Files</span>
+const PlaybookResources = ( { projectId } ) => {
+  const [files, setFiles] = useState( [] );
 
-    <div className={ styles.instructions }>
-      <p>
-        Upload files specific to this Playbook that are not available on Commons.
-      </p>
-      <p>
-        These files will not appear in any Commons search results.
-      </p>
-    </div>
+  /** This portion simulates the data returned from a file upload, should be replaced with an actual support file mutation */
+  const addFiles = e => {
+    const fileList = Array.from( e.target.files );
 
-    <ButtonAddFiles
-      accept=".docx, .pdf"
-      aria-label="Add files"
-      multiple
-    >
-      + Add Files
-    </ButtonAddFiles>
-  </section>
-);
+    const supportFiles = fileList.map( file => ( {
+      id: file.name,
+      filename: file.name,
+      input: {},
+    } ) );
 
-// PlaybookResources.propTypes = {};
+    setFiles( supportFiles );
+  };
+
+  const onRemove = id => {
+    const updated = files.filter( file => file.id !== id );
+
+    setFiles( updated );
+  };
+  /** End simulated portion */
+
+  return (
+    <section aria-label="Available Resources" className={ styles.container }>
+      <h2>Available Resources</h2>
+      <span>Upload Files</span>
+
+      <div className={ styles.instructions }>
+        <p>
+          Upload files specific to this Playbook that are not available on Commons.
+        </p>
+        <p>
+          These files will not appear in any Commons search results.
+        </p>
+      </div>
+
+      { files && files.length > 0 && (
+        <Fragment>
+          <strong>{ `Files Uploaded (${files.length})` }</strong>
+          <FileList files={ files } projectId={ projectId } onRemove={ onRemove } />
+        </Fragment>
+      ) }
+
+      <ButtonAddFiles
+        accept=".docx, .pdf"
+        aria-label="Add files"
+        multiple
+        onChange={ addFiles }
+      >
+        + Add Files
+      </ButtonAddFiles>
+    </section>
+  );
+};
+
+PlaybookResources.propTypes = {
+  projectId: PropTypes.string,
+};
 
 export default PlaybookResources;

--- a/components/admin/PlaybookEdit/PlaybookResources/PlaybookResources.js
+++ b/components/admin/PlaybookEdit/PlaybookResources/PlaybookResources.js
@@ -1,9 +1,31 @@
 import React from 'react';
 // import PropTypes from 'prop-types';
 
+import ButtonAddFiles from 'components/ButtonAddFiles/ButtonAddFiles';
+
+import styles from './PlaybookResources.module.scss';
+
 const PlaybookResources = () => (
-  <section aria-label="Available Resources">
+  <section aria-label="Available Resources" className={ styles.container }>
     <h2>Available Resources</h2>
+    <span>Upload Files</span>
+
+    <div className={ styles.instructions }>
+      <p>
+        Upload files specific to this Playbook that are not available on Commons.
+      </p>
+      <p>
+        These files will not appear in any Commons search results.
+      </p>
+    </div>
+
+    <ButtonAddFiles
+      accept=".docx, .pdf"
+      aria-label="Add files"
+      multiple
+    >
+      + Add Files
+    </ButtonAddFiles>
   </section>
 );
 

--- a/components/admin/PlaybookEdit/PlaybookResources/PlaybookResources.module.scss
+++ b/components/admin/PlaybookEdit/PlaybookResources/PlaybookResources.module.scss
@@ -1,0 +1,15 @@
+.container {
+  padding: 1.75em 0;
+  @media screen and (min-width: 768px) {
+    padding: 1.75em;
+  }
+}
+
+.instructions {
+  margin: 0.5rem 0 1rem;
+
+  > * {
+    font-size: 0.8rem;
+    margin: 0;
+  }
+}

--- a/components/admin/ProjectEdit/GraphicEdit/GraphicSupportFiles/GraphicSupportFiles.js
+++ b/components/admin/ProjectEdit/GraphicEdit/GraphicSupportFiles/GraphicSupportFiles.js
@@ -2,19 +2,18 @@ import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { useMutation } from '@apollo/client';
 import { Confirm } from 'semantic-ui-react';
+
 import ConfirmModalContent from 'components/admin/ConfirmModalContent/ConfirmModalContent';
 import IconPopup from 'components/popups/IconPopup/IconPopup';
-import Filename from 'components/admin/Filename/Filename';
-import FileRemoveReplaceButtonGroup from 'components/admin/FileRemoveReplaceButtonGroup/FileRemoveReplaceButtonGroup';
+import FileList from 'components/admin/FileList/FileList';
+
 import { GRAPHIC_PROJECT_QUERY, UPDATE_GRAPHIC_PROJECT_MUTATION } from 'lib/graphql/queries/graphic';
 import useTimeout from 'lib/hooks/useTimeout';
 import { getCount } from 'lib/utils';
+
 import './GraphicSupportFiles.scss';
 
-const GraphicSupportFiles = props => {
-  const {
-    projectId, headline, helperText, files, updateNotification,
-  } = props;
+const GraphicSupportFiles = ( { projectId, headline, helperText, files, updateNotification } ) => {
   const [fileIdToDelete, setFileIdToDelete] = useState( '' );
   const [deleteConfirmOpen, setDeleteConfirmOpen] = useState( false );
   const [updateGraphicProject] = useMutation( UPDATE_GRAPHIC_PROJECT_MUTATION );
@@ -64,34 +63,10 @@ const GraphicSupportFiles = props => {
       .catch( err => console.dir( err ) );
   };
 
-  const renderList = () => (
-    <ul className="support-files-list">
-      { files.map( file => {
-        const { id, filename, input } = file;
-        const _filename = projectId ? filename : input?.name;
-
-        return (
-          <li key={ id } className={ `support-file-item ${projectId ? 'available' : 'unavailable'}` }>
-            <span className="filename">
-              <Filename
-                children={ _filename }
-                filenameLength={ 48 }
-                numCharsBeforeBreak={ 20 }
-                numCharsAfterBreak={ 28 }
-              />
-            </span>
-
-            <FileRemoveReplaceButtonGroup
-              onRemove={ () => {
-                setDeleteConfirmOpen( true );
-                setFileIdToDelete( id );
-              } }
-            />
-          </li>
-        );
-      } ) }
-    </ul>
-  );
+  const onRemove = id => {
+    setDeleteConfirmOpen( true );
+    setFileIdToDelete( id );
+  };
 
   return (
     <div className={ `graphic-project-support-files ${headline.replace( ' ', '-' )}` }>
@@ -124,7 +99,7 @@ const GraphicSupportFiles = props => {
       />
 
       { getCount( files )
-        ? renderList()
+        ? <FileList files={ files } onRemove={ onRemove } projectId={ projectId } />
         : <p className="no-files">No files to upload</p> }
     </div>
   );

--- a/components/admin/ProjectEdit/GraphicEdit/GraphicSupportFiles/GraphicSupportFiles.scss
+++ b/components/admin/ProjectEdit/GraphicEdit/GraphicSupportFiles/GraphicSupportFiles.scss
@@ -1,4 +1,4 @@
-@import "styles/mixins.scss";
+@import 'styles/mixins.scss';
 
 .graphic-project-support-files {
   .list-heading {
@@ -16,37 +16,5 @@
     padding-top: 0.625rem;
     padding-bottom: 0.625rem;
     font-size: 0.888888889rem;
-  }
-
-  .support-files-list {
-    list-style: none;
-    padding-left: 0;
-    font-size: 0.888888889rem;
-
-    > .support-file-item {
-      display: flex;
-      align-items: center;
-      justify-content: space-between;
-
-      &.unavailable {
-        .filename {
-          span,
-          [tooltip] {
-            color: $medium-grey;
-          }
-        }
-
-        .FileRemoveReplaceButtonGroup__btn-group {
-          visibility: hidden;
-        }
-      }
-
-      [tooltip] {
-        margin: 0;
-        &:focus {
-          @include focus-styling;
-        }
-      }
-    }
   }
 }


### PR DESCRIPTION
Focused on getting the UI in place since the publish mutations aren't hooked up yet. As such, the add and remove file actions simulate the uploading/removing of files rather than kicking off actual mutations.

Since I used the graphics support file list as a starting point, I that out into a reusable `FileList` component that can be utilized in a couple other places reducing redundancy. The original had a number of nested CSS properties which I switched to CSS modules so we may want to double check at some other break points to make sure it looks good everywhere. Additionally, tests need to be extracted from the portion of the `GraphicSupportFiles.test.js` file that pertains to the file list.