### PR TITLE
CDP-2452: Remove extra white space at the bottom of playbook pages

### DIFF
--- a/components/Playbook/Playbook.js
+++ b/components/Playbook/Playbook.js
@@ -16,6 +16,14 @@ import styles from './Playbook.module.scss';
 
 const desc = 'This Playbook is for use by U.S. diplomatic missions and senior State Department officials.\nPlease treat this document as you would Daily Press Guidance.';
 
+const needsDarkText = [
+  '#94bfa2',
+  '#fff1d2',
+  '#a3e4e8',
+  '#f9c642',
+  '#fff1d2',
+];
+
 const Playbook = ( { item } ) => {
   const router = useRouter();
   const isAdminPreview = router.asPath.startsWith( '/admin' );
@@ -64,7 +72,12 @@ const Playbook = ( { item } ) => {
         <div className={ styles['policy-container'] }>
           <span
             className={ styles.policy }
-            style={ { backgroundColor: item.policy?.theme } }
+            style={ {
+              backgroundColor: item.policy?.theme,
+              color: needsDarkText.includes( item.policy?.theme )
+                ? '#112e51'
+                : 'white',
+            } }
           >
             { item.policy?.name }
           </span>

--- a/components/Playbook/Playbook.js
+++ b/components/Playbook/Playbook.js
@@ -73,13 +73,13 @@ const Playbook = ( { item } ) => {
           <span
             className={ styles.policy }
             style={ {
-              backgroundColor: item.policy?.theme,
-              color: needsDarkText.includes( item.policy?.theme )
+              backgroundColor: item?.theme,
+              color: needsDarkText.includes( item?.theme )
                 ? '#112e51'
                 : 'white',
             } }
           >
-            { item.policy?.name }
+            { item.policy }
           </span>
         </div>
       ) }

--- a/components/Playbook/Playbook.module.scss
+++ b/components/Playbook/Playbook.module.scss
@@ -19,6 +19,17 @@
 .container {
   background-color: $blue;
   padding-top: 5rem;
+
+  margin-bottom: -250px;
+  @media screen and (min-width: 560px) {
+    margin-bottom: -266px;
+  }
+  @media screen and (min-width: 736px) {
+    margin-bottom: -283px;
+  }
+  @media screen and (min-width: 768px) {
+    margin-bottom: -190px;
+  }
 }
 
 .preview {
@@ -26,15 +37,15 @@
   align-items: center;
   justify-content: center;
   gap: 0.25rem;
-  margin-top: -2.2rem !important;
+  margin-top: -2.2rem;
   @media screen and (min-width: 993px) {
-    margin-top: -1.1rem !important;
+    margin-top: -1.1rem;
   }
   margin-bottom: 0;
   padding: 0.5rem 1.5rem;
   background-color: $gold;
   color: $blue;
-  font-size: 0.888888889rem;
+  font-size: 0.8889rem;
   font-style: italic;
 }
 

--- a/components/Playbook/Playbook.module.scss
+++ b/components/Playbook/Playbook.module.scss
@@ -111,9 +111,10 @@
 }
 
 .policy {
-  color: white;
   margin: 0 auto;
   padding: 0.3rem 1rem;
+  font-size: 1.1111rem;
+  font-weight: bold;
   text-transform: uppercase;
   letter-spacing: 3px;
   transform: translateY(1rem);

--- a/components/Playbook/Playbook.test.js
+++ b/components/Playbook/Playbook.test.js
@@ -34,4 +34,31 @@ describe( '<Playbook />', () => {
 
     expect( resources.children() ).toHaveLength( mockItem.supportFiles.length );
   } );
+
+  it( 'has a policy badge', () => {
+    const policyBadge = wrapper.find( '.policy-container' );
+
+    expect( policyBadge.exists() ).toEqual( true );
+    expect( policyBadge.contains( mockItem.policy ) ).toEqual( true );
+  } );
+} );
+
+describe( '<Playbook /> without policy', () => {
+  const noPolicyMocks = {
+    ...mockItem,
+    policy: undefined,
+    theme: undefined,
+  };
+
+  const wrapper = mount( <Playbook item={ noPolicyMocks } /> );
+
+  it( 'renders without crashing', () => {
+    expect( wrapper.exists() ).toEqual( true );
+  } );
+
+  it( 'does not contain a policy badge', () => {
+    const policyBadge = wrapper.find( '.policy-container' );
+
+    expect( policyBadge.exists() ).toEqual( false );
+  } );
 } );

--- a/components/Playbook/PlaybookCard/PlaybookCard.module.scss
+++ b/components/Playbook/PlaybookCard/PlaybookCard.module.scss
@@ -14,6 +14,7 @@
   position: relative;
   display: flex;
   flex-direction: column;
+  width: 100%;
   background-color: var(--secondary-color);
   box-shadow: 0px 1px 3px 0px #d4d4d5, 0px 0px 0px 1px #d4d4d5;
 

--- a/components/Playbook/mocks.js
+++ b/components/Playbook/mocks.js
@@ -117,11 +117,8 @@ export const mockItem = {
   },
   // status: PublishStatus @default(value: DRAFT),
   // visibility: Visibility @default(value: INTERNAL),
-  policy: {
-    id: '5678',
-    name: 'COVID-19 Recovery',
-    theme: '#dd7533',
-  },
+  policy: 'COVID-19 Recovery',
+  theme: '#dd7533',
   categories: [],
   tags: [],
   supportFiles: [


### PR DESCRIPTION
This PR includes the following changes:

* Addresses the extra white space at the bottom of playbook pages. The extra white space is coming from `560px` of `padding-bottom` on `main`. Since the `main` padding affects the entire site, my solution is temporary until that extra `padding` can be refactored off `main`. I suspect the extra `padding` is related to the sticky `footer`, which could also be handled in a more modern approach with `flexbox`. Regardless, I created a separate ticket, [CDP-2468](https://design.atlassian.net/browse/CDP-2468), for refactoring and handling this in a better way more time is available.

*  Increases the policy badge text size and weight on the playbook page to make it more readable. In addition, policy badges with a theme color that don't meet AA contrast requirements with white text will now be styled with dark blue text. Currently, this applies to Climate Crisis and Human Rights, so these two policies should display with dark blue text.

* Adds a `width` declaration to `PlaybookCard` so that cards with a very short description can occupy the full width of their container on the results page, which is laying out the grid with `flexbox`. This addresses CDP-2464.


