### PR TITLE
CDP-2429: Publish Changes displays after a project is published

### DIFF
--- a/components/admin/ButtonPublish/ButtonPublish.js
+++ b/components/admin/ButtonPublish/ButtonPublish.js
@@ -19,7 +19,7 @@ const ButtonPublish = ( {
   return (
     <Fragment>
       { ( ( status === 'PUBLISHED' || status === 'PUBLISHING' ) && updated ) && (
-        <Button className={ setButtonState( 'edit basic' ) } onClick={ handlePublish } disabled={ disabled }>Publish Changes</Button>
+        <Button className={ setButtonState( 'publish-changes basic' ) } onClick={ handlePublish } disabled={ disabled }>Publish Changes</Button>
       ) }
       <Button className="action-btn btn--publish" onClick={ handleUnPublish }>Unpublish</Button>
     </Fragment>

--- a/components/admin/ButtonPublish/ButtonPublish.test.js
+++ b/components/admin/ButtonPublish/ButtonPublish.test.js
@@ -204,7 +204,7 @@ describe( '<ButtonPublish />, for PUBLISHED status & updated', () => {
     const publishChangesBtn = getBtn( 'Publish Changes', btns );
     const { className } = publishChangesBtn.props();
 
-    expect( className.includes( 'action-btn btn--edit' ) )
+    expect( className.includes( 'action-btn btn--publish-changes' ) )
       .toEqual( newProps.status === 'PUBLISHED' && newProps.updated );
     expect( className.includes( 'loading' ) ).toEqual( newProps.publishing );
   } );
@@ -276,7 +276,7 @@ describe( '<ButtonPublish />, for PUBLISHED status, updated, & disabled', () => 
     const publishChangesBtn = getBtn( 'Publish Changes', btns );
     const { className } = publishChangesBtn.props();
 
-    expect( className.includes( 'action-btn btn--edit' ) )
+    expect( className.includes( 'action-btn btn--publish-changes' ) )
       .toEqual( newProps.status === 'PUBLISHED' && newProps.updated );
     expect( className.includes( 'loading' ) ).toEqual( newProps.publishing );
   } );
@@ -401,7 +401,7 @@ describe( '<ButtonPublish />, for PUBLISHING status, publishing, and updated', (
     const publishChangesBtn = getBtn( 'Publish Changes', btns );
     const { className } = publishChangesBtn.props();
 
-    expect( className.includes( 'action-btn btn--edit' ) )
+    expect( className.includes( 'action-btn btn--publish-changes' ) )
       .toEqual( ( newProps.status === 'PUBLISHED' || newProps.status === 'PUBLISHING' ) && newProps.updated );
     expect( className.includes( 'loading' ) ).toEqual( newProps.publishing );
   } );

--- a/components/admin/TextEditor/TextEditor.js
+++ b/components/admin/TextEditor/TextEditor.js
@@ -23,7 +23,9 @@ const TextEditor = ( { id, content, query, type, updateMutation } ) => {
     autosave: {
       waitingTime: 500,
       save: async editor => {
-        if ( !editor.getData() ) return;
+        const isInitializing = editor.getData() === content?.html;
+
+        if ( !editor.getData() || isInitializing ) return;
 
         try {
           await updateMutation( {


### PR DESCRIPTION
This PR prevents the `updateMutation` from being called when the playbook text editor is loaded, and it also addresses the styling of the Publish Changes button at the bottom of the playbook details page.