### PR TITLE
Dashboard Fixes

### DIFF
--- a/components/ScrollableTableWithMenu/ScrollableTableWithMenu.js
+++ b/components/ScrollableTableWithMenu/ScrollableTableWithMenu.js
@@ -46,7 +46,7 @@ const ScrollableTableWithMenu = ( { columnMenu, persistentTableHeaders, projectT
 
   // Get teams to include in query for a specific content type
   // This is rather odd and the connection between teams and content
-  // types should be more fully thought out and absracted
+  // types should be more fully thought out and abstracted
   const teams
     = team.name === 'GPA Design & Editorial'
       ? `${team.name}|Regional Media Hubs|ShareAmerica`

--- a/components/ScrollableTableWithMenu/TableMenu/TableMenu.js
+++ b/components/ScrollableTableWithMenu/TableMenu/TableMenu.js
@@ -4,11 +4,12 @@
  *
  */
 
-import React, { useRef, useState, createRef, useEffect } from 'react';
+import { createRef, Fragment, useEffect, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 import { Accordion, Checkbox, Icon, Menu } from 'semantic-ui-react';
 
 import VisuallyHidden from 'components/VisuallyHidden/VisuallyHidden';
+
 import { isMobile, isWindowWidthLessThanOrEqualTo } from 'lib/browser';
 import { titleCase } from 'lib/utils';
 
@@ -35,7 +36,6 @@ const TableMenu = ( { columnMenu, tableMenuOnChange } ) => {
   const handleCloseMenu = () => setDisplayTableMenu( false );
 
   const handleKbdAccess = e => {
-    // console.log( displayTableMenu );
     if ( !displayTableMenu ) return;
 
     if ( [
@@ -104,9 +104,6 @@ const TableMenu = ( { columnMenu, tableMenuOnChange } ) => {
     const isTableMenuItem = parentNode && ( !!parentNode.dataset.tablemenuitem || !!dataset.tablemenuitem );
     const isShowMoreColumns = id === 'show-more-columns';
 
-    // console.log( dataset, id, parentNode );
-    // console.log( 'table menu: ', isTableMenu );
-
     if ( isTableMenu ) {
       const displayState = displayTableMenu;
 
@@ -171,7 +168,21 @@ const TableMenu = ( { columnMenu, tableMenuOnChange } ) => {
     };
   }, [] );
 
-  const isTableScrollable = menuHeaders.length >= 2;
+  // The table will always have at least three columns - created, visibility, & author
+  // Add to this the number of selected optional show more columns.
+  const totalColumns = 3 + menuHeaders.length;
+
+  // Calculate the minimum width of the content.
+  // Each column has a minimum width of 150px.
+  // Add to this the project title column which has a minimum width of 300px.
+  const contentWidth = totalColumns * 150 + 300;
+
+  // Get the width of the table that this menu controls.
+  const table = document.querySelector( '.items_table' );
+  const tableWidth = table ? table.clientWidth : 0;
+
+  // If the minimum width of the content is smaller than the table width the table is scrollable.
+  const isTableScrollable = contentWidth > tableWidth;
 
   return (
     <div className="items_menu_wrapper">
@@ -194,58 +205,61 @@ const TableMenu = ( { columnMenu, tableMenuOnChange } ) => {
                 name={ `angle ${displayTableMenu ? 'up' : 'down'}` }
               />
             </Accordion.Title>
-            { displayTableMenu
-                && (
-                  <Accordion.Content
-                    active={ displayTableMenu }
-                    aria-hidden={ !displayTableMenu }
-                    aria-labelledby="show-more-btn"
-                    as="ul"
-                    id="show-more-columns"
-                    role="menu"
-                  >
-                    { columnMenu.map( ( item, idx ) => (
-                      <li key={ item.name }>
-                        <Checkbox
-                          checked={ menuHeaders.includes( item.label ) }
-                          data-proplabel={ item.label }
-                          data-propname={ item.name }
-                          data-tablemenuitem
-                          id={ item.label }
-                          label={ titleCase( item.label ) }
-                          onChange={ tableMenuOnChange }
-                          onClick={ toggleCheckbox }
-                          ref={ refs.current[idx] }
-                          role="menuitem"
-                          tabIndex="-1"
-                        />
-                      </li>
-                    ) ) }
-                  </Accordion.Content>
-                ) }
+            { displayTableMenu && (
+              <Accordion.Content
+                active={ displayTableMenu }
+                aria-hidden={ !displayTableMenu }
+                aria-labelledby="show-more-btn"
+                as="ul"
+                id="show-more-columns"
+                role="menu"
+              >
+                { columnMenu.map( ( item, idx ) => (
+                  <li key={ item.name }>
+                    <Checkbox
+                      checked={ menuHeaders.includes( item.label ) }
+                      data-proplabel={ item.label }
+                      data-propname={ item.name }
+                      data-tablemenuitem
+                      id={ item.label }
+                      label={ titleCase( item.label ) }
+                      onChange={ tableMenuOnChange }
+                      onClick={ toggleCheckbox }
+                      ref={ refs.current[idx] }
+                      role="menuitem"
+                      tabIndex="-1"
+                    />
+                  </li>
+                ) ) }
+              </Accordion.Content>
+            ) }
           </Menu.Item>
         </Accordion>
 
-        <button
-          data-tablearrow="left"
-          onClick={ handleTableScroll }
-          onFocus={ displayTableMenu ? toggleTableMenu : null }
-          type="button"
-          disabled={ !isTableScrollable }
-        >
-          <VisuallyHidden el="span">scroll table left</VisuallyHidden>
-          <Icon name="angle left" data-tablearrow="left" />
-        </button>
-        <button
-          data-tablearrow="right"
-          onClick={ handleTableScroll }
-          onFocus={ displayTableMenu ? toggleTableMenu : null }
-          type="button"
-          disabled={ !isTableScrollable }
-        >
-          <VisuallyHidden el="span">scroll table right</VisuallyHidden>
-          <Icon name="angle right" data-tablearrow="right" />
-        </button>
+        { isTableScrollable && (
+          <Fragment>
+            <button
+              data-tablearrow="left"
+              onClick={ handleTableScroll }
+              onFocus={ displayTableMenu ? toggleTableMenu : null }
+              type="button"
+              disabled={ !isTableScrollable }
+            >
+              <VisuallyHidden el="span">scroll table left</VisuallyHidden>
+              <Icon name="angle left" data-tablearrow="left" />
+            </button>
+            <button
+              data-tablearrow="right"
+              onClick={ handleTableScroll }
+              onFocus={ displayTableMenu ? toggleTableMenu : null }
+              type="button"
+              disabled={ !isTableScrollable }
+            >
+              <VisuallyHidden el="span">scroll table right</VisuallyHidden>
+              <Icon name="angle right" data-tablearrow="right" />
+            </button>
+          </Fragment>
+        ) }
       </div>
     </div>
   );

--- a/components/ScrollableTableWithMenu/TableMenu/TableMenu.js
+++ b/components/ScrollableTableWithMenu/TableMenu/TableMenu.js
@@ -187,8 +187,7 @@ const TableMenu = ( { columnMenu, tableMenuOnChange } ) => {
               data-tablemenu
               id="show-more-btn"
             >
-              Show More
-              { ' ' }
+              { 'Show More ' }
               <VisuallyHidden el="span">columns</VisuallyHidden>
               <Icon
                 data-tablemenu

--- a/lib/graphql/queries/playbook.js
+++ b/lib/graphql/queries/playbook.js
@@ -153,14 +153,37 @@ export const TEAM_PLAYBOOKS_QUERY = gql`
     $team: TeamWhereInput!
     $first: Int,
     $skip: Int,
-    $orderBy: PlaybookOrderByInput
+    $searchTerm: String,
+    $orderBy: PlaybookOrderByInput,
   ) {
     playbooks(
       first: $first,
       skip: $skip,
       orderBy: $orderBy,
       where: {
-        team: $team
+        AND: [
+          { team: $team },
+          {
+            OR: [
+              { title_contains: $searchTerm },
+              { desc_contains: $searchTerm },
+              {
+                categories_some: {
+                  translations_some: { name_contains: $searchTerm }
+                }
+              },
+              {
+                author: {
+                  OR: [
+                    { firstName_contains: $searchTerm },
+                    { lastName_contains: $searchTerm },
+                    { email_contains: $searchTerm }
+                  ]
+                }
+              }
+            ]
+          }
+        ]
       }
     ) {
       ...playbookDetails
@@ -170,10 +193,32 @@ export const TEAM_PLAYBOOKS_QUERY = gql`
 `;
 
 export const TEAM_PLAYBOOKS_COUNT_QUERY = gql`
-  query TEAM_PLAYBOOKS_COUNT_QUERY($team: TeamWhereInput!) {
+  query TEAM_PLAYBOOKS_COUNT_QUERY($team: TeamWhereInput!, $searchTerm: String) {
     playbooks(
       where: {
-        team: $team
+        AND: [
+          { team: $team },
+          {
+            OR: [
+              { title_contains: $searchTerm },
+              { desc_contains: $searchTerm },
+              {
+                categories_some: {
+                  translations_some: { name_contains: $searchTerm }
+                }
+              },
+              {
+                author: {
+                  OR: [
+                    { firstName_contains: $searchTerm },
+                    { lastName_contains: $searchTerm },
+                    { email_contains: $searchTerm }
+                  ]
+                }
+              }
+            ]
+          }
+        ]
       }
     ) {
       id

--- a/lib/graphql/queries/playbook.js
+++ b/lib/graphql/queries/playbook.js
@@ -6,69 +6,72 @@ import { SUPPORT_FILE_DETAILS_FRAGMENT } from './common';
  Fragments
  -----------------------------------------*/
 export const PLAYBOOK_DETAILS_FRAGMENT = gql`
- fragment playbookDetails on Playbook {
-   id
-   createdAt
-   updatedAt
-   publishedAt
-   type
-   assetPath
-   author {
-     id
-     firstName
-     lastName
-   }
-   team {
-     id
-     name
-   }
-   title
-   desc
-   status
-   visibility
-   policy {
-     id
-     name
-     theme
-   }
-   categories {
-     id
-     translations(
-       where: { language: { locale: "en-us" } }
-       orderBy: name_ASC
-     ) {
-       id
-       name
-     }
-   }
-   tags {
-     id
-     translations(
-       where: { language: { locale: "en-us" } }
-       orderBy: name_ASC
-     ) {
-       id
-       name
-     }
-   }
-   content {
-     id
-     rawText
-     html
-     markdown
-   }
- }
+  fragment playbookDetails on Playbook {
+    id
+    createdAt
+    updatedAt
+    publishedAt
+    type
+    assetPath
+    author {
+      id
+      firstName
+      lastName
+    }
+    team {
+      id
+      name
+    }
+    title
+    desc
+    status
+    visibility
+    policy {
+      id
+      name
+      theme
+    }
+    categories {
+      id
+      translations(
+        where: { language: { locale: "en-us" } }
+        orderBy: name_ASC
+      ) {
+        id
+        language {
+          locale
+        }
+        name
+      }
+    }
+    tags {
+      id
+      translations(
+        where: { language: { locale: "en-us" } }
+        orderBy: name_ASC
+      ) {
+        id
+        name
+      }
+    }
+    content {
+      id
+      rawText
+      html
+      markdown
+    }
+  }
 `;
 
 /*----------------------------------------
 Mutations
 -----------------------------------------*/
 export const CREATE_PLAYBOOK_MUTATION = gql`
- mutation CREATE_PLAYBOOK_MUTATION($data: PlaybookCreateInput!) {
-   createPlaybook(data: $data) {
-     id 
-   }
- }
+  mutation CREATE_PLAYBOOK_MUTATION($data: PlaybookCreateInput!) {
+    createPlaybook(data: $data) {
+      id 
+    }
+  }
 `;
 
 // Return complete tree to enable auto cache update
@@ -126,23 +129,23 @@ export const UPDATE_PLAYBOOK_STATUS_MUTATION = gql`
         publishedAt
         status
       } 
-  }
+    }
 `;
 
 /*----------------------------------------
  Queries
  -----------------------------------------*/
 export const PLAYBOOK_QUERY = gql`
- query PLAYBOOK_QUERY($id: ID!) {
-   playbook: playbook(id: $id) {
-     ...playbookDetails
-     supportFiles {
-       ...supportFileDetails
-     }
-   }
- }
- ${PLAYBOOK_DETAILS_FRAGMENT}
- ${SUPPORT_FILE_DETAILS_FRAGMENT}
+  query PLAYBOOK_QUERY($id: ID!) {
+    playbook: playbook(id: $id) {
+      ...playbookDetails
+      supportFiles {
+        ...supportFileDetails
+      }
+    }
+  }
+  ${PLAYBOOK_DETAILS_FRAGMENT}
+  ${SUPPORT_FILE_DETAILS_FRAGMENT}
 `;
 
 export const TEAM_PLAYBOOKS_QUERY = gql`
@@ -152,7 +155,7 @@ export const TEAM_PLAYBOOKS_QUERY = gql`
         team: $team
       }
     ) {
-     ...playbookDetails
+      ...playbookDetails
     }
   }
   ${PLAYBOOK_DETAILS_FRAGMENT}

--- a/lib/graphql/queries/playbook.js
+++ b/lib/graphql/queries/playbook.js
@@ -149,8 +149,16 @@ export const PLAYBOOK_QUERY = gql`
 `;
 
 export const TEAM_PLAYBOOKS_QUERY = gql`
-  query TEAM_PLAYBOOKS_QUERY($team: TeamWhereInput!) {
+  query TEAM_PLAYBOOKS_QUERY(
+    $team: TeamWhereInput!
+    $first: Int,
+    $skip: Int,
+    $orderBy: PlaybookOrderByInput
+  ) {
     playbooks(
+      first: $first,
+      skip: $skip,
+      orderBy: $orderBy,
       where: {
         team: $team
       }


### PR DESCRIPTION
This PR addresses a number of issues.

1. [CDP-2456](https://design.atlassian.net/browse/CDP-2456) - The playbooks appearing in wrong order on the dashboard. This was resolved by adding an `orderBy` variable to the team playbooks query in `lib/graphql/queries/playbook.js`. This allows for the query to be sorted in descending order (most recent created first).
2. This change also enabled sorting the table content by clicking on the column headers.
3. Similarly, added a search term variable to the team playbooks to allow for playbook search from the dashboard.
4. Added the locale value to category return on playbooks query (also in `lib/graphql/queries/playbook.js`) so that the categories column can get populated.
5. [CDP-2396](https://design.atlassian.net/browse/CDP-2396): altered the case in which the right-left scroll arrows appear in the table menu. Rather than always showing the arrows and disabling them when there are 5 columns, I calculate the minimum width of the content and compare it to the width of the table. If the content is wider than the table I show the arrows. This accomplished using document query selectors which is not a very React-y way to do this and perhaps we should revisit after playbooks are released. For the sake of expediency, both arrows are always active whenever they are visited (i.e. - they are not disabled even when scrolled all the way over).