### PR TITLE
CDP-2399: Connect the Additional Resources file uploader

### DIFF
--- a/components/admin/PlaybookEdit/PlaybookEdit.js
+++ b/components/admin/PlaybookEdit/PlaybookEdit.js
@@ -224,6 +224,7 @@ const PlaybookEdit = ( { id: playbookId } ) => {
 
       <PlaybookResources
         assetPath={ playbook.assetPath || '' }
+        files={ playbook.supportFiles || [] }
         projectId={ playbookId }
         updateMutation={ updatePlaybook }
       />

--- a/components/admin/PlaybookEdit/PlaybookEdit.js
+++ b/components/admin/PlaybookEdit/PlaybookEdit.js
@@ -209,7 +209,7 @@ const PlaybookEdit = ( { id: playbookId } ) => {
       />
 
       <PlaybookDetailsFormContainer
-        playbook={ data.playbook }
+        playbook={ playbook }
         updateNotification={ updateNotification }
         setIsFormValid={ setIsFormValid }
       />
@@ -222,7 +222,11 @@ const PlaybookEdit = ( { id: playbookId } ) => {
         updateMutation={ updatePlaybook }
       />
 
-      <PlaybookResources projectId={ playbookId } />
+      <PlaybookResources
+        assetPath={ playbook.assetPath || '' }
+        projectId={ playbookId }
+        updateMutation={ updatePlaybook }
+      />
 
       <div className="actions">
         <ActionHeadline

--- a/components/admin/PlaybookEdit/PlaybookResources/PlaybookResources.js
+++ b/components/admin/PlaybookEdit/PlaybookResources/PlaybookResources.js
@@ -19,7 +19,8 @@ const PlaybookResources = ( { assetPath, files, projectId, updateMutation } ) =>
   } );
 
   /**
-   * Uploads and saves files. If error occurs, set 'error' prop on file object
+   * Iterates of a provided list of files, uploading each to S3 and initiating the callback function to save the file connect in GraphQL.
+   * If error occurs during upload, it sets and 'error' prop on the file object
    * @param {string} id project id
    * @param {array} fileList files to save
    * @param {string} savePath path to S3 directory to save
@@ -40,7 +41,7 @@ const PlaybookResources = ( { assetPath, files, projectId, updateMutation } ) =>
   );
 
   /**
-   * Save support file.
+   * Save a support file's data to GraphQL.
    * @param {string} id project id
    * @param {object} file file to save
    * @return {Promise}
@@ -64,6 +65,10 @@ const PlaybookResources = ( { assetPath, files, projectId, updateMutation } ) =>
     } );
   };
 
+  /**
+   * Handles the file uploads, generating an array of files and passing it to the upload function.
+   * @param {Event} e A React synthetic file upload event.
+   */
   const addFiles = async e => {
     const fileList = Array.from( e.target.files ).map( file => ( { input: file } ) );
 
@@ -75,6 +80,11 @@ const PlaybookResources = ( { assetPath, files, projectId, updateMutation } ) =>
     );
   };
 
+  /**
+   * Disconnects the given support file from the current playbook.
+   * @param {string} id The id of the file to be disconnected from the playbook.
+   * @returns {Object} The updated playbook data.
+   */
   const onRemove = id => updateMutation( {
     variables: {
       data: {

--- a/components/admin/PlaybookEdit/PlaybookResources/PlaybookResources.js
+++ b/components/admin/PlaybookEdit/PlaybookResources/PlaybookResources.js
@@ -1,31 +1,88 @@
-import { useState } from 'react';
 import PropTypes from 'prop-types';
+import { useMutation, useQuery } from '@apollo/client';
 
 import ButtonAddFiles from 'components/ButtonAddFiles/ButtonAddFiles';
 import FileList from 'components/admin/FileList/FileList';
 
+import { buildSupportFile } from 'lib/graphql/builders/common';
+import { useFileUpload } from 'lib/hooks/useFileUpload';
+import { PLAYBOOK_QUERY } from 'lib/graphql/queries/playbook';
+import { LANGUAGE_BY_NAME_QUERY } from 'components/admin/dropdowns/LanguageDropdown/LanguageDropdown';
+
 import styles from './PlaybookResources.module.scss';
 
-const PlaybookResources = ( { projectId } ) => {
-  const [files, setFiles] = useState( [] );
+const PlaybookResources = ( { assetPath, projectId, updateMutation } ) => {
+  const { uploadFile } = useFileUpload();
+
+  /**
+   * Get the English language data.
+   */
+  const { data: languageData } = useQuery( LANGUAGE_BY_NAME_QUERY, {
+    variables: { displayName: 'English' },
+  } );
+
+  /**
+   * Uploads and saves files. If error occurs, set 'error' prop on file object
+   * @param {string} id project id
+   * @param {array} files files to save
+   * @param {string} savePath path to S3 directory to save
+   * @param {func} saveFn save function
+   * @param {func} progress progress callback function
+   * @return {Promise}
+   */
+  const uploadAndSaveFiles = ( id, files, savePath, saveFn, progress ) => Promise.all(
+    files.map( async file => {
+      const _file = await uploadFile( savePath, file, progress );
+
+      if ( _file.error ) {
+        return Promise.resolve( { ...file, error: true } );
+      }
+
+      return saveFn( id, _file );
+    } ),
+  );
+
+  /**
+   * Save support file.
+   * @param {string} id project id
+   * @param {object} file file to save
+   * @return {Promise}
+   */
+  const saveSupportFile = async ( id, file ) => {
+    const _file = { ...file };
+
+    _file.language = languageData.languages[0].id;
+    _file.visibility = 'INTERNAL';
+    _file.editable = false;
+
+    return updateMutation( {
+      variables: {
+        data: {
+          supportFiles: {
+            create: [buildSupportFile( _file )],
+          },
+        },
+        where: { id },
+      },
+    } );
+  };
 
   /** This portion simulates the data returned from a file upload, should be replaced with an actual support file mutation */
-  const addFiles = e => {
-    const fileList = Array.from( e.target.files );
+  const addFiles = async e => {
+    const fileList = Array.from( e.target.files ).map( file => ( { input: file } ) );
 
-    const supportFiles = fileList.map( file => ( {
-      id: file.name,
-      filename: file.name,
-      input: {},
-    } ) );
-
-    setFiles( supportFiles );
+    await uploadAndSaveFiles(
+      projectId,
+      fileList,
+      assetPath,
+      saveSupportFile,
+    );
   };
 
   const onRemove = id => {
-    const updated = files.filter( file => file.id !== id );
+    // const updated = files.filter( file => file.id !== id );
 
-    setFiles( updated );
+    // setFiles( updated );
   };
   /** End simulated portion */
 
@@ -43,12 +100,12 @@ const PlaybookResources = ( { projectId } ) => {
         </p>
       </div>
 
-      { files && files.length > 0 && (
+      { /* { files && files.length > 0 && (
         <div className={ styles.files }>
           <strong>{ `Files Uploaded (${files.length})` }</strong>
           <FileList files={ files } projectId={ projectId } onRemove={ onRemove } />
         </div>
-      ) }
+      ) } */ }
 
       <ButtonAddFiles
         accept=".docx, .pdf"
@@ -63,7 +120,9 @@ const PlaybookResources = ( { projectId } ) => {
 };
 
 PlaybookResources.propTypes = {
+  assetPath: PropTypes.string,
   projectId: PropTypes.string,
+  updateMutation: PropTypes.func,
 };
 
 export default PlaybookResources;

--- a/components/admin/PlaybookEdit/PlaybookResources/PlaybookResources.js
+++ b/components/admin/PlaybookEdit/PlaybookResources/PlaybookResources.js
@@ -1,22 +1,19 @@
 import PropTypes from 'prop-types';
-import { useMutation, useQuery } from '@apollo/client';
+import { useQuery } from '@apollo/client';
 
 import ButtonAddFiles from 'components/ButtonAddFiles/ButtonAddFiles';
 import FileList from 'components/admin/FileList/FileList';
 
 import { buildSupportFile } from 'lib/graphql/builders/common';
-import { useFileUpload } from 'lib/hooks/useFileUpload';
-import { PLAYBOOK_QUERY } from 'lib/graphql/queries/playbook';
 import { LANGUAGE_BY_NAME_QUERY } from 'components/admin/dropdowns/LanguageDropdown/LanguageDropdown';
+import { useFileUpload } from 'lib/hooks/useFileUpload';
 
 import styles from './PlaybookResources.module.scss';
 
 const PlaybookResources = ( { assetPath, files, projectId, updateMutation } ) => {
   const { uploadFile } = useFileUpload();
 
-  /**
-   * Get the English language data.
-   */
+  // Get the English language data, needed when adding supportFiles.
   const { data: languageData } = useQuery( LANGUAGE_BY_NAME_QUERY, {
     variables: { displayName: 'English' },
   } );

--- a/components/admin/PlaybookEdit/PlaybookResources/PlaybookResources.js
+++ b/components/admin/PlaybookEdit/PlaybookResources/PlaybookResources.js
@@ -67,7 +67,6 @@ const PlaybookResources = ( { assetPath, files, projectId, updateMutation } ) =>
     } );
   };
 
-  /** This portion simulates the data returned from a file upload, should be replaced with an actual support file mutation */
   const addFiles = async e => {
     const fileList = Array.from( e.target.files ).map( file => ( { input: file } ) );
 
@@ -79,12 +78,16 @@ const PlaybookResources = ( { assetPath, files, projectId, updateMutation } ) =>
     );
   };
 
-  const onRemove = id => {
-    // const updated = files.filter( file => file.id !== id );
-
-    // setFiles( updated );
-  };
-  /** End simulated portion */
+  const onRemove = id => updateMutation( {
+    variables: {
+      data: {
+        supportFiles: {
+          'delete': { id },
+        },
+      },
+      where: { id: projectId },
+    },
+  } );
 
   return (
     <section aria-label="Available Resources" className={ styles.container }>

--- a/components/admin/PlaybookEdit/PlaybookResources/PlaybookResources.js
+++ b/components/admin/PlaybookEdit/PlaybookResources/PlaybookResources.js
@@ -11,7 +11,7 @@ import { LANGUAGE_BY_NAME_QUERY } from 'components/admin/dropdowns/LanguageDropd
 
 import styles from './PlaybookResources.module.scss';
 
-const PlaybookResources = ( { assetPath, projectId, updateMutation } ) => {
+const PlaybookResources = ( { assetPath, files, projectId, updateMutation } ) => {
   const { uploadFile } = useFileUpload();
 
   /**
@@ -24,14 +24,14 @@ const PlaybookResources = ( { assetPath, projectId, updateMutation } ) => {
   /**
    * Uploads and saves files. If error occurs, set 'error' prop on file object
    * @param {string} id project id
-   * @param {array} files files to save
+   * @param {array} fileList files to save
    * @param {string} savePath path to S3 directory to save
    * @param {func} saveFn save function
    * @param {func} progress progress callback function
    * @return {Promise}
    */
-  const uploadAndSaveFiles = ( id, files, savePath, saveFn, progress ) => Promise.all(
-    files.map( async file => {
+  const uploadAndSaveFiles = ( id, fileList, savePath, saveFn, progress ) => Promise.all(
+    fileList.map( async file => {
       const _file = await uploadFile( savePath, file, progress );
 
       if ( _file.error ) {
@@ -100,12 +100,12 @@ const PlaybookResources = ( { assetPath, projectId, updateMutation } ) => {
         </p>
       </div>
 
-      { /* { files && files.length > 0 && (
+      { files && files.length > 0 && (
         <div className={ styles.files }>
           <strong>{ `Files Uploaded (${files.length})` }</strong>
           <FileList files={ files } projectId={ projectId } onRemove={ onRemove } />
         </div>
-      ) } */ }
+      ) }
 
       <ButtonAddFiles
         accept=".docx, .pdf"
@@ -121,6 +121,7 @@ const PlaybookResources = ( { assetPath, projectId, updateMutation } ) => {
 
 PlaybookResources.propTypes = {
   assetPath: PropTypes.string,
+  files: PropTypes.array,
   projectId: PropTypes.string,
   updateMutation: PropTypes.func,
 };

--- a/components/admin/PlaybookEdit/PlaybookResources/PlaybookResources.test.js
+++ b/components/admin/PlaybookEdit/PlaybookResources/PlaybookResources.test.js
@@ -1,16 +1,144 @@
+import { MockedProvider } from '@apollo/client/testing';
 import { mount } from 'enzyme';
+
 import PlaybookResources from './PlaybookResources';
 
-describe( '<PlaybookResources />', () => {
-  let Component;
-  let wrapper;
+jest.mock( 'lib/hooks/useFileUpload', () => ( {
+  useFileUpload: () => ( {
+    uploadFile: () => {},
+  } ),
+} ) );
 
-  beforeEach( () => {
-    Component = <PlaybookResources />;
-    wrapper = mount( Component );
-  } );
+const mockProps = {
+  assetPath: 'playbook/2021/06/commons.america.gov_ckpimh5330nep0961100ouir2',
+  files: [
+    {
+      __typename: 'SupportFile',
+      createdAt: '2021-06-04T23:26:31.479Z',
+      editable: false,
+      filename: 'mostly-adequate-guide.pdf',
+      filesize: 2495004,
+      filetype: 'application/pdf',
+      id: 'ckpiyia7v0ru60961xa31vqej',
+      language: {
+        __typename: 'Language',
+        displayName: 'English',
+        id: 'ck80ddxoc0072088860vuwhiu',
+        languageCode: 'en',
+        locale: 'en-us',
+        nativeName: 'English',
+        textDirection: 'LTR',
+      },
+      signedUrl: 'https://amgov-publisher-dev.s3.amazonaws.com/playbook/2021/06/dawnjfnjfnjfekwnjfn',
+      updatedAt: '2021-06-04T23:26:31.479Z',
+      url: 'playbook/2021/06/commons.america.gov_ckpimh5330nep0961100ouir2/mostly-adequate-guide.pdf',
+    },
+    {
+      __typename: 'SupportFile',
+      createdAt: '2021-06-04T23:26:31.479Z',
+      editable: false,
+      filename: 'better-user-stories-webinar-workbook.docx',
+      filesize: 2495004,
+      filetype: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+      id: 'ckpiylluo0rxi0961ubefs9jv',
+      language: {
+        __typename: 'Language',
+        displayName: 'English',
+        id: 'ck80ddxoc0072088860vuwhiu',
+        languageCode: 'en',
+        locale: 'en-us',
+        nativeName: 'English',
+        textDirection: 'LTR',
+      },
+      signedUrl: 'https://amgov-publisher-dev.s3.amazonaws.com/playbook/2021/06/fqwnfwqnfwufwbquifhwji',
+      updatedAt: '2021-06-04T23:26:31.479Z',
+      url: 'playbook/2021/06/commons.america.gov_ckpiylluo0rxi0961ubefs9jv/better-user-stories-webinar-workbook.docx',
+    },
+  ],
+  projectId: 'ckpimh5330nep0961100ouir2',
+  updateMutation: () => {},
+};
+
+describe( '<PlaybookResources />', () => {
+  const Component = (
+    <MockedProvider addTypename>
+      <PlaybookResources { ...mockProps } />
+    </MockedProvider>
+  );
+
+  const wrapper = mount( Component );
 
   it( 'renders without crashing', () => {
     expect( wrapper.exists() ).toEqual( true );
+  } );
+
+  it( 'properly displays the number of uploaded files', () => {
+    const subheader = wrapper.find( 'strong' );
+
+    expect( subheader.exists() ).toEqual( true );
+    expect( subheader.text() ).toEqual( `Files Uploaded (${mockProps.files.length})` );
+  } );
+
+  it( 'lists all the currently uploaded files', () => {
+    const fileList = wrapper.find( 'FileList' );
+    const files = fileList.find( 'li' );
+
+    expect( fileList.exists() ).toEqual( true );
+    expect( files.length ).toEqual( mockProps.files.length );
+    files.forEach( ( item, i ) => {
+      expect( item.text() ).toEqual( mockProps.files[i].filename );
+      expect( item.find( 'FileRemoveReplaceButtonGroup' ).exists() ).toEqual( true );
+    } );
+  } );
+
+  it( 'has an add files button', () => {
+    const addFiles = wrapper.find( 'ButtonAddFiles' );
+    const addFilesBtn = addFiles.find( 'button' );
+
+    expect( addFilesBtn.exists() ).toEqual( true );
+    expect( addFilesBtn.text() ).toEqual( '+ Add Files' );
+  } );
+
+  it( 'is set to accept multiple PDFs and Word docs', () => {
+    const fileUploader = wrapper.find( 'input' );
+
+    const accepted = fileUploader.prop( 'accept' );
+
+    expect( fileUploader.exists() ).toEqual( true );
+    expect( fileUploader.prop( 'type' ) ).toEqual( 'file' );
+    expect( fileUploader.prop( 'multiple' ) ).toEqual( true );
+    expect( accepted.includes( '.docx' ) ).toEqual( true );
+    expect( accepted.includes( '.pdf' ) ).toEqual( true );
+  } );
+} );
+
+describe( '<PlaybookResources />, with no files', () => {
+  const emptyMocks = {
+    ...mockProps,
+    files: [],
+  };
+
+  const Component = (
+    <MockedProvider addTypename>
+      <PlaybookResources { ...emptyMocks } />
+    </MockedProvider>
+  );
+
+  const wrapper = mount( Component );
+
+  it( 'renders without crashing', () => {
+    expect( wrapper.exists() ).toEqual( true );
+  } );
+
+  it( 'does not have an uploaded files subheader', () => {
+    const subheader = wrapper.find( 'strong' );
+
+    expect( subheader.exists() ).toEqual( false );
+  } );
+
+  it( 'does not have a files list', () => {
+    const fileList = wrapper.find( 'FileList' );
+
+    expect( fileList.exists() ).toEqual( false );
   } );
 } );

--- a/lib/graphql/queries/playbook.js
+++ b/lib/graphql/queries/playbook.js
@@ -93,10 +93,14 @@ export const UPDATE_PLAYBOOK_MUTATION = gql`
  Queries
  -----------------------------------------*/
 export const PLAYBOOK_QUERY = gql`
- query Playbook($id: ID!) {
-   playbook: playbook(id: $id) {
-     ...playbookDetails 
-   }
- }
- ${PLAYBOOK_DETAILS_FRAGMENT} 
+  query Playbook($id: ID!) {
+    playbook: playbook(id: $id) {
+      ...playbookDetails
+      supportFiles {
+        ...supportFileDetails
+      }
+    }
+  }
+  ${PLAYBOOK_DETAILS_FRAGMENT}
+  ${SUPPORT_FILE_DETAILS_FRAGMENT}
 `;

--- a/lib/graphql/queries/playbook.js
+++ b/lib/graphql/queries/playbook.js
@@ -1,5 +1,7 @@
 import { gql } from '@apollo/client';
 
+import { SUPPORT_FILE_DETAILS_FRAGMENT } from './common';
+
 /*----------------------------------------
  Fragments
  -----------------------------------------*/
@@ -78,9 +80,13 @@ export const UPDATE_PLAYBOOK_MUTATION = gql`
     # return all data to trigger auto cache update
     updatePlaybook(data: $data, where: $where) {  
       ...playbookDetails
+      supportFiles {
+        ...supportFileDetails
+      }
     } 
   }
   ${PLAYBOOK_DETAILS_FRAGMENT}
+  ${SUPPORT_FILE_DETAILS_FRAGMENT}
 `;
 
 /*----------------------------------------


### PR DESCRIPTION
Replaces the simulated file upload action in the `PlaybookResources` component with an actual upload function that saves the files to S3 and runs a GraphQL mutation to update the `supportFiles` field on the playbook.

- Adds the support files fragment to the playbook query in `lib/graphql/queries/playbook.js`
- Adds a custom merge function for playbook support files to optimize the cache behavior