### PR TITLE
CDP-2394: Hook up unpublish and delete from dashboard

### DIFF
--- a/components/ScrollableTableWithMenu/TableActionsMenu/TableActionsMenu.scss
+++ b/components/ScrollableTableWithMenu/TableActionsMenu/TableActionsMenu.scss
@@ -1,4 +1,4 @@
-@import "../../../styles/colors.scss";
+@import 'styles/colors.scss';
 
 .actionsMenu {
   z-index: 3;
@@ -42,7 +42,6 @@
     }
 
     &--active {
-
       &:after {
         content: '';
       }
@@ -53,17 +52,6 @@
     margin-right: 0.5em;
     margin-left: 0.5em;
     cursor: pointer;
-  }
-
-  .unpublish {
-    vertical-align: top;
-    display: inline-block;
-
-    &--text {
-      display: inline-block;
-      padding: 0.4rem 0.6rem;
-      color: $light-blue;
-    }
   }
 
   .separator {

--- a/components/ScrollableTableWithMenu/TableActionsMenu/UnpublishProjects/UnpublishProjects.js
+++ b/components/ScrollableTableWithMenu/TableActionsMenu/UnpublishProjects/UnpublishProjects.js
@@ -1,8 +1,11 @@
-import React, { useContext, useEffect } from 'react';
+import { useContext, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { Button, Popup } from 'semantic-ui-react';
 import { useMutation, useQuery } from '@apollo/client';
+
 import { DashboardContext } from 'context/dashboardContext';
+
+import styles from './UnpublishProjects.module.scss';
 
 const UnpublishProjects = ( {
   handleResetSelections,
@@ -107,12 +110,12 @@ const UnpublishProjects = ( {
     <Popup
       trigger={ (
         <Button
-          className="unpublish"
+          className={ styles.unpublish }
           size="mini"
           basic
           onClick={ handleUnpublishProjects }
         >
-          <span className="unpublish--text">Unpublish</span>
+          <span className={ styles['unpublish--text'] }>Unpublish</span>
         </Button>
       ) }
       content="Unpublish Selection(s)"

--- a/components/ScrollableTableWithMenu/TableActionsMenu/UnpublishProjects/UnpublishProjects.module.scss
+++ b/components/ScrollableTableWithMenu/TableActionsMenu/UnpublishProjects/UnpublishProjects.module.scss
@@ -1,0 +1,12 @@
+@import 'styles/colors.scss';
+
+:global(.ui) button.unpublish {
+  vertical-align: top;
+  display: inline-block;
+}
+
+.unpublish--text {
+  display: inline-block;
+  padding: 0.4rem 0.6rem;
+  color: $light-blue;
+}

--- a/components/admin/Dashboard/utils.js
+++ b/components/admin/Dashboard/utils.js
@@ -31,6 +31,8 @@ import {
   PLAYBOOKS_META_QUERY,
   TEAM_PLAYBOOKS_QUERY,
   TEAM_PLAYBOOKS_COUNT_QUERY,
+  UNPUBLISH_PLAYBOOK_MUTATION,
+  UPDATE_PLAYBOOK_STATUS_MUTATION,
 } from 'lib/graphql/queries/playbook';
 
 /**
@@ -92,11 +94,11 @@ export const setQueries = team => {
       queries.count = TEAM_PLAYBOOKS_COUNT_QUERY;
       queries.remove = DELETE_PLAYBOOK_MUTATION;
       queries.metaContent = PLAYBOOKS_META_QUERY;
+      queries.unpublish = UNPUBLISH_PLAYBOOK_MUTATION;
+      queries.status = UPDATE_PLAYBOOK_STATUS_MUTATION;
       // The following queries are placeholders and for the wrong content type
       // As such, these operations will not work properly
       queries.files = PACKAGE_FILES_QUERY;
-      queries.status = UPDATE_PACKAGE_STATUS_MUTATION;
-      queries.unpublish = UNPUBLISH_PACKAGE_MUTATION;
 
       return queries;
     default:

--- a/lib/graphql/queries/playbook.js
+++ b/lib/graphql/queries/playbook.js
@@ -133,7 +133,7 @@ export const UPDATE_PLAYBOOK_STATUS_MUTATION = gql`
  Queries
  -----------------------------------------*/
 export const PLAYBOOK_QUERY = gql`
- query Playbook($id: ID!) {
+ query PLAYBOOK_QUERY($id: ID!) {
    playbook: playbook(id: $id) {
      ...playbookDetails
      supportFiles {


### PR DESCRIPTION
Connects the unpublish and delete bulk actions on the dashboard to the relevant GraphQL mutations. There is a [corresponding PR on the server](https://github.com/IIP-Design/content-commons-server/pull/62) to delete files from S3 on unpublish/deletion, but it is not strictly speaking necessary for the bulk actions to work.

Also took care of a couple of targets of opportunity:

1. Changed the operation name `query Playbook($id: ID!)` to `query PLAYBOOK_QUERY($id: ID!)` per our dev meeting [discussions on consistency](https://iip-design.github.io/lab-tools/dev_meetings/2021-06-15.html#1-graphql-operation-names). 
2. Scoped the `UnpublishProjects` CSS to fix a couple of Sementic UI overrides.