### PR TITLE
CDP 2340 - Set form to initial values when package type is changed

### DIFF
--- a/components/admin/PackageCreate/PackageCreate.js
+++ b/components/admin/PackageCreate/PackageCreate.js
@@ -71,26 +71,23 @@ const PackageCreate = () => {
     router.push( '/admin/upload' );
   };
 
+  const getPackageType = types => ( ( types.length === 1 ) ? types[0] : '' );
+  const getPackageTitle = type => ( ( type === 'PACKAGE' || type === 'DAILY_GUIDANCE' )
+    ? `Guidance Package ${moment().format( 'MM-D-YY' )}`
+    : '' );
 
   /**
    * Seed initial form values based on team and content types
    * @param {object} team object
    * @returns object
    */
-  const getInitialValues = () => {
-    let title = '';
-    let type = '';
-
-    if ( teamPackageTypes.length === 1 ) {
-      [type] = teamPackageTypes;
-
-      // if Package type, e.g. 'DAILY_GUIDANCE', pre-populate title
-      title = type === 'PACKAGE' ? `Guidance Package ${moment().format( 'MM-D-YY' )}` : '';
-    }
+  const getInitialValues = type => {
+    const packageType = type || getPackageType( teamPackageTypes );
+    const title = getPackageTitle( packageType );
 
     return {
       title,
-      type,
+      type: packageType,
       team: user?.team?.name,
       categories: [],
       tags: [],

--- a/components/admin/PackageCreate/PackageCreate.js
+++ b/components/admin/PackageCreate/PackageCreate.js
@@ -98,6 +98,25 @@ const PackageCreate = () => {
     };
   };
 
+  const reset = ( type, setValues, setTouched ) => {
+    updateSchema( type );
+
+    setTouched( {
+      title: false,
+      categories: false,
+      termsConditions: false,
+    } );
+
+    setValues( {
+      team: user?.team?.name,
+      title: getPackageTitle( type ),
+      type,
+      categories: [],
+      tags: [],
+      policy: '',
+      desc: '',
+    } );
+  };
 
   if ( loading ) {
     return 'Loading form...';
@@ -130,7 +149,7 @@ const PackageCreate = () => {
           <PackageForm
             { ...formikProps }
             packageTypes={ teamPackageTypes }
-            updateSchema={ updateSchema }
+            reset={ reset }
           >
             <div className={ styles.container }>
               <div className={ styles['container-btn'] }>

--- a/components/admin/PackageCreate/PackageForm/PackageForm.js
+++ b/components/admin/PackageCreate/PackageForm/PackageForm.js
@@ -13,7 +13,8 @@ import styles from './PackageForm.module.scss';
 export const HandleOnChangeContext = createContext();
 
 const PackageForm = ( {
-  validateForm,
+  setValues,
+  setTouched,
   setFieldValue,
   setFieldTouched,
   touched,
@@ -21,7 +22,7 @@ const PackageForm = ( {
   errors,
   children,
   packageTypes,
-  updateSchema,
+  reset,
 } ) => {
   const [hideFields, setHideFields] = useState( true );
   const isGuidance = type => type === 'DAILY_GUIDANCE' || type === 'PACKAGE';
@@ -50,13 +51,7 @@ const PackageForm = ( {
     setFieldTouched( name, true, false );
 
     if ( name === 'type' ) {
-      setHideFields( hideAdditionalFields( value ) );
-
-      // update schema when package type changes
-      updateSchema( value );
-
-      // validate form against new schema on next 'tick' to give schema time to update
-      setTimeout( () => validateForm(), 0 );
+      reset( value, setValues, setTouched );
     }
   };
 
@@ -162,15 +157,16 @@ const PackageForm = ( {
 };
 
 PackageForm.propTypes = {
-  validateForm: PropTypes.func,
+  setValues: PropTypes.func,
   setFieldValue: PropTypes.func,
+  setTouched: PropTypes.func,
   setFieldTouched: PropTypes.func,
   touched: PropTypes.object,
   values: PropTypes.object,
   errors: PropTypes.object,
   children: PropTypes.node,
   packageTypes: PropTypes.array,
-  updateSchema: PropTypes.func,
+  reset: PropTypes.func,
 };
 
 export default PackageForm;

--- a/components/admin/PackageCreate/PackageForm/PackageForm.module.scss
+++ b/components/admin/PackageCreate/PackageForm/PackageForm.module.scss
@@ -2,6 +2,7 @@
 @import "styles/mixins.scss";
 
 @include required-text;
+@include required-error;
 @include field-helper-text;
 
 .form_container {

--- a/components/admin/PackageCreate/PackageForm/TextInput/TextInput.js
+++ b/components/admin/PackageCreate/PackageForm/TextInput/TextInput.js
@@ -4,14 +4,46 @@ import { useField } from 'formik';
 
 import styles from './TextInput.module.scss';
 
-const TextArea = props => (
-  <textarea { ...props } />
+/**
+ * Creates native textarea with forwarded props. Sets value to '' if not present to
+ * to avoid the 'A component is changing an uncontrolled input to be controlled.' warning
+ * @param {object} props
+ * @param {string} props.value field value
+ *
+ * @returns <textarea>
+ */
+const TextArea = ( { value, ...props } ) => (
+  <textarea { ...props } value={ value || '' } />
 );
 
-const Input = props => (
-  <input autoComplete="off" { ...props } />
+TextArea.propTypes = {
+  value: PropTypes.string,
+};
+
+/**
+ * Creates native input with forwarded props. Sets value to '' if not present to
+ * to avoid the 'A component is changing an uncontrolled input to be controlled.' warning
+ * @param {object} props
+ * @param {string} props.value field value
+ *
+ * @returns <input>
+ */
+const Input = ( { value, ...props } ) => (
+  <input autoComplete="off" { ...props } value={ value || '' } />
 );
 
+Input.propTypes = {
+  value: PropTypes.string,
+};
+
+/**
+ * Creates a either a formik-connected input or textarea and adds
+ * optional helper text, error display & field character count tracking/display
+ * @param {object} props
+ * @param {string} props.label form field label
+ * @param {string} props.helperTxt additional text to describe field, e.g 'Briefly describe playbook..'
+ * @param {number} props.maxLength max number of allowed characters for field
+ */
 const TextInput = ( { label, helperTxt, maxLength, ...props } ) => {
   const [chars, setChars] = useState( 0 );
   const [field, meta] = useField( props.name );
@@ -57,7 +89,7 @@ const TextInput = ( { label, helperTxt, maxLength, ...props } ) => {
         />
       </label>
       <div className={ styles['text-input-helper'] }>
-        <p id={ `describedby${props.id}` } className={ styles['field__helper-text'] }>{ helperTxt }</p>
+        <p id={ `describedby_${props.id}` } className={ styles['field__helper-text'] }>{ helperTxt }</p>
         { !!maxLength && (
           <p
             aria-live="polite"

--- a/components/admin/PackageCreate/PackageForm/TextInput/TextInput.js
+++ b/components/admin/PackageCreate/PackageForm/TextInput/TextInput.js
@@ -92,6 +92,7 @@ const TextInput = ( { label, helperTxt, maxLength, ...props } ) => {
         <p id={ `describedby_${props.id}` } className={ styles['field__helper-text'] }>{ helperTxt }</p>
         { !!maxLength && (
           <p
+            role="status"
             aria-live="polite"
             className={ `${styles['field__helper-text']} ${chars === maxLength && styles['max-char']}` }
           >
@@ -100,7 +101,13 @@ const TextInput = ( { label, helperTxt, maxLength, ...props } ) => {
         ) }
       </div>
 
-      <p aria-live="polite" className={ styles.required_error }>{ meta.touched ? meta.error : '' }</p>
+      <p
+        role="status"
+        aria-live="polite"
+        className={ styles.required_error }
+      >
+        { meta.touched ? meta.error : '' }
+      </p>
     </div>
   );
 };

--- a/components/admin/PackageCreate/PackageForm/TextInput/TextInput.js
+++ b/components/admin/PackageCreate/PackageForm/TextInput/TextInput.js
@@ -31,12 +31,20 @@ const TextInput = ( { label, helperTxt, maxLength, ...props } ) => {
   };
 
   // append additional props to forward to native input control
-  const _props = {
-    ...props,
-    'aria-describedby': `describedby${props.id}`,
-    onChange: handleOnChange,
-    maxLength,
-  };
+  let _props = { ...props };
+
+
+  if ( helperTxt ) {
+    _props['aria-describedby'] = `describedby_${props.id}`;
+  }
+
+  if ( maxLength ) {
+    _props = {
+      ..._props,
+      onChange: handleOnChange,
+      maxLength,
+    };
+  }
 
   return (
     <div className={ styles['text-input'] }>

--- a/components/admin/PackageEdit/PackageEdit.test.js
+++ b/components/admin/PackageEdit/PackageEdit.test.js
@@ -29,7 +29,7 @@ jest.mock( 'next/config', () => () => ( { publicRuntimeConfig: { REACT_APP_AWS_S
 
 const getBtn = ( str, buttons ) => buttons.findWhere( n => n.text() === str && n.name() === 'button' );
 
-describe.skip( '<PackageEdit />, if DRAFT status', () => {
+describe( '<PackageEdit />, if DRAFT status', () => {
   const router = {
     push: jest.fn(),
     query: {
@@ -188,7 +188,7 @@ describe.skip( '<PackageEdit />, if DRAFT status', () => {
     expect( confirm().prop( 'open' ) ).toEqual( false );
   } );
 
-  it.skip( 'clicking the Confirm button in the Confirm modal calls deletePackage and redirects to the dashboard', async done => {
+  it( 'clicking the Confirm button in the Confirm modal calls deletePackage and redirects to the dashboard', async done => {
     await wait( 0 );
     wrapper.update();
 
@@ -278,8 +278,6 @@ describe.skip( '<PackageEdit />, if DRAFT status', () => {
       .toEqual( 'function' );
     expect( pkgFormContainer.prop( 'setIsFormValid' ).name )
       .toEqual( 'bound dispatchAction' );
-    expect( pkgFormContainer.prop( 'hasInitialUploadCompleted' ) )
-      .toEqual( router.query.action !== 'create' );
   } );
 
   it( 'renders ActionHeadline', async () => {
@@ -351,7 +349,7 @@ describe.skip( '<PackageEdit />, if DRAFT status', () => {
   } );
 } );
 
-describe.skip( '<PackageEdit />, if there are no documents & router.query.action !== create', () => {
+describe( '<PackageEdit />, if there are no documents', () => {
   const router = {
     push: jest.fn(),
     query: {
@@ -459,8 +457,6 @@ describe.skip( '<PackageEdit />, if there are no documents & router.query.action
       .toEqual( 'function' );
     expect( pkgFormContainer.prop( 'setIsFormValid' ).name )
       .toEqual( 'bound dispatchAction' );
-    expect( pkgFormContainer.prop( 'hasInitialUploadCompleted' ) )
-      .toEqual( router.query.action !== 'create' );
   } );
 
   it( 'renders ButtonPublish', async () => {
@@ -515,170 +511,7 @@ describe.skip( '<PackageEdit />, if there are no documents & router.query.action
   } );
 } );
 
-describe.skip( '<PackageEdit />, if there are no documents', () => {
-  const router = {
-    push: jest.fn(),
-    query: {
-      id: 'test-123',
-      action: 'create',
-    },
-  };
-
-  const Component = (
-    <MockedProvider mocks={ noDocumentsMocks }>
-      <RouterContext.Provider value={ router }>
-        <PackageEdit { ...props } />
-      </RouterContext.Provider>
-    </MockedProvider>
-  );
-
-  const ErrorComponent = (
-    <MockedProvider mocks={ errorMocks }>
-      <RouterContext.Provider value={ router }>
-        <PackageEdit { ...props } />
-      </RouterContext.Provider>
-    </MockedProvider>
-  );
-
-  const consoleError = console.error;
-
-  beforeAll( () => suppressActWarning( consoleError ) );
-
-  afterAll( () => {
-    console.error = consoleError;
-  } );
-
-  let wrapper;
-
-  beforeEach( () => {
-    wrapper = mount( Component );
-  } );
-
-  it( 'renders initial loading state without crashing', () => {
-    const pkgEdit = wrapper.find( 'PackageEdit' );
-    const loader = wrapper.find( 'Loader' );
-    const msg = 'Loading package details page...';
-
-    expect( pkgEdit.exists() ).toEqual( true );
-    expect( loader.exists() ).toEqual( true );
-    expect( loader.contains( msg ) ).toEqual( true );
-  } );
-
-  it( 'renders error message if a queryError is returned', async () => {
-    const errorWrapper = mount( ErrorComponent );
-
-    await wait( 2 );
-    errorWrapper.update();
-
-    const apolloError = errorWrapper.find( 'ApolloError' );
-    const msg = 'There was an error.';
-
-    expect( apolloError.exists() ).toEqual( true );
-    expect( apolloError.contains( msg ) ).toEqual( true );
-  } );
-
-  it( 'renders the final state without crashing', async () => {
-    await wait( 0 );
-    wrapper.update();
-    const pkgEdit = wrapper.find( 'PackageEdit' );
-
-    expect( pkgEdit.exists() ).toEqual( true );
-  } );
-
-  it( 'renders the ProjectHeader', async () => {
-    await wait( 0 );
-    wrapper.update();
-
-    const projectHeader = wrapper.find( 'ProjectHeader' );
-    const icon = wrapper.find( 'Icon[name="file"]' );
-    const title = 'Package Details';
-
-    expect( projectHeader.exists() ).toEqual( true );
-    expect( icon.exists() ).toEqual( true );
-    expect( projectHeader.contains( title ) ).toEqual( true );
-  } );
-
-  it( 'renders the Delete Package button', async () => {
-    await wait( 0 );
-    wrapper.update();
-
-    const actionButtons = wrapper.find( 'ActionButtons' );
-    const deleteBtn = getBtn( 'Delete Package', actionButtons );
-
-    expect( deleteBtn.exists() ).toEqual( true );
-    expect( deleteBtn.prop( 'disabled' ) ).toEqual( undefined );
-  } );
-
-  it( 'does not render the Save, Publish Changes, Publish, & Unpublish buttons', async () => {
-    await wait( 0 );
-    wrapper.update();
-
-    const actionButtons = wrapper.find( 'ActionButtons' );
-    const unrenderedBtns = [
-      'Save & Exit',
-      'Publish Changes',
-      'Publish',
-      'Unpublish',
-    ];
-
-    unrenderedBtns.forEach( b => {
-      const btn = getBtn( b, actionButtons );
-
-      expect( btn.exists() ).toEqual( false );
-    } );
-  } );
-
-  it( 'renders the PackageDetailsFormContainer', async () => {
-    await wait( 0 );
-    wrapper.update();
-    const pkgFormContainer = wrapper.find( 'PackageDetailsFormContainer' );
-    const { pkg } = noDocumentsMocks[0].result.data;
-
-    expect( pkgFormContainer.exists() ).toEqual( true );
-    expect( pkgFormContainer.prop( 'pkg' ) ).toEqual( pkg );
-    expect( typeof pkgFormContainer.prop( 'updateNotification' ) )
-      .toEqual( 'function' );
-    expect( pkgFormContainer.prop( 'updateNotification' ).name )
-      .toEqual( 'updateNotification' );
-    expect( typeof pkgFormContainer.prop( 'setIsFormValid' ) )
-      .toEqual( 'function' );
-    expect( pkgFormContainer.prop( 'setIsFormValid' ).name )
-      .toEqual( 'bound dispatchAction' );
-  } );
-
-  it( 'renders ApolloError with an empty error prop', async () => {
-    await wait( 0 );
-    wrapper.update();
-    const apolloErrors = wrapper.find( 'ApolloError' );
-
-    expect( apolloErrors.exists() ).toEqual( true );
-    expect( apolloErrors.length ).toEqual( 2 );
-    apolloErrors.forEach( error => {
-      expect( error.prop( 'error' ) ).toEqual( {} );
-    } );
-  } );
-
-  it( 'renders Notification with the correct initial props', async () => {
-    await wait( 0 );
-    wrapper.update();
-    const notification = wrapper.find( 'Notification' );
-
-    expect( notification.exists() ).toEqual( true );
-    expect( notification.props() ).toEqual( {
-      el: 'p',
-      customStyles: {
-        position: 'absolute',
-        top: '9em',
-        left: '50%',
-        transform: 'translateX(-50%)',
-      },
-      show: false,
-      msg: '',
-    } );
-  } );
-} );
-
-describe.skip( '<PackageEdit />, if data === undefined is returned', () => {
+describe( '<PackageEdit />, if data === undefined is returned', () => {
   const router = {
     push: jest.fn(),
     query: {

--- a/components/admin/PackageEdit/PackageFiles/PackageFiles.js
+++ b/components/admin/PackageEdit/PackageFiles/PackageFiles.js
@@ -14,6 +14,8 @@ const PackageFiles = ( { pkg, handleSave, progress } ) => {
   const { modalOpen, handleOpenModel, handleCloseModal } = useToggleModal();
   const units = pkg.documents || [];
 
+  if ( !pkg || !getCount( pkg ) ) return null;
+
   return (
     <section className="edit-package__files package-files">
       <div className="heading">

--- a/components/admin/PackageEdit/PackageFiles/PackageFiles.test.js
+++ b/components/admin/PackageEdit/PackageFiles/PackageFiles.test.js
@@ -19,7 +19,7 @@ jest.mock( 'lib/hooks/useCrudActionsDocument', () => ( {
 
 jest.mock( 'next/config', () => ( { publicRuntimeConfig: { REACT_APP_AWS_S3_AUTHORING_BUCKET: 's3-bucket-url' } } ) );
 
-describe.skip( '<PackageFiles />', () => {
+describe( '<PackageFiles />', () => {
   const consoleError = console.error;
 
   beforeAll( () => suppressActWarning( consoleError ) );
@@ -58,6 +58,7 @@ describe.skip( '<PackageFiles />', () => {
 
   it( 'renders EditPackageFiles with correct props', () => {
     const editPkgFiles = wrapper.find( 'EditPackageFiles' );
+
     const units = props.pkg.documents || [];
 
     expect( editPkgFiles.exists() ).toEqual( true );
@@ -88,11 +89,6 @@ describe.skip( '<PackageFiles />', () => {
     editPkgFiles().prop( 'onClose' )();
     wrapper.update();
     expect( editPkgFiles().prop( 'modalOpen' ) ).toEqual( false );
-  } );
-
-  it( 'renders null if !hasInitialUploadCompleted', () => {
-    wrapper.setProps( { hasInitialUploadCompleted: false } );
-    expect( wrapper.html() ).toEqual( null );
   } );
 
   it( 'renders null if pkg === {}', () => {

--- a/components/admin/PackageEdit/PackageFiles/mocks.js
+++ b/components/admin/PackageEdit/PackageFiles/mocks.js
@@ -368,5 +368,6 @@ export const props = {
       },
     ],
   },
-  hasInitialUploadCompleted: true,
+  handleSave: () => jest.fn(),
+  progress: 0,
 };

--- a/components/admin/PlaybookEdit/PlaybookEdit.test.js
+++ b/components/admin/PlaybookEdit/PlaybookEdit.test.js
@@ -1,5 +1,8 @@
 import { mount } from 'enzyme';
 import PlaybookEdit from './PlaybookEdit';
+import { MockedProvider } from '@apollo/client/testing';
+
+const mocks = [];
 
 jest.mock(
   'components/admin/PlaybookEdit/PlaybookDetailsFormContainer/PlaybookDetailsFormContainer',
@@ -16,13 +19,15 @@ jest.mock(
   () => function PlaybookResources() { return ''; },
 );
 
-describe.skip( '<PlaybookEdit />', () => {
-  let Component;
+describe( '<PlaybookEdit />', () => {
   let wrapper;
 
   beforeEach( () => {
-    Component = <PlaybookEdit />;
-    wrapper = mount( Component );
+    wrapper = mount( (
+      <MockedProvider mocks={ mocks } addTypename={ false }>
+        <PlaybookEdit />
+      </MockedProvider>
+    ) );
   } );
 
   it( 'renders without crashing', () => {


### PR DESCRIPTION
PR resets the form to its initial values when the package type is changed.  If the selected package type is 'Guidance', sets the name to the format: Guidance Package [date]

In addition, PR:

- Fixes skipped tests to work with new form
- Updates TextInput to conditional add props, add status role and enhance function docs 
- Makes checkbox error text red

