### PR TITLE
Playbook text editor link style adjustments

### DIFF
--- a/components/Playbook/Playbook.module.scss
+++ b/components/Playbook/Playbook.module.scss
@@ -66,6 +66,13 @@
     font-size: 0.6667rem;
     line-height: 1.5;
   }
+
+  a {
+    &:hover,
+    u:hover {
+      text-decoration: none;
+    }
+  }
 }
 
 .preview {

--- a/components/admin/TextEditor/TextEditor.module.scss
+++ b/components/admin/TextEditor/TextEditor.module.scss
@@ -16,9 +16,7 @@
 }
 
 .editor {
-  * {
-    color: #000;
-  }
+  color: #000;
 
   [class="ck ck-sticky-panel"] {
     [class*="ck-sticky-panel__content_sticky"] {


### PR DESCRIPTION
This PR adjusts the styling of playbook text editor links so that content copied from Google docs appears correctly. Content copied from a Google doc wraps underlined links in a `u` tag, which prevented the previous styling from being displayed. This also addresses Google doc headings that are wrapped in `strong` tags. Because of the `strong` tag, the desired color for headings was not being displayed correctly.