### PR TITLE
CDP-2431: Updated all labels and timestamps on the Preview and Frontend

### DIFF
--- a/components/Playbook/Playbook.controller.js
+++ b/components/Playbook/Playbook.controller.js
@@ -1,0 +1,34 @@
+/* ---- Policy priority badge helpers. ---- */
+
+/**
+ * Check a color value against a list that require dark text for proper contrast.
+ * @param {string} color A hex value for the background color.
+ * @returns {bool} Whether or not the provided background color requires dark foreground text.
+ */
+const needsDarkText = color => {
+  // List of valid background colors that require a dark foreground color.
+  const lightBackgrounds = [
+    '#94bfa2',
+    '#fff1d2',
+    '#a3e4e8',
+    '#f9c642',
+    '#fff1d2',
+  ];
+
+  return lightBackgrounds.includes( color );
+};
+
+/**
+ * Returns the color scheme for a policy priority badge depending on it's theme value.
+ * @param {string} theme The theme value for a given policy priority, expected to be a hex string.
+ * @returns {Object} The style object with relevant backgroundColor and color properties.
+ */
+export const getBadgeStyle = theme => {
+  const blue = '#112e51';
+  const lightBlue = '#0071bc';
+
+  return ( {
+    backgroundColor: theme || lightBlue,
+    color: needsDarkText( theme ) ? blue : 'white',
+  } );
+};

--- a/components/Playbook/Playbook.controller.js
+++ b/components/Playbook/Playbook.controller.js
@@ -32,3 +32,38 @@ export const getBadgeStyle = theme => {
     color: needsDarkText( theme ) ? blue : 'white',
   } );
 };
+
+/* ---- Date and time argument helpers. ---- */
+
+/**
+ * Generates the options needed to get a properly formatted date and/or time.
+ * @param {string} dateString An ISO 8601 date string.
+ * @returns {Object} The arguments needed to get a formatted date or time in Eastern time.
+ */
+export const getDateTimeArgs = dateString => {
+  const dateArgs = {
+    dateString,
+    options: {
+      month: 'long',
+      day: 'numeric',
+      year: 'numeric',
+      timeZone: 'America/New_York',
+    },
+  };
+
+  const timeArgs = {
+    ...dateArgs,
+    options: {
+      hour12: true,
+      hour: 'numeric',
+      minute: 'numeric',
+      timeZone: 'America/New_York',
+    },
+    timeStringOnly: true,
+  };
+
+  return {
+    dateArgs,
+    timeArgs,
+  };
+};

--- a/components/Playbook/Playbook.js
+++ b/components/Playbook/Playbook.js
@@ -8,6 +8,7 @@ import Share from 'components/Share/Share';
 import TexturedSection from 'components/TexturedSection/TexturedSection';
 
 import { formatBytes, formatDateTime, maybeGetUrlToProdS3 } from 'lib/utils';
+import { getBadgeStyle } from './Playbook.controller';
 import useInitialStatus from 'lib/hooks/useInitialStatus';
 import cautionIcon from 'static/icons/icon_caution.svg';
 import shareIconWhite from 'static/icons/icon_share_white.svg';
@@ -15,14 +16,6 @@ import shareIconWhite from 'static/icons/icon_share_white.svg';
 import styles from './Playbook.module.scss';
 
 const desc = 'This Playbook is for use by U.S. diplomatic missions and senior State Department officials.\nPlease treat this document as you would Daily Press Guidance.';
-
-const needsDarkText = [
-  '#94bfa2',
-  '#fff1d2',
-  '#a3e4e8',
-  '#f9c642',
-  '#fff1d2',
-];
 
 const Playbook = ( { item } ) => {
   const router = useRouter();
@@ -116,12 +109,7 @@ const Playbook = ( { item } ) => {
         <div className={ styles['policy-container'] }>
           <span
             className={ styles.policy }
-            style={ {
-              backgroundColor: item?.policy?.theme || '#0071bc',
-              color: needsDarkText.includes( item?.policy?.theme )
-                ? '#112e51'
-                : 'white',
-            } }
+            style={ getBadgeStyle( item?.policy?.theme ) }
           >
             { item.policy.name }
           </span>

--- a/components/Playbook/Playbook.js
+++ b/components/Playbook/Playbook.js
@@ -8,7 +8,7 @@ import Share from 'components/Share/Share';
 import TexturedSection from 'components/TexturedSection/TexturedSection';
 
 import { formatBytes, formatDateTime, maybeGetUrlToProdS3 } from 'lib/utils';
-import { getBadgeStyle } from './Playbook.controller';
+import { getBadgeStyle, getDateTimeArgs } from './Playbook.controller';
 import useInitialStatus from 'lib/hooks/useInitialStatus';
 import cautionIcon from 'static/icons/icon_caution.svg';
 import shareIconWhite from 'static/icons/icon_share_white.svg';
@@ -29,26 +29,8 @@ const Playbook = ( { item } ) => {
 
   const { isNeverPublished, isInitialPublish, isSavedUpdate } = useInitialStatus( dates );
 
-  const dateArgs = {
-    dateString: isInitialPublish ? dates.published : dates.updated,
-    options: {
-      month: 'long',
-      day: 'numeric',
-      year: 'numeric',
-      timeZone: 'America/New_York',
-    },
-  };
-
-  const timeArgs = {
-    ...dateArgs,
-    options: {
-      hour12: true,
-      hour: 'numeric',
-      minute: 'numeric',
-      timeZone: 'America/New_York',
-    },
-    timeStringOnly: true,
-  };
+  const dateString = isInitialPublish ? dates.published : dates.updated;
+  const { dateArgs, timeArgs } = getDateTimeArgs( dateString );
 
   // If the item has never been published or is the initial published version, show "Published".
   // If previewing and item with unpublished changes to the initial publish show "Updated".
@@ -77,7 +59,7 @@ const Playbook = ( { item } ) => {
             { isNeverPublished
               ? '(date will appear here)'
               : (
-                <time dateTime={ dateArgs.dateString }>
+                <time dateTime={ dateString }>
                   { `${formatDateTime( dateArgs )} at ${formatDateTime( timeArgs )} (Washington, DC)` }
                 </time>
               ) }

--- a/components/Playbook/Playbook.js
+++ b/components/Playbook/Playbook.js
@@ -8,6 +8,7 @@ import Share from 'components/Share/Share';
 import TexturedSection from 'components/TexturedSection/TexturedSection';
 
 import { formatBytes, formatDateTime, maybeGetUrlToProdS3 } from 'lib/utils';
+import useInitialStatus from 'lib/hooks/useInitialStatus';
 import cautionIcon from 'static/icons/icon_caution.svg';
 import shareIconWhite from 'static/icons/icon_share_white.svg';
 
@@ -26,8 +27,17 @@ const needsDarkText = [
 const Playbook = ( { item } ) => {
   const router = useRouter();
   const isAdminPreview = router.asPath.startsWith( '/admin' );
+  const updated = item?.modified || item?.updatedAt;
+  const published = item?.published || item?.publishedAt;
+  const { isInitialCreation, isInitialPublish } = useInitialStatus( {
+    created: item?.created || item?.createdAt,
+    updated,
+    published,
+    initialPublished: item?.initialPublished || item?.initialPublishedAt,
+  } );
+
   const dateArgs = {
-    dateString: item.updatedAt,
+    dateString: isInitialPublish ? published : updated,
     options: {
       month: 'long',
       day: 'numeric',
@@ -62,12 +72,18 @@ const Playbook = ( { item } ) => {
           </button>
         </div>
         <h1 className={ styles.title }>{ item?.title }</h1>
-        { item?.updatedAt && (
+        { updated && (
           <p>
-            Updated:
-            <time dateTime={ item.updatedAt }>
-              { ` ${formatDateTime( dateArgs )} at ${formatDateTime( timeArgs )} (Washington, DC)` }
-            </time>
+            { ( isInitialCreation || isInitialPublish )
+              ? 'Published: '
+              : 'Updated: ' }
+            { isInitialCreation
+              ? '(date will appear here)'
+              : (
+                <time dateTime={ dateArgs.dateString }>
+                  { `${formatDateTime( dateArgs )} at ${formatDateTime( timeArgs )} (Washington, DC)` }
+                </time>
+              ) }
           </p>
         ) }
         <div className={ styles['header-contents'] }>

--- a/components/Playbook/Playbook.js
+++ b/components/Playbook/Playbook.js
@@ -1,4 +1,3 @@
-import moment from 'moment';
 import propTypes from 'prop-types';
 import { useRouter } from 'next/router';
 import DOMPurify from 'isomorphic-dompurify';
@@ -8,7 +7,7 @@ import Popover from 'components/popups/Popover/Popover';
 import Share from 'components/Share/Share';
 import TexturedSection from 'components/TexturedSection/TexturedSection';
 
-import { formatBytes, maybeGetUrlToProdS3 } from 'lib/utils';
+import { formatBytes, formatDateTime, maybeGetUrlToProdS3 } from 'lib/utils';
 import cautionIcon from 'static/icons/icon_caution.svg';
 import shareIconWhite from 'static/icons/icon_share_white.svg';
 
@@ -27,6 +26,26 @@ const needsDarkText = [
 const Playbook = ( { item } ) => {
   const router = useRouter();
   const isAdminPreview = router.asPath.startsWith( '/admin' );
+  const dateArgs = {
+    dateString: item.updatedAt,
+    options: {
+      month: 'long',
+      day: 'numeric',
+      year: 'numeric',
+      timeZone: 'America/New_York',
+    },
+  };
+
+  const timeArgs = {
+    ...dateArgs,
+    options: {
+      hour12: true,
+      hour: 'numeric',
+      minute: 'numeric',
+      timeZone: 'America/New_York',
+    },
+    timeStringOnly: true,
+  };
 
   return (
     <div className={ styles.container }>
@@ -44,7 +63,12 @@ const Playbook = ( { item } ) => {
         </div>
         <h1 className={ styles.title }>{ item?.title }</h1>
         { item?.updatedAt && (
-          <p>{ `Updated: ${moment( item.updatedAt ).format( 'MMMM DD, YYYY \\a\\t hh:mm A' )}` }</p>
+          <p>
+            Updated:
+            <time dateTime={ item.updatedAt }>
+              { ` ${formatDateTime( dateArgs )} at ${formatDateTime( timeArgs )} (Washington, DC)` }
+            </time>
+          </p>
         ) }
         <div className={ styles['header-contents'] }>
           <Popover

--- a/components/Playbook/Playbook.js
+++ b/components/Playbook/Playbook.js
@@ -27,17 +27,17 @@ const needsDarkText = [
 const Playbook = ( { item } ) => {
   const router = useRouter();
   const isAdminPreview = router.asPath.startsWith( '/admin' );
-  const updated = item?.modified || item?.updatedAt;
-  const published = item?.published || item?.publishedAt;
-  const { isInitialCreation, isInitialPublish } = useInitialStatus( {
-    created: item?.created || item?.createdAt,
-    updated,
-    published,
+
+  const dates = {
+    updated: item?.modified || item?.updatedAt,
+    published: item?.published || item?.publishedAt,
     initialPublished: item?.initialPublished || item?.initialPublishedAt,
-  } );
+  };
+
+  const { isNeverPublished, isInitialPublish, isSavedUpdate } = useInitialStatus( dates );
 
   const dateArgs = {
-    dateString: isInitialPublish ? published : updated,
+    dateString: isInitialPublish ? dates.published : dates.updated,
     options: {
       month: 'long',
       day: 'numeric',
@@ -57,6 +57,12 @@ const Playbook = ( { item } ) => {
     timeStringOnly: true,
   };
 
+  // If the item has never been published or is the initial published version, show "Published".
+  // If previewing and item with unpublished changes to the initial publish show "Updated".
+  const showPublished = isAdminPreview
+    ? isNeverPublished || ( isInitialPublish && !isSavedUpdate )
+    : isNeverPublished || isInitialPublish;
+
   return (
     <div className={ styles.container }>
       { isAdminPreview && (
@@ -72,12 +78,10 @@ const Playbook = ( { item } ) => {
           </button>
         </div>
         <h1 className={ styles.title }>{ item?.title }</h1>
-        { updated && (
+        { dates.updated && (
           <p>
-            { ( isInitialCreation || isInitialPublish )
-              ? 'Published: '
-              : 'Updated: ' }
-            { isInitialCreation
+            { showPublished ? 'Published: ' : 'Updated: ' }
+            { isNeverPublished
               ? '(date will appear here)'
               : (
                 <time dateTime={ dateArgs.dateString }>

--- a/components/Playbook/Playbook.test.js
+++ b/components/Playbook/Playbook.test.js
@@ -17,12 +17,24 @@ jest.mock( 'next/router', () => ( {
   } ) ),
 } ) );
 
-jest.mock( 'components/download/DownloadItem/DownloadItemContent', () => 'download-item-content' );
-jest.mock( 'components/Share/Share', () => 'share' );
-jest.mock( 'components/popups/Popover/Popover', () => 'popover' );
-jest.mock( 'components/TexturedSection/TexturedSection', () => 'textured-section' );
+jest.mock(
+  'components/download/DownloadItem/DownloadItemContent',
+  () => function DownloadItemContent() { return ''; },
+);
+jest.mock(
+  'components/Share/Share',
+  () => function Share() { return ''; },
+);
+jest.mock(
+  'components/popups/Popover/Popover',
+  () => function Popover() { return ''; },
+);
+jest.mock(
+  'components/TexturedSection/TexturedSection',
+  () => function TexturedSection() { return ''; },
+);
 
-describe( '<Playbook />', () => {
+describe( '<Playbook />, when published with updates (GraphQL)', () => {
   const wrapper = mount( <Playbook item={ mockItem } /> );
 
   it( 'renders without crashing', () => {
@@ -35,11 +47,158 @@ describe( '<Playbook />', () => {
     expect( resources.children() ).toHaveLength( mockItem.supportFiles.length );
   } );
 
-  it( 'has a policy badge', () => {
-    const policyBadge = wrapper.find( '.policy-container' );
+  it( 'renders the correct date and time label', () => {
+    const dateTime = wrapper.find( '.title + p' );
 
-    expect( policyBadge.exists() ).toEqual( true );
-    expect( policyBadge.contains( mockItem.policy ) ).toEqual( true );
+    expect( dateTime.contains( 'Updated: ' ) ).toEqual( true );
+  } );
+
+  it( 'renders the correct date and time', () => {
+    const time = wrapper.find( '.title + p > time' );
+
+    expect( time.contains( 'May 28, 2021 at 7:12 AM (Washington, DC)' ) )
+      .toEqual( true );
+    expect( time.prop( 'dateTime' ) ).toEqual( mockItem.updatedAt );
+  } );
+} );
+
+describe( '<Playbook />, when published with updates (Elasticsearch)', () => {
+  const item = {
+    ...mockItem,
+    created: '2021-05-26T11:12:34.140Z',
+    modified: '2021-05-28T11:12:34.740Z',
+    published: '2021-05-28T11:12:34.140Z',
+    initialPublished: '2021-05-27T08:18:44.410Z',
+  };
+
+  delete item.createdAt;
+  delete item.updatedAt;
+  delete item.publishedAt;
+  delete item.initialPublishedAt;
+
+  const wrapper = mount( <Playbook item={ item } /> );
+
+  it( 'renders the correct date and time label', () => {
+    const dateTime = wrapper.find( '.title + p' );
+
+    expect( dateTime.contains( 'Updated: ' ) ).toEqual( true );
+  } );
+
+  it( 'renders the correct date and time', () => {
+    const time = wrapper.find( '.title + p > time' );
+
+    expect( time.contains( 'May 28, 2021 at 7:12 AM (Washington, DC)' ) )
+      .toEqual( true );
+    expect( time.prop( 'dateTime' ) ).toEqual( item.modified );
+  } );
+} );
+
+describe( '<Playbook />, when DRAFT and updated (GraphQL)', () => {
+  const item = {
+    ...mockItem,
+    createdAt: '2021-05-26T11:12:34.140Z',
+    updatedAt: '2021-05-28T18:42:34.520Z',
+    publishedAt: null,
+    initialPublishedAt: '2021-05-28T11:12:34.230Z',
+  };
+
+  const wrapper = mount( <Playbook item={ item } /> );
+
+  it( 'renders the correct date and time label', () => {
+    const dateTime = wrapper.find( '.title + p' );
+
+    expect( dateTime.contains( 'Updated: ' ) ).toEqual( true );
+  } );
+
+  it( 'renders the correct date and time', () => {
+    const time = wrapper.find( '.title + p > time' );
+
+    expect( time.contains( 'May 28, 2021 at 2:42 PM (Washington, DC)' ) )
+      .toEqual( true );
+    expect( time.prop( 'dateTime' ) ).toEqual( item.updatedAt );
+  } );
+} );
+
+describe( '<Playbook />, when initially created (GraphQL)', () => {
+  const item = {
+    ...mockItem,
+    createdAt: '2021-05-28T11:12:34.140Z',
+    updatedAt: '2021-05-28T11:12:34.740Z',
+    publishedAt: null,
+    initialPublishedAt: null,
+  };
+
+  const wrapper = mount( <Playbook item={ item } /> );
+
+  it( 'renders the correct date and time', () => {
+    const dateTime = wrapper.find( '.title + p' );
+
+    expect( dateTime.contains( 'Published: ' ) ).toEqual( true );
+    expect( dateTime.contains( '(date will appear here)' ) )
+      .toEqual( true );
+  } );
+
+  it( 'does not render the date and time', () => {
+    const time = wrapper.find( '.title + p > time' );
+
+    expect( time.exists() ).toEqual( false );
+  } );
+} );
+
+describe( '<Playbook />, when initially published (GraphQL)', () => {
+  const item = {
+    ...mockItem,
+    createdAt: '2021-05-26T11:12:34.140Z',
+    updatedAt: '2021-05-28T11:12:34.740Z',
+    publishedAt: '2021-05-28T11:12:34.320Z',
+    initialPublishedAt: '2021-05-28T11:12:34.230Z',
+  };
+
+  const wrapper = mount( <Playbook item={ item } /> );
+
+  it( 'renders the correct date and time label', () => {
+    const dateTime = wrapper.find( '.title + p' );
+
+    expect( dateTime.contains( 'Published: ' ) ).toEqual( true );
+  } );
+
+  it( 'renders the correct date and time', () => {
+    const time = wrapper.find( '.title + p > time' );
+
+    expect( time.contains( 'May 28, 2021 at 7:12 AM (Washington, DC)' ) )
+      .toEqual( true );
+    expect( time.prop( 'dateTime' ) ).toEqual( item.publishedAt );
+  } );
+} );
+
+describe( '<Playbook />, when initially published (Elasticsearch)', () => {
+  const item = {
+    ...mockItem,
+    created: '2021-05-26T11:12:34.140Z',
+    modified: '2021-05-28T11:12:34.740Z',
+    published: '2021-05-28T11:12:34.320Z',
+    initialPublished: '2021-05-28T11:12:34.230Z',
+  };
+
+  delete item.createdAt;
+  delete item.updatedAt;
+  delete item.publishedAt;
+  delete item.initialPublishedAt;
+
+  const wrapper = mount( <Playbook item={ item } /> );
+
+  it( 'renders the correct date and time label', () => {
+    const dateTime = wrapper.find( '.title + p' );
+
+    expect( dateTime.contains( 'Published: ' ) ).toEqual( true );
+  } );
+
+  it( 'renders the correct date and time', () => {
+    const time = wrapper.find( '.title + p > time' );
+
+    expect( time.contains( 'May 28, 2021 at 7:12 AM (Washington, DC)' ) )
+      .toEqual( true );
+    expect( time.prop( 'dateTime' ) ).toEqual( item.published );
   } );
 } );
 

--- a/components/Playbook/PlaybookCard/PlaybookCard.js
+++ b/components/Playbook/PlaybookCard/PlaybookCard.js
@@ -1,9 +1,8 @@
 import PropTypes from 'prop-types';
 import Link from 'next/link';
 import MediaObject from 'components/MediaObject/MediaObject';
-import MetaTerms from 'components/admin/MetaTerms/MetaTerms';
 import DosSeal from 'static/images/dos_seal.svg';
-import { getDateTimeTerms } from 'lib/utils';
+import { formatDateTime } from 'lib/utils';
 
 import styles from './PlaybookCard.module.scss';
 
@@ -14,10 +13,20 @@ const PlaybookCard = ( { cardTheme, heading: Heading, item } ) => {
     title,
     desc,
     modified,
-    published,
+    // published,
     policy,
     owner,
   } = item;
+
+  const dateArgs = {
+    dateString: modified,
+    options: {
+      month: 'long',
+      day: 'numeric',
+      year: 'numeric',
+      timeZone: 'America/New_York',
+    },
+  };
 
   return (
     <article
@@ -33,11 +42,12 @@ const PlaybookCard = ( { cardTheme, heading: Heading, item } ) => {
         </Heading>
         <p className={ styles.type }>{ type }</p>
         <p className={ styles.description }>{ desc }</p>
-        <MetaTerms
-          className={ styles['date-time'] }
-          unitId={ id }
-          terms={ getDateTimeTerms( published, modified, 'MMMM D, YYYY' ) }
-        />
+        <p className={ styles['date-time'] }>
+          Updated:
+          <time dateTime={ modified }>
+            { ` ${formatDateTime( dateArgs )}` }
+          </time>
+        </p>
       </div>
 
       <svg

--- a/components/Playbook/PlaybookCard/PlaybookCard.js
+++ b/components/Playbook/PlaybookCard/PlaybookCard.js
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 import Link from 'next/link';
 import MediaObject from 'components/MediaObject/MediaObject';
 import DosSeal from 'static/images/dos_seal.svg';
+import useInitialStatus from 'lib/hooks/useInitialStatus';
 import { formatDateTime } from 'lib/utils';
 
 import styles from './PlaybookCard.module.scss';
@@ -12,14 +13,23 @@ const PlaybookCard = ( { cardTheme, heading: Heading, item } ) => {
     type,
     title,
     desc,
+    created,
     modified,
-    // published,
+    published,
+    initialPublished,
     policy,
     owner,
   } = item;
 
+  const { isInitialPublish } = useInitialStatus( {
+    created,
+    updated: modified,
+    published,
+    initialPublished,
+  } );
+
   const dateArgs = {
-    dateString: modified,
+    dateString: isInitialPublish ? initialPublished : modified,
     options: {
       month: 'long',
       day: 'numeric',
@@ -43,9 +53,11 @@ const PlaybookCard = ( { cardTheme, heading: Heading, item } ) => {
         <p className={ styles.type }>{ type }</p>
         <p className={ styles.description }>{ desc }</p>
         <p className={ styles['date-time'] }>
-          Updated:
-          <time dateTime={ modified }>
-            { ` ${formatDateTime( dateArgs )}` }
+          { ( isInitialPublish )
+            ? 'Published: '
+            : 'Updated: ' }
+          <time dateTime={ dateArgs.dateString }>
+            { formatDateTime( dateArgs ) }
           </time>
         </p>
       </div>

--- a/components/Playbook/PlaybookCard/PlaybookCard.module.scss
+++ b/components/Playbook/PlaybookCard/PlaybookCard.module.scss
@@ -1,13 +1,6 @@
 @import 'styles/colors.scss';
 @import 'styles/mixins.scss';
 
-// results page list view
-[class*="bar--results"] [class*="list"] {
-  .card {
-    max-width: 18rem;
-  }
-}
-
 .card {
   --light: #fff;
 
@@ -52,7 +45,7 @@
   display: flex;
   flex-direction: column;
   min-height: 250px;
-  padding-bottom: 0.25rem;
+  padding-bottom: 0.5rem;
   background-color: var(--primary-color);
   color: var(--secondary-color);
 }
@@ -113,16 +106,8 @@
 }
 
 .date-time {
+  margin-top: auto;
   font-size: 0.6111rem;
-
-  &[class*="terms"] {
-    margin-top: auto;
-    margin-bottom: 0;
-
-    dt {
-      font-weight: 400;
-    }
-  }
 }
 
 .wave {

--- a/components/Playbook/PlaybookCard/PlaybookCard.test.js
+++ b/components/Playbook/PlaybookCard/PlaybookCard.test.js
@@ -15,31 +15,33 @@ jest.mock(
   () => function MetaTerms() { return ''; },
 );
 
-describe( '<PlaybookCard />', () => {
-  const props = {
-    item: {
-      id: 'ckq6k1tzi0q710720lr0zwtpv',
-      indexId: 'ANUwL3oB-mFYjIfRR7LL',
-      site: 'commons.america.gov',
-      logo: '',
-      sourcelink: 'https://commons.america.gov',
-      type: 'playbook',
-      icon: 'data:image/png;base64,iVBORw0KGgoAAAANS',
-      author: '',
-      owner: 'GPA Global Campaigns Strategy Unit',
-      link: '',
-      published: '2021-06-21T15:28:50.747Z',
-      modified: '2021-06-21T15:28:50.747Z',
-      visibility: 'INTERNAL',
-      title: 'Vivamus sagittis lacus',
-      desc: 'Nullam quis risus eget urna mollis ornare vel eu leo. Cras justo odio, dapibus ac facilisis in, eges',
-      policy: {
-        name: 'Covid-19 Recovery',
-        theme: '#dd7533',
-      },
-      supportFiles: [],
-    },
-  };
+const item = {
+  id: 'ckq6k1tzi0q710720lr0zwtpv',
+  indexId: 'ANUwL3oB-mFYjIfRR7LL',
+  site: 'commons.america.gov',
+  logo: '',
+  sourcelink: 'https://commons.america.gov',
+  type: 'playbook',
+  icon: 'data:image/png;base64,iVBORw0KGgoAAAANS',
+  author: '',
+  owner: 'GPA Global Campaigns Strategy Unit',
+  link: '',
+  created: '2021-06-21T11:50:36.443Z',
+  modified: '2021-07-08T16:13:15.807Z',
+  published: '2021-07-08T16:13:15.807Z',
+  initialPublished: '2021-07-08T16:13:15.807Z',
+  visibility: 'INTERNAL',
+  title: 'Vivamus sagittis lacus',
+  desc: 'Nullam quis risus eget urna mollis ornare vel eu leo. Cras justo odio, dapibus ac facilisis in, eges',
+  policy: {
+    name: 'Covid-19 Recovery',
+    theme: '#dd7533',
+  },
+  supportFiles: [],
+};
+
+describe( '<PlaybookCard />, when initially published', () => {
+  const props = { item };
   let Component;
   let wrapper;
 
@@ -57,5 +59,48 @@ describe( '<PlaybookCard />', () => {
 
     expect( wave.prop( 'aria-hidden' ) ).toEqual( 'true' );
     expect( wave.prop( 'focusable' ) ).toEqual( 'false' );
+  } );
+
+  it( 'renders the correct date and time label', () => {
+    const dateTime = wrapper.find( '.date-time' );
+
+    expect( dateTime.contains( 'Published: ' ) ).toEqual( true );
+  } );
+
+  it( 'renders the correct date and time', () => {
+    const time = wrapper.find( 'time' );
+
+    expect( time.contains( 'July 8, 2021' ) ).toEqual( true );
+    expect( time.prop( 'dateTime' ) ).toEqual( props.item.initialPublished );
+  } );
+} );
+
+describe( '<PlaybookCard />, when published with updates', () => {
+  const props = {
+    item: {
+      ...item,
+      modified: '2021-07-08T17:29:46.896Z',
+      published: '2021-07-08T17:29:46.896Z',
+    },
+  };
+  let Component;
+  let wrapper;
+
+  beforeEach( () => {
+    Component = <PlaybookCard { ...props } />;
+    wrapper = mount( Component );
+  } );
+
+  it( 'renders the correct date and time label', () => {
+    const dateTime = wrapper.find( '.date-time' );
+
+    expect( dateTime.contains( 'Updated: ' ) ).toEqual( true );
+  } );
+
+  it( 'renders the correct date and time', () => {
+    const time = wrapper.find( 'time' );
+
+    expect( time.contains( 'July 8, 2021' ) ).toEqual( true );
+    expect( time.prop( 'dateTime' ) ).toEqual( props.item.modified );
   } );
 } );

--- a/components/Playbook/mocks.js
+++ b/components/Playbook/mocks.js
@@ -101,8 +101,9 @@ const mockContent = `
 export const mockItem = {
   id: '1234',
   createdAt: '2021-05-26T11:12:34.140Z',
-  updatedAt: '2021-05-27T11:12:34.140Z',
+  updatedAt: '2021-05-28T11:12:34.740Z',
   publishedAt: '2021-05-28T11:12:34.140Z',
+  initialPublishedAt: '2021-05-27T08:18:44.410Z',
   type: 'PLAYBOOK',
   title: 'COVAX Deliveries and Announcement Guidance Playbook',
   // assetPath: String,

--- a/components/ScrollableTableWithMenu/TableRow/TableRow.js
+++ b/components/ScrollableTableWithMenu/TableRow/TableRow.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import dynamic from 'next/dynamic';
 import { Table } from 'semantic-ui-react';
 
-import { formatDate } from 'lib/utils';
+import { formatDateTime } from 'lib/utils';
 import TableMobileDataToggleIcon from 'components/ScrollableTableWithMenu/TableMobileDataToggleIcon/TableMobileDataToggleIcon';
 
 const MyProjectPrimaryCol = dynamic( () => import( /* webpackChunkName: "myProjectPrimaryCol" */ 'components/admin/Dashboard/MyProjects/MyProjectPrimaryCol/MyProjectPrimaryCol' ) );
@@ -69,7 +69,17 @@ const TableRow = ( { d, tableHeaders, projectTab } ) => {
                   <div className="items_table_mobileHeader">{ header.label }</div>
                   {
                     header.name === 'createdAt' || header.name === 'updatedAt'
-                      ? formatDate( d[header.name] )
+                      ? (
+                        formatDateTime( {
+                          dateString: d[header.name],
+                          options: {
+                            month: 'long',
+                            day: 'numeric',
+                            year: 'numeric',
+                            timeZone: 'America/New_York',
+                          },
+                        } )
+                      )
                       : d[header.name]
                   }
                 </span>

--- a/components/admin/ProjectEdit/EditVideoModal/ModalForms/FileDataForm/FileDataForm.js
+++ b/components/admin/ProjectEdit/EditVideoModal/ModalForms/FileDataForm/FileDataForm.js
@@ -20,7 +20,7 @@ import QualityDropdown from 'components/admin/dropdowns/QualityDropdown/QualityD
 import UseDropdown, { VIDEO_USE_QUERY } from 'components/admin/dropdowns/UseDropdown/UseDropdown';
 import VideoBurnedInStatusDropdown from 'components/admin/dropdowns/VideoBurnedInStatusDropdown/VideoBurnedInStatusDropdown';
 import { EditSingleProjectItemContext } from 'components/admin/ProjectEdit/EditSingleProjectItem/EditSingleProjectItem';
-import { formatBytes, formatDate, secondsToHMS } from 'lib/utils';
+import { formatBytes, formatDateTime, secondsToHMS } from 'lib/utils';
 
 // eslint-disable-next-line import/no-cycle
 import { VIDEO_UNIT_QUERY } from 'components/admin/ProjectEdit/EditVideoModal/ModalSections/FileSection/FileSection';
@@ -347,7 +347,15 @@ const FileDataForm = ( {
                 </span>
               ) }
               <span className="file_meta_content file_meta_content--uploaded">
-                { `Uploaded: ${formatDate( file.createdAt )}` }
+                { `Uploaded: ${formatDateTime( {
+                  dateString: file.createdAt,
+                  options: {
+                    month: 'long',
+                    day: 'numeric',
+                    year: 'numeric',
+                    timeZone: 'America/New_York',
+                  },
+                } )}` }
               </span>
               { file.duration && (
                 <span className="file_meta_content file_meta_content--duration">

--- a/components/admin/ProjectReview/VideoProjectFiles/VideoProjectFile/VideoProjectFile.test.js
+++ b/components/admin/ProjectReview/VideoProjectFiles/VideoProjectFile/VideoProjectFile.test.js
@@ -5,7 +5,7 @@ import VideoProjectFile from './VideoProjectFile';
 
 jest.mock( 'lib/utils', () => ( {
   formatBytes: jest.fn( () => '631.9 MB' ),
-  formatDate: jest.fn( () => 'May 5, 2019' ),
+  formatDateTime: jest.fn( () => 'May 5, 2019' ),
   getStreamData: jest.fn( ( stream, site = 'youtube', field = 'url' ) => {
     const uri = stream.find( s => s.site.toLowerCase() === site );
 

--- a/lib/__tests__/useInitialStatus.test.js
+++ b/lib/__tests__/useInitialStatus.test.js
@@ -1,0 +1,88 @@
+import { mount } from 'enzyme';
+import useInitialStatus from '../hooks/useInitialStatus';
+
+const setup = ( ...args ) => {
+  const returnVal = {};
+
+  const TestComponent = () => {
+    Object.assign( returnVal, useInitialStatus( ...args ) );
+
+    return null;
+  };
+
+  mount( <TestComponent /> );
+
+  return returnVal;
+};
+
+describe( 'useInitialStatus', () => {
+  it( 'returns correct values for initially created projects', () => {
+    const dateStatuses = setup( {
+      created: '2021-07-01T14:53:10.605Z',
+      updated: '2021-07-01T14:53:10.975Z',
+      published: null,
+      initialPublished: null,
+    } );
+
+    expect( dateStatuses ).toEqual( {
+      isInitialCreation: true,
+      isInitialPublish: false,
+    } );
+  } );
+
+  it( 'returns correct values for initially PUBLISHED projects', () => {
+    const dateStatuses = setup( {
+      created: '2021-06-04T19:06:16.585Z',
+      updated: '2021-07-01T12:30:33.793Z',
+      published: '2021-07-01T12:30:33.418Z',
+      initialPublished: '2021-07-01T12:30:33.252Z',
+    } );
+
+    expect( dateStatuses ).toEqual( {
+      isInitialCreation: false,
+      isInitialPublish: true,
+    } );
+  } );
+
+  it( 'returns correct values for updated DRAFT projects', () => {
+    const dateStatuses = setup( {
+      created: '2021-07-01T14:53:10.605Z',
+      updated: '2021-07-01T14:58:24.975Z',
+      published: null,
+      initialPublished: null,
+    } );
+
+    expect( dateStatuses ).toEqual( {
+      isInitialCreation: false,
+      isInitialPublish: false,
+    } );
+  } );
+
+  it( 'returns correct values for PUBLISHED projects that have been republished', () => {
+    const dateStatuses = setup( {
+      created: '2021-06-04T19:06:16.585Z',
+      updated: '2021-07-03T12:30:33.793Z',
+      published: '2021-07-03T12:30:33.418Z',
+      initialPublished: '2021-07-01T12:30:33.252Z',
+    } );
+
+    expect( dateStatuses ).toEqual( {
+      isInitialCreation: false,
+      isInitialPublish: false,
+    } );
+  } );
+
+  it( 'returns correct values for PUBLISHED projects that have been unpublished', () => {
+    const dateStatuses = setup( {
+      created: '2021-06-04T19:06:16.585Z',
+      updated: '2021-07-05T12:30:33.793Z',
+      published: null,
+      initialPublished: '2021-07-01T12:30:33.252Z',
+    } );
+
+    expect( dateStatuses ).toEqual( {
+      isInitialCreation: false,
+      isInitialPublish: false,
+    } );
+  } );
+} );

--- a/lib/__tests__/useInitialStatus.test.js
+++ b/lib/__tests__/useInitialStatus.test.js
@@ -1,4 +1,5 @@
 import { mount } from 'enzyme';
+
 import useInitialStatus from '../hooks/useInitialStatus';
 
 const setup = ( ...args ) => {
@@ -25,8 +26,9 @@ describe( 'useInitialStatus', () => {
     } );
 
     expect( dateStatuses ).toEqual( {
-      isInitialCreation: true,
+      isNeverPublished: true,
       isInitialPublish: false,
+      isSavedUpdate: false,
     } );
   } );
 
@@ -39,8 +41,9 @@ describe( 'useInitialStatus', () => {
     } );
 
     expect( dateStatuses ).toEqual( {
-      isInitialCreation: false,
+      isNeverPublished: false,
       isInitialPublish: true,
+      isSavedUpdate: false,
     } );
   } );
 
@@ -53,8 +56,24 @@ describe( 'useInitialStatus', () => {
     } );
 
     expect( dateStatuses ).toEqual( {
-      isInitialCreation: false,
+      isNeverPublished: true,
       isInitialPublish: false,
+      isSavedUpdate: false,
+    } );
+  } );
+
+  it( 'returns correct values for PUBLISHED project with unpublished changes', () => {
+    const dateStatuses = setup( {
+      created: '2021-06-04T19:06:16.585Z',
+      updated: '2021-07-03T12:32:40.793Z',
+      published: '2021-07-03T12:30:33.418Z',
+      initialPublished: '2021-07-01T12:30:33.252Z',
+    } );
+
+    expect( dateStatuses ).toEqual( {
+      isNeverPublished: false,
+      isInitialPublish: false,
+      isSavedUpdate: true,
     } );
   } );
 
@@ -67,8 +86,9 @@ describe( 'useInitialStatus', () => {
     } );
 
     expect( dateStatuses ).toEqual( {
-      isInitialCreation: false,
+      isNeverPublished: false,
       isInitialPublish: false,
+      isSavedUpdate: false,
     } );
   } );
 
@@ -81,8 +101,9 @@ describe( 'useInitialStatus', () => {
     } );
 
     expect( dateStatuses ).toEqual( {
-      isInitialCreation: false,
+      isNeverPublished: false,
       isInitialPublish: false,
+      isSavedUpdate: false,
     } );
   } );
 } );

--- a/lib/__tests__/utils.test.js
+++ b/lib/__tests__/utils.test.js
@@ -96,4 +96,49 @@ describe( 'utility function', () => {
       }
     } );
   } );
+
+  it( 'formatDateTime returns a correctly formatted date', () => {
+    const { formatDateTime } = utils;
+
+    // Eastern daylight time
+    const dateArgsDT = {
+      dateString: '2021-06-27T03:12:34.140Z',
+      options: {
+        month: 'long',
+        day: 'numeric',
+        year: 'numeric',
+        timeZone: 'America/New_York',
+      },
+    };
+
+    const timeArgsDT = {
+      ...dateArgsDT,
+      options: {
+        hour12: true,
+        hour: 'numeric',
+        minute: 'numeric',
+        timeZone: 'America/New_York',
+      },
+      timeStringOnly: true,
+    };
+
+    // Eastern standard time
+    const dateArgsST = {
+      ...dateArgsDT,
+      dateString: '2021-02-27T03:12:34.140Z',
+    };
+
+    const timeArgsST = {
+      ...dateArgsST,
+      options: timeArgsDT.options,
+      timeStringOnly: timeArgsDT.timeStringOnly,
+    };
+
+    // EDT
+    expect( formatDateTime( dateArgsDT ) ).toEqual( 'June 26, 2021' );
+    expect( formatDateTime( timeArgsDT ) ).toEqual( '11:12 PM' );
+    // EST
+    expect( formatDateTime( dateArgsST ) ).toEqual( 'February 26, 2021' );
+    expect( formatDateTime( timeArgsST ) ).toEqual( '10:12 PM' );
+  } );
 } );

--- a/lib/elastic/parser.js
+++ b/lib/elastic/parser.js
@@ -331,6 +331,8 @@ const populatePackageItem = source => {
 const populatePlaybookItem = source => {
   const obj = {
     title: source.title,
+    created: source.created,
+    initialPublished: source.initialPublished,
     desc: source.desc || '',
     policy: {
       name: source?.policy?.name,

--- a/lib/graphql/queries/playbook.js
+++ b/lib/graphql/queries/playbook.js
@@ -11,6 +11,7 @@ export const PLAYBOOK_DETAILS_FRAGMENT = gql`
     createdAt
     updatedAt
     publishedAt
+    initialPublishedAt
     type
     assetPath
     author {

--- a/lib/hooks/useInitialStatus.js
+++ b/lib/hooks/useInitialStatus.js
@@ -1,0 +1,49 @@
+import { useEffect, useState } from 'react';
+
+/**
+ * Return the initial created and initial published status
+ * @param {Object} dates Project date strings
+ * @param {string} dates.created Project created date
+ * @param {string} dates.updated Project updated date
+ * @param {string} dates.published Project published date
+ * @param {string} dates.initialPublished Project initial published date
+ */
+const useInitialStatus = ( {
+  created,
+  updated,
+  published,
+  initialPublished,
+} ) => {
+  const [statuses, setStatuses] = useState( {} );
+
+  // truncate down to nearest second
+  const getRoundedDate = date => (
+    Math.floor( date.getTime() / 1000 )
+  );
+
+  // equal if within 1 second
+  const areDatesEqual = ( date1, date2 ) => (
+    Math.abs( date1 - date2 ) <= 1
+  );
+
+  useEffect( () => {
+    const createdDate = getRoundedDate( new Date( created ) );
+    const updatedDate = getRoundedDate( new Date( updated ) );
+    const publishedDate = getRoundedDate( new Date( published ) );
+    const initialPublishedDate = getRoundedDate( new Date( initialPublished ) );
+
+    setStatuses( {
+      isInitialCreation: areDatesEqual( createdDate, updatedDate ),
+      isInitialPublish: !!initialPublishedDate && areDatesEqual( initialPublishedDate, publishedDate ),
+    } );
+  }, [
+    created,
+    updated,
+    published,
+    initialPublished,
+  ] );
+
+  return statuses;
+};
+
+export default useInitialStatus;

--- a/lib/hooks/useInitialStatus.js
+++ b/lib/hooks/useInitialStatus.js
@@ -3,13 +3,11 @@ import { useEffect, useState } from 'react';
 /**
  * Return the initial created and initial published status
  * @param {Object} dates Project date strings
- * @param {string} dates.created Project created date
  * @param {string} dates.updated Project updated date
  * @param {string} dates.published Project published date
  * @param {string} dates.initialPublished Project initial published date
  */
 const useInitialStatus = ( {
-  created,
   updated,
   published,
   initialPublished,
@@ -27,17 +25,16 @@ const useInitialStatus = ( {
   );
 
   useEffect( () => {
-    const createdDate = getRoundedDate( new Date( created ) );
     const updatedDate = getRoundedDate( new Date( updated ) );
     const publishedDate = getRoundedDate( new Date( published ) );
     const initialPublishedDate = getRoundedDate( new Date( initialPublished ) );
 
     setStatuses( {
-      isInitialCreation: areDatesEqual( createdDate, updatedDate ),
+      isNeverPublished: !initialPublishedDate,
       isInitialPublish: !!initialPublishedDate && areDatesEqual( initialPublishedDate, publishedDate ),
+      isSavedUpdate: !!publishedDate && !areDatesEqual( publishedDate, updatedDate ),
     } );
   }, [
-    created,
     updated,
     published,
     initialPublished,

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -272,6 +272,7 @@ export const compareValues = ( key, order = 'asc' ) => function( a, b ) {
     order === 'desc' ? comparison * -1 : comparison
   );
 };
+
 export const formatDate = (
   dateString,
   locale = 'en-US',
@@ -279,12 +280,23 @@ export const formatDate = (
     month: 'long',
     day: 'numeric',
     year: 'numeric',
+    timeZone: 'America/New_York',
   },
-) => {
-  const d = dateString.split( /[^0-9]/ );
-  const dateTime = new Date( d[0], d[1] - 1, d[2], d[3], d[4], d[5] );
+) => new Date( dateString ).toLocaleDateString( locale, options );
 
-  return dateTime.toLocaleString( locale, options );
+/**
+ * Return formatted date/time portion of an ISO 8601
+ * date string, e.g., YYYY-MM-DDThh:mm:ss.sZ
+ * @param {object}    `Date` method parameters
+ * @returns {string}  Formatted date and/or time
+ */
+export const formatDateTime = ( {
+  dateString, locale = 'en-us', options = {}, timeStringOnly = false,
+} ) => {
+  const date = new Date( dateString );
+  const method = timeStringOnly ? 'toLocaleTimeString' : 'toLocaleDateString';
+
+  return date[method]( locale, options );
 };
 
 /*

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -273,17 +273,6 @@ export const compareValues = ( key, order = 'asc' ) => function( a, b ) {
   );
 };
 
-export const formatDate = (
-  dateString,
-  locale = 'en-US',
-  options = {
-    month: 'long',
-    day: 'numeric',
-    year: 'numeric',
-    timeZone: 'America/New_York',
-  },
-) => new Date( dateString ).toLocaleDateString( locale, options );
-
 /**
  * Return formatted date/time portion of an ISO 8601
  * date string, e.g., YYYY-MM-DDThh:mm:ss.sZ


### PR DESCRIPTION
This PR handles the date and time display on playbook pages (Commons and admin preview) and playbook cards on Commons.

### Summary
* Displays the time in the Eastern time zone and should automatically update for daylight saving time. I included a test for the `formatDateTime` utility function for this scenario.
* Displays either Updated or Published dates and label, per description in [CDP-2443](https://design.atlassian.net/browse/CDP-2443).
* Updates the tests for `Playbook` and `PlaybookCard` for the various scenarios.