### PR TITLE
CDP-2460: Enable publish changes button when a support file is removed

### DIFF
--- a/components/admin/PlaybookEdit/PlaybookResources/PlaybookResources.js
+++ b/components/admin/PlaybookEdit/PlaybookResources/PlaybookResources.js
@@ -106,6 +106,7 @@ const PlaybookResources = ( { assetPath, files, projectId, updateMutation } ) =>
         supportFiles: {
           'delete': { id },
         },
+        type: 'PLAYBOOK', // This property is included to ensure that the updatedAt date on the playbook is updated
       },
       where: { id: projectId },
     },

--- a/components/admin/ProjectEdit/GraphicEdit/SupportFiles/SupportFiles.js
+++ b/components/admin/ProjectEdit/GraphicEdit/SupportFiles/SupportFiles.js
@@ -1,33 +1,31 @@
-import React from 'react';
+import { Fragment } from 'react';
 import PropTypes from 'prop-types';
+
 import GraphicSupportFiles from 'components/admin/ProjectEdit/GraphicEdit/GraphicSupportFiles/GraphicSupportFiles';
+
 import './SupportFiles.scss';
 
-const SupportFiles = props => {
-  const { projectId, updateNotification, fileTypes } = props;
+const SupportFiles = ( { projectId, updateNotification, fileTypes } ) => (
+  <div className="support-files-container">
+    { fileTypes.map( ( fileType, i ) => {
+      const { files, headline, helperText } = fileType;
 
-  return (
-    <div className="support-files-container">
-      { fileTypes.map( ( fileType, i ) => {
-        const { files, headline, helperText } = fileType;
+      return (
+        <Fragment key={ `${projectId}-${headline}` }>
+          <GraphicSupportFiles
+            projectId={ projectId }
+            headline={ headline }
+            helperText={ helperText }
+            files={ files }
+            updateNotification={ updateNotification }
+          />
 
-        return (
-          <React.Fragment key={ `${projectId}-${headline}` }>
-            <GraphicSupportFiles
-              projectId={ projectId }
-              headline={ headline }
-              helperText={ helperText }
-              files={ files }
-              updateNotification={ updateNotification }
-            />
-
-            { i !== fileTypes.length - 1 && <div className="separator" /> }
-          </React.Fragment>
-        );
-      } ) }
-    </div>
-  );
-};
+          { i !== fileTypes.length - 1 && <div className="separator" /> }
+        </Fragment>
+      );
+    } ) }
+  </div>
+);
 
 SupportFiles.propTypes = {
   projectId: PropTypes.string,


### PR DESCRIPTION
Adds the type property to the update playbook mutation when removing support files. This ensures that the playbook `updateAt` date is updated thereby toggling `isDirty`.

Also simplifies the `GraphicEdit/SupportFiles` component. There are no substantive changes to that component, just makes it a bit more compact. 