### PR TITLE
CDP-2395: Implement Save & Exit button

### DIFF
--- a/components/admin/PlaybookEdit/PlaybookEdit.scss
+++ b/components/admin/PlaybookEdit/PlaybookEdit.scss
@@ -2,6 +2,11 @@
 @import 'styles/mixins.scss';
 
 .edit-playbook {
+  padding: 6.7rem 1rem 0;
+  @media screen and (min-width: 768px) {
+    padding: 5rem 2rem 0;
+  }
+
   @media screen and (max-width: 550px) {
     .project_buttons {
       @include multi-column-layout;


### PR DESCRIPTION
The `PlaybookEdit` action buttons were hidden under the site's fixed header. This was occurring because we're not using the Semantic UI container to wrap the page. I added `padding` to the page to reveal the page's header and action buttons and match the appearance of other edit pages.

The functionality of the Save & Edit button was already in place. That is, clicking on the button redirected to the dashboard as expected.