### PR TITLE
CDP-2442: Removing all content from the text editor does not trigger autosave

### DIFF
--- a/components/admin/PlaybookEdit/PlaybookEdit.js
+++ b/components/admin/PlaybookEdit/PlaybookEdit.js
@@ -226,6 +226,7 @@ const PlaybookEdit = ( { id: playbookId } ) => {
         query={ PLAYBOOK_QUERY }
         type={ playbook.type }
         updateMutation={ updatePlaybook }
+        updateNotification={ updateNotification }
       />
 
       <PlaybookResources

--- a/components/admin/TextEditor/TextEditor.js
+++ b/components/admin/TextEditor/TextEditor.js
@@ -23,9 +23,7 @@ const TextEditor = ( { id, content, query, type, updateMutation } ) => {
     autosave: {
       waitingTime: 500,
       save: async editor => {
-        const isInitializing = editor.getData() === content?.html;
-
-        if ( !editor.getData() || isInitializing ) return;
+        if ( editor.getData() === content?.html ) return;
 
         try {
           await updateMutation( {

--- a/components/admin/TextEditor/TextEditor.test.js
+++ b/components/admin/TextEditor/TextEditor.test.js
@@ -24,6 +24,7 @@ describe( '<TextEditor />', () => {
     },
     type: 'PLAYBOOK',
     updateMutation: jest.fn(),
+    updateNotification: jest.fn(),
   };
 
   beforeEach( () => {


### PR DESCRIPTION
This PR fixes two `TextEditor` autosave bugs and adds handling for the green "Changes saved" message.

### Removing all content not saving bug
Previously, removing all content from the text editor would not trigger autosave. This was happening because `!editor.getData()` was a condition in the autosave early return. Removing that condition fixed this bug.

### Same content not saving bug
However, in the process of fixing this bug, I discovered that autosave would not be triggered if a user removes some content from the text editor and then adds back the *same* content in the same location. (I'd described this bug briefly during one of the stand ups.) This was happening because of a fix in PR #311, which added `editor.getData() === content?.html` as a condition in the autosave early return. When the text editor is instantiated, it holds on to the value of `content.html` that is initially set. As a result, autosave wasn't triggered when the text editor data is equal to the initial value of `content.html` that's held in the text editor instance. I resolved this bug by removing the CKEditor autosave from the config and replacing it with a custom save using `useEffect` and an `initializing` flag.

### Changes saved notification
I also added `updateNotification` to the `TextEditor` to display the "Changes saved" message at the top of the page.