### PR TITLE
CDP-2418: Populate the file list for playbooks in the dashboard

### DIFF
--- a/components/admin/Dashboard/TeamProjects/DetailsPopup/DetailsPopup.js
+++ b/components/admin/Dashboard/TeamProjects/DetailsPopup/DetailsPopup.js
@@ -1,13 +1,15 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
-import dynamic from 'next/dynamic';
 import debounce from 'lodash/debounce';
+import dynamic from 'next/dynamic';
 import { Popup } from 'semantic-ui-react';
+
 import './DetailsPopup.scss';
 
 const VideoDetailsPopup = dynamic( () => import( './VideoDetailsPopup' ) );
-const PackageDetailsPopup = dynamic( () => import( './PackageDetailsPopup' ) );
 const GraphicDetailsPopup = dynamic( () => import( './GraphicDetailsPopup' ) );
+const PackageDetailsPopup = dynamic( () => import( './PackageDetailsPopup' ) );
+const PlaybookDetailsPopup = dynamic( () => import( './PlaybookDetailsPopup' ) );
 
 const DetailsPopup = props => {
   const { id, team } = props;
@@ -58,6 +60,7 @@ const DetailsPopup = props => {
     if ( contentTypes.includes( 'VIDEO' ) ) return <VideoDetailsPopup id={ id } />;
     if ( contentTypes.includes( 'PACKAGE' ) ) return <PackageDetailsPopup id={ id } />;
     if ( contentTypes.includes( 'GRAPHIC' ) ) return <GraphicDetailsPopup id={ id } />;
+    if ( contentTypes.includes( 'PLAYBOOK' ) ) return <PlaybookDetailsPopup id={ id } />;
   };
 
   return (

--- a/components/admin/Dashboard/TeamProjects/DetailsPopup/PackageDetailsPopup.js
+++ b/components/admin/Dashboard/TeamProjects/DetailsPopup/PackageDetailsPopup.js
@@ -1,9 +1,8 @@
-import React from 'react';
+import ApolloError from 'components/errors/ApolloError';
 import PropTypes from 'prop-types';
 import { useQuery } from '@apollo/client';
-import ApolloError from 'components/errors/ApolloError';
-import { PACKAGE_FILES_QUERY } from 'lib/graphql/queries/package';
 
+import { PACKAGE_FILES_QUERY } from 'lib/graphql/queries/package';
 
 const PackageDetailsPopup = ( { id } ) => {
   const { loading, error, data } = useQuery( PACKAGE_FILES_QUERY, {

--- a/components/admin/Dashboard/TeamProjects/DetailsPopup/PlaybookDetailsPopup.js
+++ b/components/admin/Dashboard/TeamProjects/DetailsPopup/PlaybookDetailsPopup.js
@@ -1,0 +1,32 @@
+import PropTypes from 'prop-types';
+import { useQuery } from '@apollo/client';
+
+import ApolloError from 'components/errors/ApolloError';
+
+import { PLAYBOOK_FILES_QUERY } from 'lib/graphql/queries/playbook';
+
+const PlaybookDetailsPopup = ( { id } ) => {
+  const { loading, error, data } = useQuery( PLAYBOOK_FILES_QUERY, {
+    variables: { id },
+  } );
+
+  if ( loading ) return <p>Loading....</p>;
+  if ( error ) return <ApolloError error={ error } />;
+
+  const { supportFiles } = data.playbook;
+
+  return (
+    <div className="details-files">
+      <ul>
+        { !supportFiles.length && <li>There are no files associated with this project.</li> }
+        { supportFiles.map( file => <li key={ file.id }>{ file.filename }</li> ) }
+      </ul>
+    </div>
+  );
+};
+
+PlaybookDetailsPopup.propTypes = {
+  id: PropTypes.string,
+};
+
+export default PlaybookDetailsPopup;

--- a/components/admin/Dashboard/utils.js
+++ b/components/admin/Dashboard/utils.js
@@ -28,6 +28,7 @@ import {
 } from 'lib/graphql/queries/video';
 import {
   DELETE_PLAYBOOK_MUTATION,
+  PLAYBOOK_FILES_QUERY,
   PLAYBOOKS_META_QUERY,
   TEAM_PLAYBOOKS_QUERY,
   TEAM_PLAYBOOKS_COUNT_QUERY,
@@ -92,13 +93,11 @@ export const setQueries = team => {
     case 'playbooks':
       queries.content = TEAM_PLAYBOOKS_QUERY;
       queries.count = TEAM_PLAYBOOKS_COUNT_QUERY;
+      queries.files = PLAYBOOK_FILES_QUERY;
       queries.remove = DELETE_PLAYBOOK_MUTATION;
       queries.metaContent = PLAYBOOKS_META_QUERY;
       queries.unpublish = UNPUBLISH_PLAYBOOK_MUTATION;
       queries.status = UPDATE_PLAYBOOK_STATUS_MUTATION;
-      // The following queries are placeholders and for the wrong content type
-      // As such, these operations will not work properly
-      queries.files = PACKAGE_FILES_QUERY;
 
       return queries;
     default:

--- a/lib/graphql/queries/playbook.js
+++ b/lib/graphql/queries/playbook.js
@@ -179,3 +179,16 @@ export const PLAYBOOKS_META_QUERY = gql`
     }
   }
 `;
+
+export const PLAYBOOK_FILES_QUERY = gql`
+  query PLAYBOOK_FILES_QUERY($id: ID!) {
+    playbook(id: $id) {
+      id
+      assetPath
+      supportFiles {
+       ...supportFileDetails
+     }
+    }
+  }
+  ${SUPPORT_FILE_DETAILS_FRAGMENT}
+`;


### PR DESCRIPTION
Creates a `PLAYBOOK_FILES_QUERY` and the `PlaybookDetailsPopup` component to render the list of playbook support files in the dashboard.

Also, for completeness, sets the `PLAYBOOK_FILES_QUERY` as the files query for playbooks in the `admin/Dashboard/utils.js` function `setQueries`, although that value is never used.