### PR TITLE
CDP-2469: Display support file size and type properties on the playbook frontend

### DIFF
--- a/components/Playbook/Playbook.js
+++ b/components/Playbook/Playbook.js
@@ -7,7 +7,7 @@ import Popover from 'components/popups/Popover/Popover';
 import Share from 'components/Share/Share';
 import TexturedSection from 'components/TexturedSection/TexturedSection';
 
-import { formatBytes, formatDateTime, maybeGetUrlToProdS3 } from 'lib/utils';
+import { formatBytes, formatDateTime, getColloquialFiletype, maybeGetUrlToProdS3 } from 'lib/utils';
 import { getBadgeStyle, getDateTimeArgs } from './Playbook.controller';
 import useInitialStatus from 'lib/hooks/useInitialStatus';
 import cautionIcon from 'static/icons/icon_caution.svg';
@@ -127,7 +127,7 @@ const Playbook = ( { item } ) => {
                         </strong>
                       </p>
                       { file.filetype && (
-                        <p className="item-content__meta">{ `File type: ${file.filetype}` }</p>
+                        <p className="item-content__meta">{ `File type: ${getColloquialFiletype( file.filetype )}` }</p>
                       ) }
                       { file.filesize && (
                         <p className="item-content__meta">{ `File size: ${formatBytes( file.filesize )}` }</p>

--- a/components/Playbook/Playbook.js
+++ b/components/Playbook/Playbook.js
@@ -126,8 +126,12 @@ const Playbook = ( { item } ) => {
                           { `Download "${file.filename}"` }
                         </strong>
                       </p>
-                      <p className="item-content__meta">{ `File type: ${file.filetype}` }</p>
-                      <p className="item-content__meta">{ `File size: ${formatBytes( file.filesize )}` }</p>
+                      { file.filetype && (
+                        <p className="item-content__meta">{ `File type: ${file.filetype}` }</p>
+                      ) }
+                      { file.filesize && (
+                        <p className="item-content__meta">{ `File size: ${formatBytes( file.filesize )}` }</p>
+                      ) }
                     </div>
                   </DownloadItemContent>
                 </li>

--- a/components/ScrollableTableWithMenu/ScrollableTableWithMenu.scss
+++ b/components/ScrollableTableWithMenu/ScrollableTableWithMenu.scss
@@ -32,12 +32,10 @@
         }
       }
     }
-  }  
+  }
 }
 
-
 .items {
-
   &_table {
     position: relative;
     overflow: auto;
@@ -77,7 +75,7 @@
           display: none;
         }
       }
-      
+
       th {
         letter-spacing: 0.5px;
       }
@@ -91,7 +89,8 @@
         }
       }
 
-      td, th {
+      td,
+      th {
         &:first-child {
           position: sticky;
           left: 0;
@@ -107,10 +106,10 @@
         z-index: 1;
         font-size: 12px;
         background-color: #fff;
-        box-shadow: 3px 0 3px 1px rgba(0,0,0,0.1);
-        
+        box-shadow: 3px 0 3px 1px rgba(0, 0, 0, 0.1);
+
         &.items_table_item {
-          @media screen and (max-width: 767px){
+          @media screen and (max-width: 767px) {
             position: relative;
             z-index: 2;
             width: auto !important;
@@ -127,7 +126,7 @@
           // Mobile - Display data actions menu
           &.displayDataActions {
             z-index: 3 !important;
-          
+
             .projects_data_actions_wrapper {
               display: block;
             }
@@ -148,6 +147,17 @@
         display: none;
       }
     }
+  }
+}
 
+// Override Semantic UI for table header.
+.ui.celled.table thead tr:first-child {
+  > th:first-child {
+    border-radius: 0;
+  }
+
+  > th:last-child {
+    border-radius: 0;
+    border-right: none;
   }
 }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -93,6 +93,22 @@ export const getFileNameNoExt = filename => {
   return '';
 };
 
+/**
+ * Converts common MIME types into their colloquial equivalent.
+ * @param {string} type A MIME type.
+ * @return {string} The common name or the provided type if common name not available.
+ */
+export const getColloquialFiletype = type => {
+  switch ( type ) {
+    case 'application/pdf':
+      return 'PDF';
+    case 'application/vnd.openxmlformats-officedocument.wordprocessingml.document':
+      return 'Word Document';
+    default:
+      return type;
+  }
+};
+
 export const maybeGetUrlToProdS3 = url => {
   if ( url.startsWith( 'http:' ) || url.startsWith( 'https:' ) ) return url;
   const { publicRuntimeConfig } = getConfig();


### PR DESCRIPTION
These changes work with server [PR #67](https://github.com/IIP-Design/content-commons-server/pull/67) and API [PR #101](https://github.com/IIP-Design/cdp-public-api/pull/101), which make the file size and file type properties available on the public API response.

In the case that file size and/or file type are not returned, those values will be omitted from the additional resources item.

Also added a helper function to convert common MIME types into more approachable filetype names (i.e. `Word Document` rather than `application/vnd.openxmlformats-officedocument.wordprocessingml.document`).

Finally, includes an opportunistic change to the dashboard styling to override Semantic UI styling that was rounding the corners of the scrollable table header row.