### PR TITLE
CDP-2400: Save Playbook text editor data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ _This sections lists changes committed since most recent release_
 - CKEditor5 and custom editor build directory
 - CKEditor5 setup to `TextEditor`
 - CKEditor5 custom build file to eslint `ignorePattern`
+- Mutation for updating a playbook: `UPDATE_PLAYBOOK_MUTATION`
 
 
 **Changed:**
@@ -59,6 +60,7 @@ _This sections lists changes committed since most recent release_
 - Use CSS modules for `ProjectHeader` component styling
 - Rename `PlaybookTextEditor` to `TextEditor` and move up one level
 - Update tests for `TextEditor`
+- Replace mock mutation with `updatePlaybook` mutation in `PlaybookEdit`
 
 **Fixed:**
 - Skip to content link for improved accessibility

--- a/components/admin/PlaybookEdit/PlaybookEdit.js
+++ b/components/admin/PlaybookEdit/PlaybookEdit.js
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { useRouter } from 'next/router';
-import { useQuery } from '@apollo/client';
+import { useMutation, useQuery } from '@apollo/client';
 import { Loader } from 'semantic-ui-react';
 import useIsDirty from 'lib/hooks/useIsDirty';
 // import usePublish from 'lib/hooks/usePublish';
@@ -19,6 +19,7 @@ import {
   // DELETE_PLAYBOOK_MUTATION,
   // PUBLISH_PLAYBOOK_MUTATION,
   // UNPUBLISH_PLAYBOOK_MUTATION,
+  UPDATE_PLAYBOOK_MUTATION,
   // UPDATE_PLAYBOOK_STATUS_MUTATION,
 } from 'lib/graphql/queries/playbook';
 
@@ -47,6 +48,7 @@ const PlaybookEdit = ( { id: playbookId } ) => {
   // const [publishPlaybook] = useMutation( PUBLISH_PLAYBOOK_MUTATION );
   // const [unpublishPlaybook] = useMutation( UNPUBLISH_PLAYBOOK_MUTATION );
   // const [updatePlaybookStatus] = useMutation( UPDATE_PLAYBOOK_STATUS_MUTATION );
+  const [updatePlaybook] = useMutation( UPDATE_PLAYBOOK_MUTATION );
 
   const [publishOperation, setPublishOperation] = useState( '' );
   const [deleteConfirmOpen, setDeleteConfirmOpen] = useState( false );
@@ -216,15 +218,7 @@ const PlaybookEdit = ( { id: playbookId } ) => {
         id={ playbookId }
         content={ playbook?.content || {} }
         type={ playbook.type }
-        updateMutation={ async obj => ( {
-          // temp: mock mutation
-          id: playbookId,
-          type: playbook.type,
-          content: {
-            id: playbook.content.id,
-            html: obj.variables.data.content.update.html,
-          },
-        } ) }
+        updateMutation={ updatePlaybook }
       />
 
       <PlaybookResources projectId={ playbookId } />

--- a/lib/graphql/queries/playbook.js
+++ b/lib/graphql/queries/playbook.js
@@ -69,6 +69,20 @@ export const CREATE_PLAYBOOK_MUTATION = gql`
  }
 `;
 
+// Return complete tree to enable auto cache update
+export const UPDATE_PLAYBOOK_MUTATION = gql`
+  mutation UPDATE_PLAYBOOK_MUTATION(
+    $data: PlaybookUpdateInput!
+    $where: PlaybookWhereUniqueInput!
+  ) {
+    # return all data to trigger auto cache update
+    updatePlaybook(data: $data, where: $where) {  
+      ...playbookDetails
+    } 
+  }
+  ${PLAYBOOK_DETAILS_FRAGMENT}
+`;
+
 /*----------------------------------------
  Queries
  -----------------------------------------*/


### PR DESCRIPTION
This PR replaces the mock mutation in `PlaybookEdit` with an actual `updatePlaybook` mutation. See also the server PR #59.