### PR TITLE
CDP 2337 - Add character count validation to internal description field

### DIFF
--- a/components/admin/PackageCreate/ButtonPackageCreate/ButtonPackageCreate.js
+++ b/components/admin/PackageCreate/ButtonPackageCreate/ButtonPackageCreate.js
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { useRouter } from 'next/router';
 import { useMutation } from '@apollo/client';
-
+import { useFormikContext } from 'formik';
 import { getCount, getPluralStringOrNot } from 'lib/utils';
 
 import ButtonAddFiles from 'components/ButtonAddFiles/ButtonAddFiles';
@@ -12,25 +12,29 @@ import useToggleModal from 'lib/hooks/useToggleModal';
 import { useFileUpload } from 'lib/hooks/useFileUpload';
 
 import { buildCreateDocument } from 'lib/graphql/builders/document';
-import { UPDATE_PACKAGE_MUTATION } from 'lib/graphql/queries/package';
+import { buildCreatePlaybookTree } from 'lib/graphql/builders/playbook';
+import { buildCreatePackageTree } from 'lib/graphql/builders/package';
+import { UPDATE_PACKAGE_MUTATION,
+  CREATE_PACKAGE_MUTATION,
+  PACKAGE_EXISTS_QUERY } from 'lib/graphql/queries/package';
+import { CREATE_PLAYBOOK_MUTATION } from 'lib/graphql/queries/playbook';
 
 import styles from './ButtonPackageCreate.module.scss';
 
-
-const ButtonPackageCreate = ( {
-  pkg,
-  formikProps,
-  createGuidancePackage,
-  createPlaybookPackage,
-} ) => {
+const ButtonPackageCreate = ( { user, setError } ) => {
   const [files, setFiles] = useState( [] );
   const [progress, setProgress] = useState( 0 );
+  const [pkg, setPkg] = useState( null );
+  const { values, isValid } = useFormikContext();
 
-  const { modalOpen, handleOpenModel, handleCloseModal } = useToggleModal();
   const router = useRouter();
+  const { modalOpen, handleOpenModel, handleCloseModal } = useToggleModal();
   const { uploadFile } = useFileUpload();
 
   const [updatePackage] = useMutation( UPDATE_PACKAGE_MUTATION );
+  const [createPlaybook] = useMutation( CREATE_PLAYBOOK_MUTATION );
+  const [createPackage] = useMutation( CREATE_PACKAGE_MUTATION );
+  const [packageExists] = useMutation( PACKAGE_EXISTS_QUERY );
 
   const createFile = async ( { id, assetPath }, file, callback ) => {
     let _file;
@@ -77,16 +81,99 @@ const ButtonPackageCreate = ( {
     router.push( `/admin/package/guidance/${pkg?.id}` );
   };
 
-  const createPackage = async e => {
+  /**
+   * Checks whether a package exists with the supplied field name and values
+   * @param {object} where clause containing fields to test existence against, i.e. { title: Daily Guidance }
+   * @returns bool
+   */
+  const doesPackageExist = async where => {
+    const res = await packageExists( {
+      variables: {
+        where,
+      },
+    } );
+
+    return res.data.packageExists;
+  };
+
+  /**
+   * Convenience func to execute graphql create mutations
+   * @param {func} creator create mutation
+   * @param {func} builder func to transform form values to applicable package type format
+   * @param {object} values form values
+   * @returns Promise
+   */
+  const executeCreate = async ( creator, builder, vals ) => creator( {
+    variables: {
+      data: builder( vals ),
+    },
+  } );
+
+  /**
+  * Create guidance package and send user to
+  * package edit screen on success.
+  * @returns void
+  */
+  const createGuidancePackage = async vals => {
+    const { title } = vals;
+    const _values = {
+      title,
+      type: 'DAILY_GUIDANCE',
+      userId: user.id,
+      teamId: user.team.id,
+    };
+
+    if ( await doesPackageExist( { title } ) ) {
+      setError( `A Guidance Package with the name "${title}" already exists.` );
+
+      return;
+    }
+
+    try {
+      const res = await executeCreate( createPackage, buildCreatePackageTree, _values );
+
+      setPkg( res.data.createPackage );
+
+      return res.data.createPackage;
+    } catch ( err ) {
+      setError( err );
+    }
+  };
+
+  /**
+  * Create playbook package and send user to
+  * playbook edit screen on success.
+  * @returns void
+  */
+  const createPlaybookPackage = async vals => {
+    const _values = { ...vals };
+
+    // Remove values
+    delete _values.visibility;
+    delete _values.termsConditions;
+
+    _values.userId = user.id;
+    _values.teamId = user.team.id;
+
+    try {
+      const res = await executeCreate( createPlaybook, buildCreatePlaybookTree, _values );
+
+      router.push( `/admin/package/playbook/${res.data.createPlaybook.id}` );
+    } catch ( err ) {
+      setError( err );
+    }
+  };
+
+  const _createPackage = async e => {
     const fileList = Array.from( e.target.files );
-    const _pkg = await createGuidancePackage( formikProps.values );
+    const _pkg = await createGuidancePackage( values );
 
     if ( _pkg?.id ) {
       handleAddFiles( fileList );
     }
   };
 
-  return ( ( formikProps.values.type === 'DAILY_GUIDANCE' )
+  return ( ( values.type === 'PACKAGE' || values.type === 'DAILY_GUIDANCE' )
     ? (
       <EditPackageFiles
         filesToEdit={ files }
@@ -94,8 +181,8 @@ const ButtonPackageCreate = ( {
         trigger={ (
           <ButtonAddFiles
             accept=".doc, .docx"
-            onChange={ createPackage }
-            disabled={ !formikProps.isValid }
+            onChange={ _createPackage }
+            disabled={ !isValid }
             fluid
             multiple
           >
@@ -116,9 +203,9 @@ const ButtonPackageCreate = ( {
     : (
       <button
         type="button"
-        disabled={ !formikProps.isValid }
+        disabled={ !isValid }
         className={ styles['btn-submit'] }
-        onClick={ () => createPlaybookPackage( formikProps.values ) }
+        onClick={ () => createPlaybookPackage( values ) }
       >
         Save draft & continue
       </button>
@@ -126,10 +213,8 @@ const ButtonPackageCreate = ( {
 };
 
 ButtonPackageCreate.propTypes = {
-  formikProps: PropTypes.object,
-  pkg: PropTypes.object,
-  createGuidancePackage: PropTypes.func,
-  createPlaybookPackage: PropTypes.func,
+  user: PropTypes.object,
+  setError: PropTypes.func,
 };
 
 export default ButtonPackageCreate;

--- a/components/admin/PackageCreate/ButtonPackageCreate/ButtonPackageCreate.js
+++ b/components/admin/PackageCreate/ButtonPackageCreate/ButtonPackageCreate.js
@@ -3,21 +3,23 @@ import PropTypes from 'prop-types';
 import { useRouter } from 'next/router';
 import { useMutation } from '@apollo/client';
 import { useFormikContext } from 'formik';
-import { getCount, getPluralStringOrNot } from 'lib/utils';
 
 import ButtonAddFiles from 'components/ButtonAddFiles/ButtonAddFiles';
 import EditPackageFiles from 'components/admin/PackageEdit/EditPackageFilesModal/EditPackageFilesModal';
 
-import useToggleModal from 'lib/hooks/useToggleModal';
+import { getCount, getPluralStringOrNot } from 'lib/utils';
 import { useFileUpload } from 'lib/hooks/useFileUpload';
+import useToggleModal from 'lib/hooks/useToggleModal';
 
 import { buildCreateDocument } from 'lib/graphql/builders/document';
 import { buildCreatePlaybookTree } from 'lib/graphql/builders/playbook';
 import { buildCreatePackageTree } from 'lib/graphql/builders/package';
-import { UPDATE_PACKAGE_MUTATION,
-  CREATE_PACKAGE_MUTATION,
-  PACKAGE_EXISTS_QUERY } from 'lib/graphql/queries/package';
 import { CREATE_PLAYBOOK_MUTATION } from 'lib/graphql/queries/playbook';
+import {
+  CREATE_PACKAGE_MUTATION,
+  PACKAGE_EXISTS_QUERY,
+  UPDATE_PACKAGE_MUTATION,
+} from 'lib/graphql/queries/package';
 
 import styles from './ButtonPackageCreate.module.scss';
 

--- a/components/admin/PackageCreate/ButtonPackageCreate/ButtonPackageCreate.module.scss
+++ b/components/admin/PackageCreate/ButtonPackageCreate/ButtonPackageCreate.module.scss
@@ -7,6 +7,7 @@
   border-radius: 4px;
   box-shadow: 0px 1px 2px rgba(0,0,0,0.2); 
   transition: all 0.1s ease 0s;
+  white-space: nowrap;
   cursor: pointer;
 
   &:disabled {

--- a/components/admin/PackageCreate/PackageCreate.js
+++ b/components/admin/PackageCreate/PackageCreate.js
@@ -1,18 +1,18 @@
 import React, { useState, useEffect } from 'react';
-import { useRouter } from 'next/router';
 import { Formik } from 'formik';
 import moment from 'moment';
+import { useQuery } from '@apollo/client';
+import { useRouter } from 'next/router';
 
 import ApolloError from 'components/errors/ApolloError';
-import ProjectHeader from '../ProjectHeader/ProjectHeader';
-import PackageForm from './PackageForm/PackageForm';
 import ButtonPackageCreate from './ButtonPackageCreate/ButtonPackageCreate';
 import Checkbox from './PackageForm/Checkbox/Checkbox';
+import PackageForm from './PackageForm/PackageForm';
+import ProjectHeader from '../ProjectHeader/ProjectHeader';
 
 import { guidanceSchema, packageSchema } from './PackageForm/validationSchema';
-import { useAuth } from 'context/authContext';
-import { useQuery } from '@apollo/client';
 import { PACKAGE_TYPE_QUERY } from 'components/admin/dropdowns/PackageTypeDropdown/PackageTypeDropdown';
+import { useAuth } from 'context/authContext';
 
 import styles from './PackageCreate.module.scss';
 

--- a/components/admin/PackageCreate/PackageCreate.module.scss
+++ b/components/admin/PackageCreate/PackageCreate.module.scss
@@ -12,27 +12,21 @@
     transition: all 0.1s ease 0s,
   } 
 
-  .form-child { 
-    display: grid;
-    grid-template-columns: 1fr; 
-    grid-gap: 1rem;
-    align-items: start;
-    margin-top: 1em; 
-
-    @media (min-width: 700px ) {  
-      grid-column: span 2; 
-      grid-template-columns: 1fr 1fr; 
-      margin-top: 2em;
+  .container { 
+    display: flex; 
+    flex-wrap: wrap;
+    gap: 1.5em;;
+    
+    &-btn {
+     flex: 1 0 8em;
+     
+     > * {
+       width: 100%;
+     } 
     }
 
-    @media (min-width: 1000px ) {
-      grid-column: span 4;
-      grid-template-columns: repeat( 4, 1fr); 
-
-      .terms {
-        grid-column: span 2;
-      } 
-    }
+    &-terms {
+      flex: 2 1 auto;
+    } 
   } 
- 
 }

--- a/components/admin/PackageCreate/PackageCreate.module.scss
+++ b/components/admin/PackageCreate/PackageCreate.module.scss
@@ -15,7 +15,8 @@
   .container { 
     display: flex; 
     flex-wrap: wrap;
-    gap: 1.5em;;
+    gap: 1.5em;
+    margin-top: 1em;
     
     &-btn {
      flex: 1 0 8em;

--- a/components/admin/PackageCreate/PackageForm/PackageForm.module.scss
+++ b/components/admin/PackageCreate/PackageForm/PackageForm.module.scss
@@ -2,8 +2,7 @@
 @import "styles/mixins.scss";
 
 @include required-text;
-
-//hidden] { display: none !important; }
+@include field-helper-text;
 
 .form_container {
   padding: 1.75em 0;
@@ -21,7 +20,11 @@
   .form {
     display: grid; 
     grid-template-columns: 1fr;
-    grid-gap: 1rem;
+    grid-gap: 1.5rem 1rem;
+
+    &:first-child {
+      margin-bottom: 1.5em;
+    }
 
     @media (min-width: 700px ) {
       grid-template-columns: 1fr 1fr;

--- a/components/admin/PackageCreate/PackageForm/PackageForm.module.scss
+++ b/components/admin/PackageCreate/PackageForm/PackageForm.module.scss
@@ -44,7 +44,7 @@
     
     .dropdown-required {
       label {
-       @include label; 
+       @include form-field-label; 
         &::after {
           @include asterisk;
         } 
@@ -52,7 +52,7 @@
     }
  
     label {
-      @include label;  
+      @include form-field-label;  
     } 
   } 
  

--- a/components/admin/PackageCreate/PackageForm/PackageType/PackageType.js
+++ b/components/admin/PackageCreate/PackageForm/PackageType/PackageType.js
@@ -10,12 +10,12 @@ import { titleCase } from 'lib/utils';
 /**
  * Displays a readonly input for a team with a single content type
  * or a dropdown for a team with multiple content types
- * @params {}
- *  contentTypes: teams' associated content types
- *  value: field current value
- *  onChange: formik change handler
- *  required: is field required
- * @returns PackageTypeDropdown | TextInput
+ * @param {Object} props
+ * @param {string[]} props.packageTypes The package types that are associated with the current team. Array should only include 'PACKAGE', 'PLAYBOOK', and/or 'TOOLKIT'.
+ * @param {string} props.value The field's current value.
+ * @param {func} props.onChange The formik change handler callback function.
+ * @param {bool} props.required Whether or not the given field is required.
+ * @returns {PackageTypeDropdown|TextInput}
  */
 const PackageType = ( { packageTypes, value, onChange, required } ) => {
   const router = useRouter();

--- a/components/admin/PackageCreate/PackageForm/PackageType/PackageType.js
+++ b/components/admin/PackageCreate/PackageForm/PackageType/PackageType.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { useRouter } from 'next/router';
-import intersection from 'lodash/intersection';
 
 import TextInput from 'components/admin/PackageCreate/PackageForm/TextInput/TextInput';
 import PackageTypeDropdown from 'components/admin/dropdowns/PackageTypeDropdown/PackageTypeDropdown';
@@ -18,17 +17,9 @@ import { titleCase } from 'lib/utils';
  *  required: is field required
  * @returns PackageTypeDropdown | TextInput
  */
-const PackageType = ( { contentTypes, value, onChange, required } ) => {
+const PackageType = ( { packageTypes, value, onChange, required } ) => {
   const router = useRouter();
   const isCreate = router.route.includes( '/package/create' );
-
-  const packageTypes = [
-    'PACKAGE',
-    'TOOLKIT',
-    'PLAYBOOK',
-  ];
-
-  const types = intersection( packageTypes, contentTypes );
 
   const renderTextInput = val => (
     <TextInput
@@ -50,7 +41,7 @@ const PackageType = ( { contentTypes, value, onChange, required } ) => {
   // if on create screen, return either input or dropdown based
   // on num content types in packageTypes type array above
   return (
-    ( types.length > 1 )
+    ( packageTypes.length > 1 )
       ? (
         <PackageTypeDropdown
           id="type"
@@ -58,16 +49,19 @@ const PackageType = ( { contentTypes, value, onChange, required } ) => {
           label="Package Type"
           value={ value }
           onChange={ onChange }
-          contentTypes={ types }
+          contentTypes={ packageTypes }
         />
       )
-      : renderTextInput( types[0] || '' )
+      : renderTextInput( packageTypes[0] || '' )
   );
 };
 
+PackageTypeDropdown.defaultProps = {
+  contentTypes: [],
+};
 
 PackageType.propTypes = {
-  contentTypes: PropTypes.array,
+  packageTypes: PropTypes.array,
   value: PropTypes.string,
   required: PropTypes.bool,
   onChange: PropTypes.func,

--- a/components/admin/PackageCreate/PackageForm/TextInput/TextInput.js
+++ b/components/admin/PackageCreate/PackageForm/TextInput/TextInput.js
@@ -1,6 +1,7 @@
-import React from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { useField } from 'formik';
+
 import styles from './TextInput.module.scss';
 
 const TextArea = props => (
@@ -11,20 +12,54 @@ const Input = props => (
   <input autoComplete="off" { ...props } />
 );
 
-const TextInput = ( { label, ...props } ) => {
+const TextInput = ( { label, helperTxt, maxLength, ...props } ) => {
+  const [chars, setChars] = useState( 0 );
   const [field, meta] = useField( props.name );
+
   const Component = props.type === 'text' ? Input : TextArea;
 
+  /**
+   * Intercept and forward change event to formik onchange handler
+   * to add additional logic to handle text character count. Could
+   * receive additional change handler as a prop to make component
+   * a bit more flexible
+   * @param {object} native event obj
+   */
+  const handleOnChange = e => {
+    field.onChange( e );
+    setChars( e.target.value.length );
+  };
+
+  // append additional props to forward to native input control
+  const _props = {
+    ...props,
+    'aria-describedby': `describedby${props.id}`,
+    onChange: handleOnChange,
+    maxLength,
+  };
+
   return (
-    <div className={ styles.textInput }>
+    <div className={ styles['text-input'] }>
       <label htmlFor={ props.id }>
         <span className={ props.required ? styles.required : '' }>{ label }</span>
         <Component
           { ...field }
-          { ...props }
+          { ..._props }
           { ...( meta.touched && meta.error && { 'aria-invalid': 'true' } ) }
         />
       </label>
+      <div className={ styles['text-input-helper'] }>
+        <p id={ `describedby${props.id}` } className={ styles['field__helper-text'] }>{ helperTxt }</p>
+        { !!maxLength && (
+          <p
+            aria-live="polite"
+            className={ `${styles['field__helper-text']} ${chars === maxLength && styles['max-char']}` }
+          >
+            { `${chars} of ${maxLength} characters` }
+          </p>
+        ) }
+      </div>
+
       <p aria-live="polite" className={ styles.required_error }>{ meta.touched ? meta.error : '' }</p>
     </div>
   );
@@ -36,6 +71,8 @@ TextInput.propTypes = {
   type: PropTypes.string,
   required: PropTypes.bool,
   label: PropTypes.string,
+  helperTxt: PropTypes.string,
+  maxLength: PropTypes.number,
 };
 
 export default TextInput;

--- a/components/admin/PackageCreate/PackageForm/TextInput/TextInput.module.scss
+++ b/components/admin/PackageCreate/PackageForm/TextInput/TextInput.module.scss
@@ -3,7 +3,7 @@
 .textInput {
   @include required-asterisk;
   @include required-error;
-  @include label;
+  @include form-field-label;
 
   [type="text"],
   textarea {
@@ -31,6 +31,5 @@
   }
 
   label span {
-    @include label;  
-  } 
+    @include form-field-label;  
 }

--- a/components/admin/PackageCreate/PackageForm/TextInput/TextInput.module.scss
+++ b/components/admin/PackageCreate/PackageForm/TextInput/TextInput.module.scss
@@ -1,8 +1,10 @@
 @import "styles/mixins.scss";
+@import "styles/colors.scss";
 
-.textInput {
+.text-input {
   @include required-asterisk;
   @include required-error;
+  @include field-helper-text;
   @include form-field-label;
 
   [type="text"],
@@ -17,7 +19,7 @@
     &:focus {  
       border: 1px solid $half-baked; 
       outline: none;
-      //@include focus-styling($kbd_only: false);
+      //@include focus-styling();
     }
   
     &[aria-invalid] {
@@ -32,4 +34,14 @@
 
   label span {
     @include form-field-label;  
+  } 
+
+  &-helper {
+    display: flex;
+    justify-content:space-between;
+  }
+
+  .max-char {
+    color: $red;
+  }
 }

--- a/components/admin/PackageCreate/PackageForm/validationSchema.js
+++ b/components/admin/PackageCreate/PackageForm/validationSchema.js
@@ -1,11 +1,11 @@
 import * as Yup from 'yup';
 
 const _packageSchema = {
-  categories: Yup.array()
-    .max( 2, 'Maximum of 2 categories can be selected' )
-    .required( 'At least 1 category is required.' ),
   desc: Yup.string()
     .required( 'An internal description is required.' ),
+  categories: Yup.array()
+    .min( 1, 'At least 1 category is required.' )
+    .max( 2, 'Maximum of 2 categories can be selected' ),
 };
 
 const _guidanceSchema = {

--- a/components/admin/PackageEdit/PackageFiles/PressPackageFile/PressPackageFile.module.scss
+++ b/components/admin/PackageEdit/PackageFiles/PressPackageFile/PressPackageFile.module.scss
@@ -52,7 +52,7 @@
     // add required * and format label for semantic dropdown
     .dropdown_required {
       label {
-       @include label; 
+       @include form-field-label; 
         &::after {
           @include asterisk;
         } 
@@ -61,64 +61,10 @@
 
     .dropdown  {
       label {
-        @include label;
+        @include form-field-label;
       }  
     }
   }
 
   @include field-helper-text
 }
-
-// .package-file2 {
-//   padding-top: 2em;
-//   padding-bottom: 2em;
-//   @media screen and (min-width: 768px) {
-//     padding-bottom: 2.5em;
-//   }
-
-//   &:not(:last-child) {
-//     border-bottom: 1px solid $light-grey;
-//   }
-
-//   fieldset {
-//     &.form-fields {
-//       border: 0;
-//       margin: 0;
-//       padding: 0;
-
-//       .field > .data {
-//         // for long strings in title - break word w/ hyphens if browser support, otherwise fallback to wrap
-//         @include hyphenate;
-//         @include wrap-text;
-//       }
-//     }
-//   }
-
-//   @media screen and (max-width: 767px) {
-//     .ui.form .fields:not(:last-child),
-//     .ui.form .fields .field:not(:last-child) {
-//       margin-bottom: 1em;
-//     }
-//   }
-
-//   .thumbnail {
-//     > img {
-//       width: 225px;
-//       margin-bottom: 1em;
-//       height: auto;
-//       max-width: 100%;
-//       box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px 0 rgba(0, 0, 0, 0.2);
-//       @media screen and (min-width: 767px) {
-//         width: 100%;
-//       }
-//     }
-//   }
-
-//   .meta {
-//     > .data {
-//       margin-bottom: 1.5em;      
-//     }
-//   }
-
-//   @include field-helper-text;
-// }

--- a/styles/mixins.scss
+++ b/styles/mixins.scss
@@ -146,8 +146,8 @@
   }
 }
 
-// used for form labels
-@mixin label($display: block) {
+// used for form field labels
+@mixin form-field-label($display: block) {
   display: $display;
   font-size: 1rem;
   color: $blue;


### PR DESCRIPTION
Adds a character count validation to Playbook internal description field.  Does this by adding validation to the TextInput component to make functionality available for other contexts. In addition, this PR addresses a few other issues:

- Updates schema and validates form when the Package types is changed
- Moves package create functions to the ButtonPackage create component
- Determines team package types in the PackageCreate screen and passes types thru props to make it less error prone and to avoid the whole PackageType/ContentType confusion
- Removes functionality specific for the "Press Guidance" team, e.g. title is pre-populated for the press team, and treats the Package type the same regardless of team.
- Updates various styles