### PR TITLE
CDP-2406: Update delete confirmation from dashboard

### DIFF
--- a/components/ScrollableTableWithMenu/TableActionsMenu/DeleteProjects/DeleteProjects.js
+++ b/components/ScrollableTableWithMenu/TableActionsMenu/DeleteProjects/DeleteProjects.js
@@ -28,6 +28,7 @@ const DeleteProjects = ( {
     if ( types.includes( 'GRAPHIC' ) ) return 'graphic';
     if ( types.includes( 'VIDEO' ) ) return 'video';
     if ( types.includes( 'PACKAGE' ) ) return 'package';
+    if ( types.includes( 'PLAYBOOK' ) ) return 'playbook';
 
     return '';
   };
@@ -82,7 +83,13 @@ const DeleteProjects = ( {
   const messageFragment = isDraft => {
     const getFunc = isDraft === 'draft' ? getDrafts() : getNonDrafts();
 
-    return `${displayProjectTypeText()} ${getPluralStringOrNot( getFunc, 'project' )}`;
+    const type = displayProjectTypeText();
+
+    if ( type === 'graphic' || type === 'video' ) {
+      return `${type} ${getPluralStringOrNot( getFunc, 'project' )}`;
+    }
+
+    return getPluralStringOrNot( getFunc, type );
   };
 
   return (


### PR DESCRIPTION
When deleting a playbook from the dashboard the confirmation message will now say 

`Are you sure you want to delete the selected DRAFT playbook?`

or in the case of multiple packages selected:

`Are you sure you want to delete the selected DRAFT playbooks?`.

Similarly, I removed the word "project" from the confirmation message for packages.