### PR TITLE
CDP-2462: Switch playbook query on playbook frontend from GraphQL to Elasticsearch 

### DIFF
--- a/components/Playbook/Playbook.js
+++ b/components/Playbook/Playbook.js
@@ -86,7 +86,7 @@ const Playbook = ( { item } ) => {
             </small>
             <ul className={ styles['resources-list'] }>
               { item.supportFiles.map( file => (
-                <li key={ file.id }>
+                <li key={ file.filename }>
                   <DownloadItemContent
                     hoverText={ `Download ${file.filename}` }
                     isAdminPreview={ isAdminPreview }

--- a/components/admin/ProjectReview/VideoReview/VideoReview.js
+++ b/components/admin/ProjectReview/VideoReview/VideoReview.js
@@ -205,7 +205,7 @@ const VideoReview = props => {
               headline="Are you sure you want to delete this video project?"
             >
               <p>
-                This video project will be permanently removed from the Content Cloud. Any videos
+                This video project will be permanently removed from the Content Commons. Any videos
                 that you uploaded here will not be uploaded.
               </p>
             </ConfirmModalContent>

--- a/components/admin/Upload/modals/Confirm/Confirm.js
+++ b/components/admin/Upload/modals/Confirm/Confirm.js
@@ -53,7 +53,7 @@ FileConfirm.propTypes = {
 FileConfirm.defaultProps = {
   open: false,
   headline: 'Are you sure you want to delete this video project?',
-  content: 'This video project will be permanently removed from the Content Cloud. Any videos that you uploaded here will not be uploaded.',
+  content: 'This video project will be permanently removed from the Content Commons. Any videos that you uploaded here will not be uploaded.',
   cancelButton: 'Cancel',
   confirmButton: 'OK',
 };

--- a/lib/elastic/api.js
+++ b/lib/elastic/api.js
@@ -319,6 +319,17 @@ export const getItemRequest = ( site, postId, useIdKey = false, user ) => axios
   // eslint-disable-next-line no-console
   .catch( error => console.log( error ) );
 
+export const getItemByIdRequest = ( id, user ) => axios
+  .post( SEARCH, {
+    body: bodybuilder()
+      .size( 1 )
+      .query( 'query_string', 'query', `id: ${id}` )
+      .build(),
+  }, {
+    headers: { Authorization: `Bearer ${user?.esToken}` },
+  } )
+  .then( response => response.data )
+  .catch( error => console.error( error ) );
 
 export const getTermsRequest = ( key, values, user ) => axios
   .post( SEARCH, {

--- a/lib/elastic/parser.js
+++ b/lib/elastic/parser.js
@@ -334,6 +334,7 @@ const populatePlaybookItem = source => {
     desc: source.desc || '',
     policy: source.policy?.name || '',
     theme: source.policy?.theme || '',
+    content: source.content || '',
     supportFiles: source.supportFiles,
   };
 

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -11,7 +11,7 @@ import propTypes from 'prop-types';
 
 import Page from 'components/Page';
 
-import { AuthProvider, canAccessPage, fetchUser } from 'context/authContext';
+import { AuthProvider, canAccessPage } from 'context/authContext';
 import awsconfig from '../aws-exports';
 import storeWrapper from 'lib/redux/store';
 import withApollo from 'hocs/withApollo';
@@ -23,7 +23,7 @@ Amplify.configure( {
   ssr: true,
 } );
 
-const Commons = ( { apollo, Component, pageProps, router, user } ) => {
+const Commons = ( { apollo, Component, pageProps, router } ) => {
   const { redirect } = pageProps;
 
   useEffect( () => {
@@ -36,7 +36,7 @@ const Commons = ( { apollo, Component, pageProps, router, user } ) => {
     <ApolloProvider client={ apollo }>
       <AuthProvider>
         <Page redirect={ pageProps.redirect }>
-          <Component { ...pageProps } user={ user } />
+          <Component { ...pageProps } />
         </Page>
       </AuthProvider>
     </ApolloProvider>
@@ -64,9 +64,7 @@ Commons.getInitialProps = async appContext => {
     appProps.pageProps.query = ctx.query;
   }
 
-  const user = await fetchUser( ctx );
-
-  return { ...appProps, user };
+  return { ...appProps };
 };
 
 Commons.propTypes = {

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -2,12 +2,13 @@
 import 'core-js/stable';
 import 'regenerator-runtime/runtime';
 /* eslint-enable */
+
 import { useEffect } from 'react';
 import Amplify from 'aws-amplify';
 import { ApolloProvider } from '@apollo/client';
 import App from 'next/app';
 import isEmpty from 'lodash/isEmpty';
-import propTypes from 'prop-types';
+import PropTypes from 'prop-types';
 
 import Page from 'components/Page';
 
@@ -68,14 +69,13 @@ Commons.getInitialProps = async appContext => {
 };
 
 Commons.propTypes = {
-  apollo: propTypes.object,
-  Component: propTypes.oneOfType( [
-    propTypes.func,
-    propTypes.object,
+  apollo: PropTypes.object,
+  Component: PropTypes.oneOfType( [
+    PropTypes.func,
+    PropTypes.object,
   ] ),
-  pageProps: propTypes.object,
-  router: propTypes.object,
-  user: propTypes.object,
+  pageProps: PropTypes.object,
+  router: PropTypes.object,
 };
 
 export default withApollo( storeWrapper.withRedux( Commons ) );

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -11,7 +11,7 @@ import propTypes from 'prop-types';
 
 import Page from 'components/Page';
 
-import { AuthProvider, canAccessPage } from 'context/authContext';
+import { AuthProvider, canAccessPage, fetchUser } from 'context/authContext';
 import awsconfig from '../aws-exports';
 import storeWrapper from 'lib/redux/store';
 import withApollo from 'hocs/withApollo';
@@ -23,7 +23,7 @@ Amplify.configure( {
   ssr: true,
 } );
 
-const Commons = ( { apollo, Component, pageProps, router } ) => {
+const Commons = ( { apollo, Component, pageProps, router, user } ) => {
   const { redirect } = pageProps;
 
   useEffect( () => {
@@ -36,7 +36,7 @@ const Commons = ( { apollo, Component, pageProps, router } ) => {
     <ApolloProvider client={ apollo }>
       <AuthProvider>
         <Page redirect={ pageProps.redirect }>
-          <Component { ...pageProps } />
+          <Component { ...pageProps } user={ user } />
         </Page>
       </AuthProvider>
     </ApolloProvider>
@@ -64,7 +64,9 @@ Commons.getInitialProps = async appContext => {
     appProps.pageProps.query = ctx.query;
   }
 
-  return { ...appProps };
+  const user = await fetchUser( ctx );
+
+  return { ...appProps, user };
 };
 
 Commons.propTypes = {
@@ -75,6 +77,7 @@ Commons.propTypes = {
   ] ),
   pageProps: propTypes.object,
   router: propTypes.object,
+  user: propTypes.object,
 };
 
 export default withApollo( storeWrapper.withRedux( Commons ) );

--- a/pages/package/playbook/[id].js
+++ b/pages/package/playbook/[id].js
@@ -27,14 +27,14 @@ const getPlaybook = async ( id, user ) => {
     };
   }
 
-  return { item: {} };
+  return { item: null };
 };
 
 const PlaybookPage = ( { query, user } ) => {
   const id = query?.id;
 
   const [loading, setLoading] = useState( true );
-  const [item, setItem] = useState( {} );
+  const [item, setItem] = useState( null );
 
   useEffect( () => {
     const fetchData = async ( i, u ) => {

--- a/pages/package/playbook/[id].js
+++ b/pages/package/playbook/[id].js
@@ -53,7 +53,7 @@ const PlaybookPage = ( { id, playbook } ) => {
         <Loader
           active
           inline="centered"
-          style={ { marginBottom: '1em' } }
+          style={ { margin: '6em 0 1em' } }
           content="Loading Playbook preview..."
         />
       </div>

--- a/pages/package/playbook/[id].js
+++ b/pages/package/playbook/[id].js
@@ -7,6 +7,7 @@ import Playbook from 'components/Playbook/Playbook';
 
 import { getDataFromHits, normalizeItem } from 'lib/elastic/parser';
 import { getItemByIdRequest } from 'lib/elastic/api';
+import { useAuth } from 'context/authContext';
 
 /**
  * Queries the public API for a given playbook.
@@ -30,8 +31,9 @@ const getPlaybook = async ( id, user ) => {
   return { item: null };
 };
 
-const PlaybookPage = ( { query, user } ) => {
+const PlaybookPage = ( { query } ) => {
   const id = query?.id;
+  const { user } = useAuth();
 
   const [loading, setLoading] = useState( true );
   const [item, setItem] = useState( null );
@@ -73,7 +75,6 @@ PlaybookPage.propTypes = {
   query: PropTypes.shape( {
     id: PropTypes.string,
   } ),
-  user: PropTypes.object,
 };
 
 export default PlaybookPage;


### PR DESCRIPTION
Removes `getServerSideProps` from the page entirely since the query depends on the current user object, which is only available on the client side.

Incidental updates:

- Fetch the current user in the `_app` component's `getInitialProps` and pass it as a prop to the child component.
- Use the filename rather than id for the additional resources list key since the support file id is not available on the ES query response.
- Replace instances of `Content Cloud` with `Content Commons`.