### PR TITLE
Addresses several bug tickets

### DIFF
--- a/components/Results/ResultsHeader/ResultsHeader.js
+++ b/components/Results/ResultsHeader/ResultsHeader.js
@@ -87,7 +87,7 @@ const ResultsHeader = ( {
             ) }
           </div>
         </div>
-        <ResultsToggleView toggle={ toggleView } currentView={ currentView } />
+        { /* <ResultsToggleView toggle={ toggleView } currentView={ currentView } /> */ }
       </div>
 
       <div className={ styles.perPage }>

--- a/components/Results/ResultsHeader/ResultsHeader.js
+++ b/components/Results/ResultsHeader/ResultsHeader.js
@@ -70,7 +70,7 @@ const ResultsHeader = ( {
     <div>
       <div className={ styles.controls }>
         <div className={ styles.sortResults }>
-          <div className={ styles.fields }>
+          <div className={ `${styles.fields} ${viewingAllPkgs ? styles['no-border'] : ''}` }>
             { !viewingAllPkgs && (
               <Fragment>
                 <span aria-hidden="true">Sort by</span>

--- a/components/Results/ResultsHeader/ResultsHeader.module.scss
+++ b/components/Results/ResultsHeader/ResultsHeader.module.scss
@@ -15,6 +15,7 @@
   font-size: inherit;
 }
 
+
 .fields {
   position: relative;
   display: flex;
@@ -22,7 +23,7 @@
   border: 1px solid $blue;
   border-radius: 0.28571429rem;
   margin: 0;
-  padding: 0 0.25rem;
+  padding: 0 0.25rem; 
 
   :first-child {
     margin-right: 0.125rem;
@@ -31,6 +32,10 @@
   &:focus-within {
     @include focus-styling($kbd_only: false);
   }
+}
+
+.no-border {
+  border: transparent;
 }
 
 .sortDropdown {

--- a/components/Results/ResultsHeader/ResultsHeader.module.scss
+++ b/components/Results/ResultsHeader/ResultsHeader.module.scss
@@ -11,7 +11,7 @@
 }
 
 .sortResults {
-  margin: 0 1rem 0 0;
+  // margin: 0 1rem 0 0;
   font-size: inherit;
 }
 

--- a/components/Results/ResultsHeader/ResultsHeader.test.js
+++ b/components/Results/ResultsHeader/ResultsHeader.test.js
@@ -54,7 +54,7 @@ describe( '<ResultsHeader />', () => {
     expect( dropdown.exists() ).toEqual( true );
   } );
 
-  it( 'renders ResultsToggleView', () => {
+  it.skip( 'renders ResultsToggleView', () => {
     const toggleView = resultsHeader.find( 'ResultsToggleView' );
 
     expect( toggleView.exists() ).toEqual( true );

--- a/lib/elastic/api.js
+++ b/lib/elastic/api.js
@@ -115,7 +115,11 @@ export const sourceAggRequest = () => axios
  * Get all post types that have associated content
  */
 export const postTypeAggRequest = user => {
-  const options = user ? {} : { exclude: ['document', 'package'] };
+  const options = ( user && user.id !== 'public' )
+    ? {}
+    : { exclude: [
+      'document', 'package', 'playbook',
+    ] };
 
   return axios
     .post( SEARCH, {

--- a/lib/redux/actions/postType.js
+++ b/lib/redux/actions/postType.js
@@ -5,6 +5,7 @@ import {
   LOAD_POST_TYPES_FAILED,
   LOAD_POST_TYPES_SUCCESS,
 } from '../constants';
+import sortBy from 'lodash/sortBy';
 
 export const loadPostTypes = user => async dispatch => {
   dispatch( { type: LOAD_POST_TYPES_PENDING } );
@@ -32,9 +33,10 @@ export const loadPostTypes = user => async dispatch => {
       };
     } );
 
+
     return dispatch( {
       type: LOAD_POST_TYPES_SUCCESS,
-      payload,
+      payload: sortBy( payload, ['display_name'] ),
     } );
   }
 };


### PR DESCRIPTION
This PR addresses the following items/tickets:

- CDP 2449 - Alphabetizes the items in the format filter menu
- CDP 2446 - Hides the toggle list/gallery display on the results screen
- CDP 2448 - Removes the border on the sort by dropdown on the results screen so the '-' is hidden when Guidance Packages are viewed (this would happen when the Guidance Packages 'Browse All' link was clicked on the anding page)
- CDP 2459 - Removes the Playbook and Press Guidance checkboxes from the Format filter menu on the results screen when a user is not logged in