### PR TITLE
CDP-2436: Limit width of playbook title

### DIFF
--- a/components/Playbook/Playbook.js
+++ b/components/Playbook/Playbook.js
@@ -76,7 +76,7 @@ const Playbook = ( { item } ) => {
           dangerouslySetInnerHTML={ { __html: DOMPurify.sanitize( item?.content?.html || '' ) } } // eslint-disable-line react/no-danger
         />
       </TexturedSection>
-      { item?.supportFiles && item?.supportFiles?.length && (
+      { item?.supportFiles && item?.supportFiles?.length > 0 && (
         <div className={ styles['resources-container'] }>
           <h3 className={ styles['resources-title'] }>Additional Resources</h3>
           <div className={ styles['resources-content'] }>

--- a/components/Playbook/Playbook.module.scss
+++ b/components/Playbook/Playbook.module.scss
@@ -93,6 +93,9 @@
 }
 
 .title {
+  max-width: 50ch;
+  margin-left: auto;
+  margin-right: auto;
   color: white;
 }
 

--- a/components/ScrollableTableWithMenu/TableActionsMenu/DeleteProjects/DeleteProjects.js
+++ b/components/ScrollableTableWithMenu/TableActionsMenu/DeleteProjects/DeleteProjects.js
@@ -104,7 +104,7 @@ const DeleteProjects = ( {
       >
         { hasDrafts && (
           <DeleteProjectsList
-            headline={ `The following DRAFT ${messageFragment( 'draft' )} will be removed permanently from the Content Cloud:` }
+            headline={ `The following DRAFT ${messageFragment( 'draft' )} will be removed permanently from Content Commons:` }
             projects={ getDrafts() }
             isDrafts
           />


### PR DESCRIPTION
This PR places a limit on the width of the title on the playbook and playbook preview page and two miscellaneous fixes.

1. Added an adjustment to the conditional check for  `item.supportFiles.length` to prevent a `0` from being rendered on the playbook page. This was causing the blue bar to appear at the bottom even when there are no support files.
2. Replaced "Content Cloud" with "Content Commons" in the delete confirmation modal.