### PR TITLE
CDP-2393: Hook up delete resolver

### DIFF
--- a/components/admin/ActionButtons/ActionButtons.js
+++ b/components/admin/ActionButtons/ActionButtons.js
@@ -25,6 +25,9 @@ const ActionButtons = ( {
     case 'playbook':
       contentType = 'playbook';
       break;
+    case 'toolkit':
+      contentType = 'toolkit';
+      break;
     default:
       contentType = 'project';
   }

--- a/components/admin/ActionButtons/ActionButtons.js
+++ b/components/admin/ActionButtons/ActionButtons.js
@@ -16,8 +16,20 @@ const ActionButtons = ( {
   show,
   loading,
 } ) => {
-  const isPackage = type.toLowerCase() === 'package';
-  const contentType = isPackage ? type : 'project';
+  let contentType;
+
+  switch ( type.toLowerCase() ) {
+    case 'package':
+      contentType = 'package';
+      break;
+    case 'playbook':
+      contentType = 'playbook';
+      break;
+    default:
+      contentType = 'project';
+  }
+
+  const capitalizeFirst = string => `${string.charAt( 0 ).toUpperCase()}${string.slice( 1 )}`;
 
   return (
     <Fragment>
@@ -25,7 +37,7 @@ const ActionButtons = ( {
         <Fragment>
           <Button
             className="action-btn btn--delete"
-            content={ `Delete ${type === 'package' ? 'Package' : 'Project'}` }
+            content={ `Delete ${capitalizeFirst( contentType )}` }
             basic
             onClick={ () => setDeleteConfirmOpen( true ) }
             disabled={ disabled.delete }
@@ -40,7 +52,7 @@ const ActionButtons = ( {
                 headline={ `Are you sure you want to delete this ${contentType}?` }
               >
                 <p>
-                  { `This ${contentType} will be removed permanently from the Content Cloud. Any files uploaded in this ${contentType} will also be removed permanently.` }
+                  { `This ${contentType} will be removed permanently from the Content Commons. Any files uploaded in this ${contentType} will also be removed permanently.` }
                 </p>
               </ConfirmModalContent>
             ) }

--- a/components/admin/ActionButtons/ActionButtons.test.js
+++ b/components/admin/ActionButtons/ActionButtons.test.js
@@ -200,7 +200,7 @@ describe( '<ActionButtons />, if not disabled', () => {
     const confirmModal = wrapper.find( 'Confirm' );
     const confirmModalContent = mount( confirmModal.prop( 'content' ) );
     const headline = 'Are you sure you want to delete this package?';
-    const msg = `This ${props.type} will be removed permanently from the Content Cloud. Any files uploaded in this ${props.type} will also be removed permanently.`;
+    const msg = `This ${props.type} will be removed permanently from the Content Commons. Any files uploaded in this ${props.type} will also be removed permanently.`;
 
     expect( confirmModalContent.contains( headline ) ).toEqual( true );
     expect( confirmModalContent.find( 'p' ).text() ).toEqual( msg );

--- a/components/admin/PlaybookEdit/PlaybookEdit.js
+++ b/components/admin/PlaybookEdit/PlaybookEdit.js
@@ -15,8 +15,8 @@ import PlaybookResources from 'components/admin/PlaybookEdit/PlaybookResources/P
 import ProjectHeader from 'components/admin/ProjectHeader/ProjectHeader';
 import TextEditor from 'components/admin/TextEditor/TextEditor';
 import {
+  DELETE_PLAYBOOK_MUTATION,
   PLAYBOOK_QUERY,
-  // DELETE_PLAYBOOK_MUTATION,
   // PUBLISH_PLAYBOOK_MUTATION,
   // UNPUBLISH_PLAYBOOK_MUTATION,
   UPDATE_PLAYBOOK_MUTATION,
@@ -31,7 +31,6 @@ const PlaybookEdit = ( { id: playbookId } ) => {
   // temp
   const publishError = {};
   const publishing = false;
-  const deletePlaybook = async () => {};
   const publishPlaybook = () => {};
   const unpublishPlaybook = () => {};
   const executePublishOperation = () => {};
@@ -44,7 +43,7 @@ const PlaybookEdit = ( { id: playbookId } ) => {
     displayName: 'playbookQuery',
   } );
 
-  // const [deletePlaybook] = useMutation( DELETE_PLAYBOOK_MUTATION );
+  const [deletePlaybook] = useMutation( DELETE_PLAYBOOK_MUTATION );
   // const [publishPlaybook] = useMutation( PUBLISH_PLAYBOOK_MUTATION );
   // const [unpublishPlaybook] = useMutation( UNPUBLISH_PLAYBOOK_MUTATION );
   // const [updatePlaybookStatus] = useMutation( UPDATE_PLAYBOOK_STATUS_MUTATION );

--- a/components/admin/PlaybookEdit/PlaybookEdit.js
+++ b/components/admin/PlaybookEdit/PlaybookEdit.js
@@ -162,7 +162,7 @@ const PlaybookEdit = ( { id: playbookId } ) => {
       <div className="header">
         <ProjectHeader icon="file" text="Package Details">
           <ActionButtons
-            type="package"
+            type="playbook"
             deleteConfirmOpen={ deleteConfirmOpen }
             setDeleteConfirmOpen={ setDeleteConfirmOpen }
             disabled={ {

--- a/components/admin/PlaybookEdit/PlaybookEdit.js
+++ b/components/admin/PlaybookEdit/PlaybookEdit.js
@@ -1,10 +1,9 @@
-import React, { useState } from 'react';
-import PropTypes from 'prop-types';
-import { useRouter } from 'next/router';
-import { useMutation, useQuery } from '@apollo/client';
 import { Loader } from 'semantic-ui-react';
-import useIsDirty from 'lib/hooks/useIsDirty';
-// import usePublish from 'lib/hooks/usePublish';
+import PropTypes from 'prop-types';
+import { useMutation, useQuery } from '@apollo/client';
+import { useRouter } from 'next/router';
+import { useState } from 'react';
+
 import ActionButtons from 'components/admin/ActionButtons/ActionButtons';
 import ActionHeadline from 'components/admin/ActionHeadline/ActionHeadline';
 import ApolloError from 'components/errors/ApolloError';
@@ -14,6 +13,9 @@ import PlaybookDetailsFormContainer from 'components/admin/PlaybookEdit/Playbook
 import PlaybookResources from 'components/admin/PlaybookEdit/PlaybookResources/PlaybookResources';
 import ProjectHeader from 'components/admin/ProjectHeader/ProjectHeader';
 import TextEditor from 'components/admin/TextEditor/TextEditor';
+
+import useIsDirty from 'lib/hooks/useIsDirty';
+// import usePublish from 'lib/hooks/usePublish';
 import {
   DELETE_PLAYBOOK_MUTATION,
   PLAYBOOK_QUERY,

--- a/lib/graphql/queries/playbook.js
+++ b/lib/graphql/queries/playbook.js
@@ -83,6 +83,14 @@ export const UPDATE_PLAYBOOK_MUTATION = gql`
   ${PLAYBOOK_DETAILS_FRAGMENT}
 `;
 
+export const DELETE_PLAYBOOK_MUTATION = gql`
+  mutation DELETE_PLAYBOOK_MUTATION($id: ID!) {
+    deletePlaybook(id: $id) {
+      id
+    }
+  }
+`;
+
 /*----------------------------------------
  Queries
  -----------------------------------------*/


### PR DESCRIPTION
Corresponds to [PR #60 on the server](https://github.com/IIP-Design/content-commons-server/pull/60).

Adds the delete playbook query to the list of playbook queries.

Also updates the `ActionButtons` component so that it can display multiple content types rather than the binary `project` or `package`.