### PR TITLE
CDP-2403: GraphQL error when I tried to save using the Text Editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,7 @@ _This sections lists changes committed since most recent release_
 - Prevent opening of results per page dropdown when focused
 - Live region for the results per page dropdown that gets announced by screen readers when changed
 - Add image dimensions to the DoS seal in the `Header`
+- Use `upsert` for the `TextEditor` `updateMutation` to prevent `the relation has no node...` GraphQL error
 
 # [5.4.8](https://github.com/IIP-Design/content-commons-client/compare/v5.4.7...v5.4.8)(2021-04-29)
 **Fixed:**

--- a/components/admin/PlaybookEdit/PlaybookEdit.js
+++ b/components/admin/PlaybookEdit/PlaybookEdit.js
@@ -217,6 +217,7 @@ const PlaybookEdit = ( { id: playbookId } ) => {
       <TextEditor
         id={ playbookId }
         content={ playbook?.content || {} }
+        query={ PLAYBOOK_QUERY }
         type={ playbook.type }
         updateMutation={ updatePlaybook }
       />


### PR DESCRIPTION
This PR addresses a bug where calling the `updatePlaybook` mutation in the `TextEditor` component resulted in the following GraphQL error:

```
Error: The relation DocumentConversionFormatToPlaybook has no node
for the model Playbook connected to a Node for the model DocumentConversionFormat
on your mutation path.
```
I replaced the `update` in the `data` tree with an `upsert`. In addition, I added a cache refresh to the mutation based on behavior observed on dev.