### PR TITLE
CDP-2432: Correct file links to playbook additional resources

### DIFF
--- a/components/Playbook/Playbook.js
+++ b/components/Playbook/Playbook.js
@@ -8,7 +8,7 @@ import Popover from 'components/popups/Popover/Popover';
 import Share from 'components/Share/Share';
 import TexturedSection from 'components/TexturedSection/TexturedSection';
 
-import { formatBytes } from 'lib/utils';
+import { formatBytes, maybeGetUrlToProdS3 } from 'lib/utils';
 import cautionIcon from 'static/icons/icon_caution.svg';
 import shareIconWhite from 'static/icons/icon_share_white.svg';
 
@@ -90,7 +90,7 @@ const Playbook = ( { item } ) => {
                   <DownloadItemContent
                     hoverText={ `Download ${file.filename}` }
                     isAdminPreview={ isAdminPreview }
-                    srcUrl={ file.url }
+                    srcUrl={ maybeGetUrlToProdS3( file.url ) }
                     downloadFilename={ file.filename }
                   >
                     <div className="item-content">

--- a/components/admin/download/DownloadPkgFiles/DownloadPkgFiles.js
+++ b/components/admin/download/DownloadPkgFiles/DownloadPkgFiles.js
@@ -1,9 +1,12 @@
-import React, { useState, Fragment } from 'react';
+import { useState, Fragment } from 'react';
 import PropTypes from 'prop-types';
-import downloadIcon from 'static/icons/icon_download.svg';
-import { downloadPackage } from 'lib/utils';
+
 import SignedUrlLink from './SignedUrlLink/SignedUrlLink';
+
+import { downloadPackage } from 'lib/utils';
 import { useAuth } from 'context/authContext';
+
+import downloadIcon from 'static/icons/icon_download.svg';
 
 const DownloadPkgFiles = ( { files, id, isPreview, title } ) => {
   const [loading, setLoading] = useState( false );

--- a/components/admin/download/DownloadPkgFiles/SignedUrlLink/SignedUrlLink.js
+++ b/components/admin/download/DownloadPkgFiles/SignedUrlLink/SignedUrlLink.js
@@ -1,6 +1,7 @@
-import React from 'react';
 import PropTypes from 'prop-types';
+
 import DownloadItemContent from 'components/download/DownloadItem/DownloadItemContent';
+
 import useSignedUrl from 'lib/hooks/useSignedUrl';
 
 const SignedUrlLink = ( { file, isPreview } ) => {

--- a/components/admin/download/DownloadVideo/DownloadVideo.js
+++ b/components/admin/download/DownloadVideo/DownloadVideo.js
@@ -1,13 +1,12 @@
-import React from 'react';
 import PropTypes from 'prop-types';
+
 import DownloadItemContent from 'components/download/DownloadItem/DownloadItemContent';
+
 import { formatBytes, getS3Url } from 'lib/utils';
 
 // NOTE: Using the 'download' attribute to trigger downloads
 // Need to research more robust options depending on browser support
-const DownloadVideo = props => {
-  const { selectedLanguageUnit, burnedInCaptions, isPreview } = props;
-
+const DownloadVideo = ( { selectedLanguageUnit, burnedInCaptions, isPreview } ) => {
   const getSizeInfo = ( dimensions, filesize ) => {
     if ( !Object.keys( dimensions ) || !filesize ) return null;
 
@@ -16,7 +15,6 @@ const DownloadVideo = props => {
       weight: formatBytes( filesize ),
     };
   };
-
 
   const sortByFilesize = ( a, b ) => {
     if ( a.filesize && b.filesize ) {

--- a/components/download/DownloadItem/DownloadItemContent.js
+++ b/components/download/DownloadItem/DownloadItemContent.js
@@ -1,7 +1,9 @@
-import React from 'react';
 import PropTypes from 'prop-types';
+
 import useSignedUrl from 'lib/hooks/useSignedUrl';
+
 import downloadIcon from 'static/icons/icon_download.svg';
+
 import './DownloadItemContent.scss';
 
 const DownloadItemContent = ( {


### PR DESCRIPTION
The `url` field on the playbook data object returns an asset path to the file without the bucket URL prefix. Using the `signedUrl` property on the playbook would work, however, that currently provides a link to the asset in the authoring bucket rather than the production bucket (not sure why that is the case).

However, my using the `maybeGetUrlToProdS3` function, we can convert that asset path to the actual S3 URL before trying to derive a signed URL to the asset.

Also made some trivial tweaks to whitespace and import statement order in a couple of other files.