### PR TITLE
CDP-2392: Implement preview from Playbook edit page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,7 +64,8 @@ _This sections lists changes committed since most recent release_
 - Rename `PlaybookTextEditor` to `TextEditor` and move up one level
 - Update tests for `TextEditor`
 - Replace mock mutation with `updatePlaybook` mutation in `PlaybookEdit`
-- Switch to `[...slug]` catch all route from `[id]` for `admin/package/playbook` route to allow for `preview` param
+- Create `admin/package/playbook/preview/[id]` route
+- Use `PlaybookPreview` component to fetch playbook data
 - Use CSS modules for `PlaybookEdit` component
 - Adjust focus styling for `Playbook` header buttons
 - Remove media embed functionality from `TextEditor`

--- a/components/Playbook/Playbook.js
+++ b/components/Playbook/Playbook.js
@@ -18,10 +18,11 @@ const desc = 'This Playbook is for use by U.S. diplomatic missions and senior St
 
 const Playbook = ( { item } ) => {
   const router = useRouter();
+  const isAdminPreview = router.asPath.startsWith( '/admin' );
 
   return (
     <div className={ styles.container }>
-      { router.asPath.startsWith( '/admin' ) && (
+      { isAdminPreview && (
         <div className={ styles.preview }>
           <img src={ cautionIcon } alt="" height="18" width="18" />
           <p>This is a preview of how your Playbook will appear on Content Commons</p>
@@ -49,7 +50,11 @@ const Playbook = ( { item } ) => {
               <h2 className="ui header" style={ { textAlign: 'left' } }>Share this playbook.</h2>
               <Share
                 id={ item?.id }
+                isPreview={ isAdminPreview }
                 type="playbook"
+                { ...( isAdminPreview
+                  ? { link: 'The direct link to the playbook will appear here.' }
+                  : null ) }
               />
             </div>
           </Popover>

--- a/components/Playbook/Playbook.js
+++ b/components/Playbook/Playbook.js
@@ -89,6 +89,7 @@ const Playbook = ( { item } ) => {
                 <li key={ file.id }>
                   <DownloadItemContent
                     hoverText={ `Download ${file.filename}` }
+                    isAdminPreview={ isAdminPreview }
                     srcUrl={ file.url }
                     downloadFilename={ file.filename }
                   >

--- a/components/Playbook/mocks.js
+++ b/components/Playbook/mocks.js
@@ -100,9 +100,9 @@ const mockContent = `
 
 export const mockItem = {
   id: '1234',
-  createdAt: new Date(),
-  updatedAt: new Date(),
-  publishedAt: new Date(),
+  createdAt: '2021-05-26T11:12:34.140Z',
+  updatedAt: '2021-05-27T11:12:34.140Z',
+  publishedAt: '2021-05-28T11:12:34.140Z',
   type: 'PLAYBOOK',
   title: 'COVAX Deliveries and Announcement Guidance Playbook',
   // assetPath: String,
@@ -127,8 +127,8 @@ export const mockItem = {
   supportFiles: [
     {
       id: '9012',
-      createdAt: new Date(),
-      updatedAt: new Date(),
+      createdAt: '2021-05-26T11:12:34.140Z',
+      updatedAt: '2021-05-27T11:12:34.140Z',
       // language: Language!
       url: 'http://blahblah.dev',
       signedUrl: 'http://blahblah.dev',

--- a/components/admin/Previews/PlaybookPreview/PlaybookPreview.js
+++ b/components/admin/Previews/PlaybookPreview/PlaybookPreview.js
@@ -6,10 +6,10 @@ import Playbook from 'components/Playbook/Playbook';
 import { PLAYBOOK_QUERY } from 'lib/graphql/queries/playbook';
 import styles from './PlaybookPreview.module.scss';
 
-const PlaybookPreview = ( { id, item } ) => {
+const PlaybookPreview = ( { id, item: itemFromServer } ) => {
   const { data, error, loading } = useQuery( PLAYBOOK_QUERY, {
     variables: { id },
-    skip: !!item,
+    skip: !!itemFromServer,
   } );
 
   if ( loading ) {
@@ -26,11 +26,11 @@ const PlaybookPreview = ( { id, item } ) => {
   }
 
   if ( error ) return <ApolloError error={ error } />;
-  if ( !item && !data?.playbook ) {
+  if ( !itemFromServer && !data?.playbook ) {
     return <p className={ styles.unavailable }>Preview is unavailable.</p>;
   }
 
-  return <Playbook item={ item || data.playbook } />;
+  return <Playbook item={ itemFromServer || data.playbook } />;
 };
 
 PlaybookPreview.propTypes = {

--- a/components/admin/Previews/PlaybookPreview/PlaybookPreview.js
+++ b/components/admin/Previews/PlaybookPreview/PlaybookPreview.js
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 import { useQuery } from '@apollo/client';
 import { Loader } from 'semantic-ui-react';
 import ApolloError from 'components/errors/ApolloError';
+import ErrorSection from 'components/errors/ErrorSection';
 import Playbook from 'components/Playbook/Playbook';
 import { PLAYBOOK_QUERY } from 'lib/graphql/queries/playbook';
 import styles from './PlaybookPreview.module.scss';
@@ -27,7 +28,7 @@ const PlaybookPreview = ( { id, item: itemFromServer } ) => {
 
   if ( error ) return <ApolloError error={ error } />;
   if ( !itemFromServer && !data?.playbook ) {
-    return <p className={ styles.unavailable }>Preview is unavailable.</p>;
+    return <ErrorSection statusCode={ 404 } title="Preview is unavailable." />;
   }
 
   return <Playbook item={ itemFromServer || data.playbook } />;

--- a/components/admin/Previews/PlaybookPreview/PlaybookPreview.js
+++ b/components/admin/Previews/PlaybookPreview/PlaybookPreview.js
@@ -1,0 +1,41 @@
+import PropTypes from 'prop-types';
+import { useQuery } from '@apollo/client';
+import { Loader } from 'semantic-ui-react';
+import ApolloError from 'components/errors/ApolloError';
+import Playbook from 'components/Playbook/Playbook';
+import { PLAYBOOK_QUERY } from 'lib/graphql/queries/playbook';
+import styles from './PlaybookPreview.module.scss';
+
+const PlaybookPreview = ( { id, item } ) => {
+  const { data, error, loading } = useQuery( PLAYBOOK_QUERY, {
+    variables: { id },
+    skip: !!item,
+  } );
+
+  if ( loading ) {
+    return (
+      <div className={ styles.loading }>
+        <Loader
+          active
+          inline="centered"
+          style={ { marginBottom: '1em' } }
+          content="Loading Playbook preview..."
+        />
+      </div>
+    );
+  }
+
+  if ( error ) return <ApolloError error={ error } />;
+  if ( !item && !data?.playbook ) {
+    return <p className={ styles.unavailable }>Preview is unavailable.</p>;
+  }
+
+  return <Playbook item={ item || data.playbook } />;
+};
+
+PlaybookPreview.propTypes = {
+  id: PropTypes.string,
+  item: PropTypes.object,
+};
+
+export default PlaybookPreview;

--- a/components/admin/Previews/PlaybookPreview/PlaybookPreview.module.scss
+++ b/components/admin/Previews/PlaybookPreview/PlaybookPreview.module.scss
@@ -1,0 +1,12 @@
+.loading {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 200px;
+}
+
+.unavailable {
+  padding-top: 10rem;
+  text-align: center;
+}

--- a/components/admin/Previews/PlaybookPreview/PlaybookPreview.module.scss
+++ b/components/admin/Previews/PlaybookPreview/PlaybookPreview.module.scss
@@ -5,8 +5,3 @@
   justify-content: center;
   min-height: 200px;
 }
-
-.unavailable {
-  padding-top: 10rem;
-  text-align: center;
-}

--- a/components/admin/Previews/PlaybookPreview/PlaybookPreview.test.js
+++ b/components/admin/Previews/PlaybookPreview/PlaybookPreview.test.js
@@ -1,0 +1,143 @@
+import { mount } from 'enzyme';
+import wait from 'waait';
+import { MockedProvider } from '@apollo/client/testing';
+import PlaybookPreview from 'components/admin/Previews/PlaybookPreview/PlaybookPreview';
+import { PLAYBOOK_QUERY } from 'lib/graphql/queries/playbook';
+import { suppressActWarning } from 'lib/utils';
+import { mockItem } from 'components/Playbook/mocks';
+
+jest.mock(
+  'components/Playbook/Playbook',
+  () => function Playbook() { return ''; },
+);
+
+const props = {
+  id: '1234',
+  item: mockItem,
+};
+
+const undefinedItemProps = {
+  id: '1234',
+  item: undefined,
+};
+
+const mocks = [
+  {
+    request: {
+      query: PLAYBOOK_QUERY,
+      variables: { id: props.id },
+    },
+    result: {
+      data: {
+        playbook: mockItem,
+      },
+    },
+  },
+];
+
+const errorMocks = [
+  {
+    ...mocks[0],
+    result: {
+      errors: [{ message: 'There was an error.' }],
+    },
+  },
+];
+
+const undefinedMocks = [
+  {
+    ...mocks[0],
+    result: {
+      data: { playbook: undefined },
+    },
+  },
+];
+
+describe( '<PlaybookPreview />, for server side render', () => {
+  const consoleError = console.error;
+
+  beforeAll( () => suppressActWarning( consoleError ) );
+  afterAll( () => {
+    console.error = consoleError;
+  } );
+
+  it( 'renders the Playbook without crashing', async () => {
+    const Component = (
+      <MockedProvider mocks={ mocks } addTypename={ false }>
+        <PlaybookPreview { ...props } />
+      </MockedProvider>
+    );
+    const wrapper = mount( Component );
+
+    await wait( 0 );
+    wrapper.update();
+    const playbook = wrapper.find( 'Playbook' );
+
+    expect( playbook.exists() ).toEqual( true );
+  } );
+
+  it( 'renders an unavailable message if !item and !data.playbook', async () => {
+    const Component = (
+      <MockedProvider mocks={ undefinedMocks } addTypename={ false }>
+        <PlaybookPreview { ...undefinedItemProps } />
+      </MockedProvider>
+    );
+    const wrapper = mount( Component );
+
+    await wait( 0 );
+    wrapper.update();
+    const container = wrapper.find( 'PlaybookPreview' );
+    const msg = 'Preview is unavailable.';
+
+    expect( container.contains( msg ) ).toEqual( true );
+  } );
+} );
+
+describe( '<PlaybookPreview />, for client side render', () => {
+  const consoleError = console.error;
+
+  beforeAll( () => suppressActWarning( consoleError ) );
+  afterAll( () => {
+    console.error = consoleError;
+  } );
+
+  const Component = (
+    <MockedProvider mocks={ mocks } addTypename={ false }>
+      <PlaybookPreview { ...undefinedItemProps } />
+    </MockedProvider>
+  );
+
+  it( 'renders loading state without crashing', () => {
+    const wrapper = mount( Component );
+    const container = wrapper.find( 'PlaybookPreview' );
+    const msg = 'Loading Playbook preview...';
+
+    expect( container.contains( msg ) ).toEqual( true );
+  } );
+
+  it( 'renders the Playbook without crashing', async () => {
+    const wrapper = mount( Component );
+
+    await wait( 0 );
+    wrapper.update();
+    const playbook = wrapper.find( 'Playbook' );
+
+    expect( playbook.exists() ).toEqual( true );
+  } );
+
+  it( 'renders an error message if there is a GraphQL error', async () => {
+    const ErrorComponent = (
+      <MockedProvider mocks={ errorMocks } addTypename={ false }>
+        <PlaybookPreview { ...undefinedItemProps } />
+      </MockedProvider>
+    );
+    const wrapper = mount( ErrorComponent );
+
+    await wait( 0 );
+    wrapper.update();
+    const container = wrapper.find( 'PlaybookPreview' );
+    const error = errorMocks[0].result.errors[0];
+
+    expect( container.contains( error.message ) ).toEqual( true );
+  } );
+} );

--- a/pages/admin/package/playbook/preview/[id].js
+++ b/pages/admin/package/playbook/preview/[id].js
@@ -1,7 +1,6 @@
 import PropTypes from 'prop-types';
 import { ApolloClient, HttpLink, InMemoryCache } from '@apollo/client';
-import fetch from 'isomorphic-unfetch';
-import Playbook from 'components/Playbook/Playbook';
+import PlaybookPreview from 'components/admin/Previews/PlaybookPreview/PlaybookPreview';
 import { PLAYBOOK_QUERY } from 'lib/graphql/queries/playbook';
 
 /**
@@ -9,13 +8,10 @@ import { PLAYBOOK_QUERY } from 'lib/graphql/queries/playbook';
  * 2. Execute a SSR query for initial page population from server
  * @param {*} props
  */
-const PlaybookPage = props => {
-  const {
-    playbook,
-    query: { id },
-  } = props;
+const PlaybookPage = ( { playbook, query } ) => {
+  const { id } = query;
 
-  return <Playbook id={ id } item={ playbook } />;
+  return <PlaybookPreview id={ id } item={ playbook } />;
 };
 
 export async function getServerSideProps( { query } ) {


### PR DESCRIPTION
This PR is a follow up to PR #297 and #298.

### Summary
* Creates a `PlaybookPreview` component that will render `Playbook` with server side data if available. If the data from the server is `undefined`, then data is fetched using a client query.
* Makes unavailable the share URL and support files downloading
* Preview opens in the same window for now, per UX.